### PR TITLE
Basic support for XDG-complaint config directory.

### DIFF
--- a/lib/howl/settings.moon
+++ b/lib/howl/settings.moon
@@ -8,7 +8,7 @@ default_dir = ->
   return File(howl_dir) if howl_dir
   home = os.getenv('HOME')
   xdg_config_home = os.getenv('XDG_CONFIG_HOME')
-  -- if none of this are set, we wwon't be able to find config
+  -- if none of this are set, we won't be able to find config
   return nil unless home or xdg_config_home
   xdg_conf_dir = nil
   if xdg_config_home

--- a/lib/howl/settings.moon
+++ b/lib/howl/settings.moon
@@ -10,17 +10,20 @@ default_dir = ->
   xdg_config_home = os.getenv('XDG_CONFIG_HOME')
   -- if none of this are set, we wwon't be able to find config
   return nil unless home or xdg_config_home
-  -- trying ~/.howl first
-  dotdir = nil
-  if home
-    dotdir = File(home)\join('.howl')
-    return dotdir if dotdir.is_directory
-  -- trying xdg-complaint ~/.config/howl
   xdg_conf_dir = nil
   if xdg_config_home
     xdg_conf_dir = File(xdg_config_home)\join('howl')
   elseif home
     xdg_conf_dir = File(home)\join('.config')\join('howl')
+  -- trying ~/.howl first
+  dotdir = nil
+  if home
+    dotdir = File(home)\join('.howl')
+    if dotdir.is_directory
+      if xdg_conf_dir and xdg_conf_dir.is_directory
+        howl.log.warn("Ignoring #{xdg_conf_dir.path} in favor of #{dotdir.path}")
+      return dotdir
+  -- trying xdg-complaint ~/.config/howl
   if xdg_conf_dir and xdg_conf_dir.is_directory
     return xdg_conf_dir
   -- if none of these exists falling back to ~/.howl

--- a/lib/howl/settings.moon
+++ b/lib/howl/settings.moon
@@ -7,7 +7,24 @@ default_dir = ->
   howl_dir = os.getenv 'HOWL_DIR'
   return File(howl_dir) if howl_dir
   home = os.getenv('HOME')
-  home and File(home)\join('.howl') or nil
+  xdg_config_home = os.getenv('XDG_CONFIG_HOME')
+  -- if none of this are set, we wwon't be able to find config
+  return nil unless home or xdg_config_home
+  -- trying ~/.howl first
+  dotdir = nil
+  if home
+    dotdir = File(home)\join('.howl')
+    return dotdir if dotdir.is_directory
+  -- trying xdg-complaint ~/.config/howl
+  xdg_conf_dir = nil
+  if xdg_config_home
+    xdg_conf_dir = File(xdg_config_home)\join('howl')
+  elseif home
+    xdg_conf_dir = File(home)\join('.config')\join('howl')
+  if xdg_conf_dir and xdg_conf_dir.is_directory
+    return xdg_conf_dir
+  -- if none of these exists falling back to ~/.howl
+  dotdir
 
 class Settings
 

--- a/spec/settings_spec.moon
+++ b/spec/settings_spec.moon
@@ -40,8 +40,8 @@ describe 'Settings', ->
 
       it 'uses "$HOME/.config/howl" if one exists', ->
         with_tmpdir (dir) ->
-          xdg_config_dir = dir\join(".config")
-          howl_dir = xdg_config_dir\join("howl")
+          xdg_config_dir = dir\join('.config')
+          howl_dir = xdg_config_dir\join('howl')
           howl_dir\mkdir_p!
           getenv = os.getenv
           os.getenv = (name) -> tostring dir.path if name == 'HOME'
@@ -51,23 +51,23 @@ describe 'Settings', ->
 
       it 'uses "$XDG_CONFIG_HOME" when specified', ->
         with_tmpdir (dir) ->
-          xdg_config_dir = dir\join("xdgconfdirname")
-          howl_dir = xdg_config_dir\join("howl")
+          xdg_config_dir = dir\join('xdgconfdirname')
+          howl_dir = xdg_config_dir\join('howl')
           howl_dir\mkdir_p!
           getenv = os.getenv
           os.getenv = (name) ->
             return tostring dir.path if name == 'HOME'
-            return tostring xdg_config_dir.path if name == "XDG_CONFIG_HOME"
+            return tostring xdg_config_dir.path if name == 'XDG_CONFIG_HOME'
           pcall Settings
           os.getenv = getenv
           assert.is_true howl_dir\join('system').exists
 
       it 'uses ~/.howl instead of ~/.config/howl if both exists', ->
         with_tmpdir (dir) ->
-          xdg_config_dir = dir\join(".config")
-          conf_dir = xdg_config_dir\join("howl")
+          xdg_config_dir = dir\join('.config')
+          conf_dir = xdg_config_dir\join('howl')
           conf_dir\mkdir_p!
-          dot_dir = dir\join(".howl")
+          dot_dir = dir\join('.howl')
           dot_dir\mkdir!
           getenv = os.getenv
           os.getenv = (name) -> tostring dir.path if name == 'HOME'

--- a/spec/settings_spec.moon
+++ b/spec/settings_spec.moon
@@ -38,6 +38,30 @@ describe 'Settings', ->
           os.getenv = getenv
           assert.is_true dir\join('.howl').exists
 
+      it 'loads settings from "$HOME/.config/howl" if one exists', ->
+        with_tmpdir (dir) ->
+          xdg_config_dir = dir\join(".config")
+          howl_dir = xdg_config_dir\join("howl")
+          howl_dir\mkdir_p!
+          getenv = os.getenv
+          os.getenv = (name) -> tostring dir.path if name == 'HOME'
+          pcall Settings
+          os.getenv = getenv
+          assert.is_true howl_dir\join('system').exists
+
+      it 'loads settiings from "$XDG_CONFIG_HOME/howl"', ->
+        with_tmpdir (dir) ->
+          xdg_config_dir = dir\join("xdgconfdirname")
+          howl_dir = xdg_config_dir\join("howl")
+          howl_dir\mkdir_p!
+          getenv = os.getenv
+          os.getenv = (name) ->
+            return tostring dir.path if name == 'HOME'
+            return tostring xdg_config_dir.path if name == "XDG_CONFIG_HOME"
+          pcall Settings
+          os.getenv = getenv
+          assert.is_true howl_dir\join('system').exists
+
   it '.dir is set to the settings directory if available', ->
     assert.equal tmpdir, Settings(tmpdir).dir
     assert.is_nil Settings(tmpdir\join('sub', 'bar')).dir

--- a/spec/settings_spec.moon
+++ b/spec/settings_spec.moon
@@ -38,7 +38,7 @@ describe 'Settings', ->
           os.getenv = getenv
           assert.is_true dir\join('.howl').exists
 
-      it 'loads settings from "$HOME/.config/howl" if one exists', ->
+      it 'uses "$HOME/.config/howl" if one exists', ->
         with_tmpdir (dir) ->
           xdg_config_dir = dir\join(".config")
           howl_dir = xdg_config_dir\join("howl")
@@ -49,7 +49,7 @@ describe 'Settings', ->
           os.getenv = getenv
           assert.is_true howl_dir\join('system').exists
 
-      it 'loads settiings from "$XDG_CONFIG_HOME/howl"', ->
+      it 'uses "$XDG_CONFIG_HOME" when specified', ->
         with_tmpdir (dir) ->
           xdg_config_dir = dir\join("xdgconfdirname")
           howl_dir = xdg_config_dir\join("howl")
@@ -61,6 +61,22 @@ describe 'Settings', ->
           pcall Settings
           os.getenv = getenv
           assert.is_true howl_dir\join('system').exists
+
+      it 'uses ~/.howl instead of ~/.config/howl if both exists', ->
+        with_tmpdir (dir) ->
+          xdg_config_dir = dir\join(".config")
+          conf_dir = xdg_config_dir\join("howl")
+          conf_dir\mkdir_p!
+          dot_dir = dir\join(".howl")
+          dot_dir\mkdir!
+          getenv = os.getenv
+          os.getenv = (name) -> tostring dir.path if name == 'HOME'
+          pcall Settings
+          os.getenv = getenv
+          assert.is_false conf_dir\join('system').exists
+          assert.is_true dot_dir\join('system').exists
+
+
 
   it '.dir is set to the settings directory if available', ->
     assert.equal tmpdir, Settings(tmpdir).dir


### PR DESCRIPTION
If there are `$XDG_CONFIG_HOME/howl` or `~/.config/howl` directory, use one to load config files.  
Requires user to manually change config directory location with `mv ~/.howl ~/.config/howl` otherwise will work as before.

See [XDG Base Directory Specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) for more info.