### PR TITLE
Bugfix to highlight growing buffer-grep match

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,12 @@ indentation levels to work as a stand-alone code chunk.
 
 - Issues as seen on [Github](https://github.com/howl-editor/howl/issues?utf8=%E2%9C%93&q=created%3A%3E2015-09-02+state%3Aclosed++type%3Aissue)
 
+### API changes
+
+- The `on_selection_change` callback for interactions has been renamed to
+`on_change` and triggers even when selection stays the same but the text
+changes.
+
 ## 0.3 (2015-09-01)
 
 - Added a new command, `project-build` that executes a pre-configured command

--- a/lib/howl/interactions/line_selection.moon
+++ b/lib/howl/interactions/line_selection.moon
@@ -64,8 +64,8 @@ interact.register
     unless lines
       error '"lines" field required', 2
 
-    if opts.matcher or opts.items or opts.on_selection_change
-      error '"matcher", "items" or "on_selection_change" not allowed', 2
+    if opts.matcher or opts.items or opts.on_change
+      error '"matcher", "items" or "on_change" not allowed', 2
 
     editor = opts.editor or howl.app.editor
     line_items = [{tostring(line.nr), line.chunk, buffer: line.buffer, line_nr: line.nr, :line} for line in *lines]
@@ -80,7 +80,7 @@ interact.register
 
     matcher = Matcher line_items, preserve_order: true
     opts.matcher = matcher
-    opts.on_selection_change = line_match_highlighter(editor)
+    opts.on_change = line_match_highlighter(editor)
     opts.force_preview = true
 
     result = interact.select_location opts

--- a/lib/howl/interactions/location_selection.moon
+++ b/lib/howl/interactions/location_selection.moon
@@ -15,16 +15,16 @@ interact.register
     buffer = editor.buffer
 
     if howl.config.preview_files or opts.force_preview
-      on_selection_change = opts.on_selection_change
-      opts.on_selection_change = (selection, text, items) ->
+      on_change = opts.on_change
+      opts.on_change = (selection, text, items) ->
         if selection
           buffer = selection.buffer or preview.get_preview_buffer selection.file
           editor\preview buffer
           if selection.line_nr
             editor.line_at_center = selection.line_nr
 
-        if on_selection_change
-          on_selection_change selection, text, items
+        if on_change
+          on_change selection, text, items
 
     result = interact.select opts
     editor\cancel_preview!

--- a/lib/howl/interactions/selection_list.moon
+++ b/lib/howl/interactions/selection_list.moon
@@ -18,7 +18,7 @@ class SelectionList
 
     matcher = @opts.matcher or Matcher @opts.items
     @list_widget = ListWidget matcher,
-      on_selection_change: @\_selection_changed
+      on_selection_change: @\_handle_change
       reverse: @opts.reverse
       never_shrink: true
 
@@ -46,11 +46,14 @@ class SelectionList
     @showing_list = true
 
   on_update: (text) =>
+    @_change_triggered = false
     @list_widget\update text
+    @_handle_change! unless @_change_triggered
 
-  _selection_changed: =>
-    if @opts.on_selection_change
-      @opts.on_selection_change @list_widget.selection, @command_line.text, @list_widget.items
+  _handle_change: =>
+    @_change_triggered = true
+    if @opts.on_change
+      @opts.on_change @list_widget.selection, @command_line.text, @list_widget.items
 
   submit: =>
     if @list_widget.selection

--- a/site/source/doc/api/interact.md
+++ b/site/source/doc/api/interact.md
@@ -203,10 +203,10 @@ filtered list of items matching the given text.
 column. Identical to the `columns` argument in the
 [StyledText.for_table](ui/styled_text.html#styledtext.for_table) function.
 - `keymap`: _[optional]_ An additional keymap to used for this interaction.
-- `on_selection_change`: _[optional]_ A function callback that is called
-whenever the user changes the currently selected item (usually by using the
-arrow keys). The callback function is called with the three arguments
-`(selection, text, items)`, where:
+- `on_change`: _[optional]_ A function callback that is called whenever the user
+changes the currently selected item or updates the text in the command line. The
+callback function is called with the three arguments `(selection, text, items)`,
+where:
   - `selection` is the newly selected item
   - `text` is the current text in the command line
   - `items` is the current (possibly filtered) list of items
@@ -323,7 +323,7 @@ Lets the user select a line from a list of source lines. `opts` is a table
 similar to the table accepted by [select](#select), with the following
 differences:
 
-- `items`, `matcher` and `on_selection_change` cannot be specified.
+- `items`, `matcher` and `on_change` cannot be specified.
 - `lines` must be provided and should be a list of [Line] objects.
 
 If the user presses `enter`, returns a table containing:


### PR DESCRIPTION
The match highlighting worked only whenever a new line was selected, not if the match grew on the current line.

Also rename on_selection_change callback to on_change and trigger even when the user entered text changes.