### PR TITLE
Fix null error message

### DIFF
--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -719,6 +719,7 @@ class Editor extends PropertyObject
       skip_styles = config.completion_skip_auto_within
       if skip_styles
         cur_style = @current_context.style
+        return if not cur_style
         for skip_style in *skip_styles
           return if cur_style\match skip_style
 


### PR DESCRIPTION
Without this, for every other character I enter, I get an error message about indexing `nil` field `cur_style`.
