### PR TITLE
Fix not scrolling far enough to the right when searching for text

### DIFF
--- a/lib/howl/ui/searcher.moon
+++ b/lib/howl/ui/searcher.moon
@@ -66,6 +66,7 @@ class Searcher
     start_pos, end_pos = @_find_match search, init, direction, ensure_word
 
     if start_pos
+      @editor.cursor.pos = end_pos
       @editor.cursor.pos = start_pos
       @_highlight_matches search, start_pos, ensure_word
     else


### PR DESCRIPTION
To reproduce the issue:

1. Open up a new file.
2. On the first line, type some text (I did `abc`).
3. Enter the same thing on the second line, but put a bunch of spaces before the text so that you need to scroll right to see it.
4. Move the cursor to the first line, first column.
5. Open a search for the text and go to the second match.
