### PR TITLE
Mail mode

### DIFF
--- a/bundles/mail-mode/README.md
+++ b/bundles/mail-mode/README.md
@@ -1,0 +1,25 @@
+# mail-mode bundle
+
+## License
+
+Copyright 2012-2015 The Howl Developers
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/bundles/mail-mode/init.moon
+++ b/bundles/mail-mode/init.moon
@@ -1,0 +1,19 @@
+-- Copyright 2014-2015 The Howl Developers
+-- License: MIT (see README.md at the top-level directory of the bundle)
+
+mode_reg =
+  name: 'mail-mode'
+  extensions: {'eml', 'mbox', 'mbx'}
+  create: -> bundle_load('mail_mode')!
+
+howl.mode.register mode_reg
+
+unload = -> howl.mode.unregister 'mail-mode'
+
+return {
+  info:
+    author: 'Copyright 2015 The Howl Developers',
+    description: 'Mail mode',
+    license: 'MIT',
+  :unload
+}

--- a/bundles/mail-mode/mail_lexer.moon
+++ b/bundles/mail-mode/mail_lexer.moon
@@ -30,8 +30,7 @@ howl.aux.lpeg_lexer ->
   header_key = alpha * any(alpha, '-')^1 * ':'
 
   preamble = sequence {
-    -B(1),
-    #header_key,
+    #(header_key * scan_to(eol))^2,
     sub_lex_by_inline('embedded', end_of_preamble, any {
       c('keyword', P'Subject:') * space^1 * c('h1', scan_until(eol)),
       c('keyword', header_key) * scan_until(eol)

--- a/bundles/mail-mode/mail_lexer.moon
+++ b/bundles/mail-mode/mail_lexer.moon
@@ -1,0 +1,75 @@
+-- Copyright 2014-2015 The Howl Developers
+-- License: MIT (see README.md at the top-level directory of the bundle)
+
+{:style} = howl.ui
+
+style.define_default 'mail_level_1', 'green'
+style.define_default 'mail_level_2', 'blue'
+style.define_default 'mail_level_3', 'cyan'
+style.define_default 'mail_level_4', 'comment'
+style.define_default 'mail_ref', 'bold'
+style.define_default 'mail_link', 'link_url'
+
+howl.aux.lpeg_lexer ->
+  c = capture
+
+  -- mail markup conventions
+  bold = c 'strong', P'*' * complement('*')^1 * '*'
+  emphasis = c 'emphasis', P'_' * complement('_')^1 * '_'
+  reference = c 'mail_ref', P'[' * digit^1 * ']'
+  link = c 'mail_link', P'http' * P('s')^-1 * '://' * scan_until(blank + eol)
+
+  mail_markup = any {
+    separate(any(bold, emphasis)),
+    reference,
+    link
+  }
+
+  -- mail headers / preamble
+  end_of_preamble = B(eol) * (eol + '-')
+  header_key = alpha * any(alpha, '-')^1 * ':'
+
+  preamble = sequence {
+    -B(1),
+    #header_key,
+    sub_lex_by_inline('embedded', end_of_preamble, any {
+      c('keyword', P'Subject:') * space^1 * c('h1', scan_until(eol)),
+      c('keyword', header_key) * scan_until(eol)
+    })
+  }
+
+  -- quoted correspondence
+  quote_pattern = (start, level) ->
+    s = "mail_level_#{level}"
+    c(s, start) * sub_lex_by_inline(s, eol, mail_markup)
+
+  quoted = line_start * any {
+    quote_pattern('>>>>', 4),
+    quote_pattern('>>>', 3),
+    quote_pattern('>>    ', 3),
+    quote_pattern('>>', 2),
+    quote_pattern('>           ', 4),
+    quote_pattern('>        ', 3),
+    quote_pattern('>    ', 2),
+    quote_pattern('>', 1),
+    quote_pattern('    ', 1),
+  }
+
+  -- comments and signature
+  signature = c 'comment', sequence {
+    line_start,
+    '--',
+    eol,
+    scan_until(eol * eol)
+  }
+
+  comment = c 'comment', line_start * '-' * S'-=' * scan_until(eol)
+
+  -- and that's a wrap
+  any {
+    quoted,
+    preamble
+    signature,
+    comment,
+    mail_markup
+  }

--- a/bundles/mail-mode/mail_mode.moon
+++ b/bundles/mail-mode/mail_mode.moon
@@ -1,0 +1,27 @@
+-- Copyright 2014-2015 The Howl Developers
+-- License: MIT (see README.md at the top-level directory of the bundle)
+
+append = table.insert
+
+class MailMode
+  new: =>
+    @lexer = bundle_load('mail_lexer')
+
+  default_config:
+    auto_reflow_text: true
+    hard_wrap_column: 72
+    indent: 4
+
+  auto_pairs: {
+    '(': ')'
+    '[': ']'
+    '{': '}'
+    '"': '"'
+  }
+
+  line_is_reflowable: (line) =>
+    no_break = { '^%s*>', '^%s%s>', '^[%w-]+:%s', '^-' }
+    for p in *no_break
+      return false if line\find p
+
+    true

--- a/bundles/mail-mode/misc/example.eml
+++ b/bundles/mail-mode/misc/example.eml
@@ -1,0 +1,40 @@
+Subject:   Re: Bacon!
+To:        My Recipient <bacon.lover@foo-test.com>
+Cc:
+Bcc:
+Return-path: <>
+-=-=-=-=-=-=-=-=-=# A comment of some sort #=-=-=-=-=-=-=-=-=-
+
+On 09/03/2015 10:02 PM, My Recipient wrote:
+>>
+>> On 09/03/2015 08:02 PM, Yours truly wrote:
+>>
+>>> Did you know you can bacon wrap almost _anything_? We should totally
+>>> bacon wrap the product.
+>>
+>> Well on one hand perhaps, on another the it's unclear whether the
+>> universal synergies would align, but does anyone consider *that*?
+>> All things considered this, I _truly_ believe, merits some not one
+>> but two exta rounds of careful review and pondering.
+>
+> Well I really, *really* think something. Consider for instance [1],
+> wouldn't it be just _faboulous_ if yadda yadda?
+>
+> [1] http://amazingsource.com/bacon
+
+But let's now talk about *email*. Consider below the questionable use of
+indentation based quoting:
+
+>    This is really the equivalent of ">> ", but it's just so much
+>    harder to handle correctly. Good job someone!
+>>    And level three? Who knows.
+
+    Oh no, but now I'm doing it! The equivalent of "> ". Well thats
+    double standards for you.
+
+Formatting has already been illustrated above, but a few more points;
+It's not considered an emphasis with underscored parts in a word, e.g.
+this_should_not_be_highlighted.
+
+--
+A snazzy signature to finish things off.

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -217,9 +217,16 @@ DisplayLine = define_class {
 
     @background_ranges = parse_background_ranges @styling
 
-    if #@background_ranges == 1
+    if #@background_ranges > 0
       range = @background_ranges[1]
-      @_full_background = range.start_offset == 1 and range.end_offset > line.full_size
+      full = range.start_offset == 1
+      for i = 2, #@background_ranges
+        r = @background_ranges[i]
+        full and= r.start_offset == range.end_offset
+        break unless full
+        range = r
+
+      @_full_background = full and range.end_offset > line.full_size
 
   properties: {
     block: =>
@@ -240,8 +247,11 @@ DisplayLine = define_class {
     block = @block
     @_flairs or= get_flairs opts.buffer, opts.line, @
 
-    for bg_range in *@background_ranges
-      width = block and block.width and block.width - base_x or nil
+    for i, bg_range in ipairs @background_ranges
+      width = nil
+      if i == 1 and block and block.width
+        width = block.width - base_x
+
       bg_flair = flair.build {
         type: flair.RECTANGLE,
         background: bg_range.style.background

--- a/lib/aullar/spec/styles_spec.moon
+++ b/lib/aullar/spec/styles_spec.moon
@@ -82,3 +82,19 @@ describe 'styles', ->
       assert.is_not_nil def
       assert.equal '#112233', def.background
       assert.equal '#999999', def.color
+
+    it 'allows aliases for the base', ->
+      styles.define 'base_alias', 'base'
+
+      styles.define 'override', {
+        color: '#999999'
+        font: {
+          italic: true
+        }
+      }
+
+      def = styles.def_for 'base_alias:override'
+      assert.is_not_nil def
+      assert.equal '#112233', def.background
+      assert.equal '#999999', def.color
+      assert.equal true, def.font.bold

--- a/lib/aullar/styles.moon
+++ b/lib/aullar/styles.moon
@@ -101,22 +101,26 @@ define = (name, definition) ->
 define_default = (name, def) ->
   define name, def unless styles[name]
 
-def_for = (name) ->
-  base = styles.default
+resolve_def = (name) ->
   def = styles[name]
 
   while type(def) == 'string'
     name = def
     def = styles[def]
 
+  def, name
+
+def_for = (name) ->
+  base = styles.default
+  def, name = resolve_def name
+
   if not def
     -- look for sub styling (base:style)
     sub_base, ext = name\match '^([^:]+):(%S+)$'
 
     if sub_base
-      base, def = styles[sub_base] or base, styles[ext]
-      while type(def) == 'string'
-        def = styles[def]
+      base = resolve_def(sub_base) or base
+      def = resolve_def ext
 
   return base unless def
 

--- a/lib/howl/commands/ui_commands.moon
+++ b/lib/howl/commands/ui_commands.moon
@@ -1,8 +1,9 @@
 -- Copyright 2012-2014-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-import app, command, config from howl
-import style from howl.ui
+import app, command, config, mode from howl
+import style, ActionBuffer, BufferPopup, StyledText from howl.ui
+serpent = require 'serpent'
 
 command.register
   name: 'window-toggle-fullscreen',
@@ -18,8 +19,25 @@ command.register
   name: 'describe-style',
   description: 'Describes the current style at cursor'
   handler: ->
-    name, def = style.at_pos app.editor.buffer, app.editor.cursor.pos
-    log.info "#{name}"
+    name = style.at_pos app.editor.buffer, app.editor.cursor.pos
+    unless name
+      log.info "Unstyled"
+      return
+
+    def = style[name]
+    editor = app.editor
+    buf = ActionBuffer!
+    buf\append name, 'h1'
+    buf\append "\n\n"
+    def_s = serpent.block def, comment: false
+    lua_mode = mode.by_name 'lua'
+
+    if lua_mode
+      styles = lua_mode.lexer(def_s)
+      def_s = StyledText def_s, styles
+
+    buf\append def_s
+    editor\show_popup BufferPopup buf
 
 command.register
   name: 'zoom-in',

--- a/lib/howl/editing/text.moon
+++ b/lib/howl/editing/text.moon
@@ -33,6 +33,10 @@ paragraph_at = (line) ->
   lines
 
 can_reflow = (line, limit) ->
+  mode = line.buffer.mode
+  if mode and mode.line_is_reflowable
+    return false unless mode\line_is_reflowable(line.buffer, line)
+
   len = line.ulen
   first_blank = line\find('[\t ]')
   if len > limit
@@ -153,6 +157,7 @@ reflow_check = (args) ->
 
   -- check whether the modification affects the current line
   cur_line = editor.current_line
+  return unless cur_line
   cur_start_pos = cur_line.byte_start_pos
   cur_end_pos = cur_line.byte_end_pos
   start_pos = args.at_pos

--- a/lib/howl/ui/style.moon
+++ b/lib/howl/ui/style.moon
@@ -23,6 +23,10 @@ define 'magenta', color: colors.magenta
 define 'cyan', color: colors.cyan
 define 'white', color: colors.white
 
+-- define some default formatting styles
+define 'bold', font: bold: true
+define 'emphasis', font: italic: true
+
 -- alias some default styles
 define 'symbol', 'key'
 define 'global', 'member'

--- a/spec/editing/text_spec.moon
+++ b/spec/editing/text_spec.moon
@@ -93,41 +93,41 @@ describe 'text', ->
   describe 'reflow_paragraph_at(line, limit)', ->
     it 'splits lines to enforce at most <limit> columns', ->
       buffer.text = 'one two three four\n'
-      text.reflow_paragraph_at lines[1], 10
+      assert.is_true text.reflow_paragraph_at lines[1], 10
       assert.equals 'one two\nthree four\n', buffer.text
 
     it 'splits lines as close to <limit> as possible, given non-breaking words', ->
       buffer.text = 'onetwo three four\n'
-      text.reflow_paragraph_at lines[1], 5
+      assert.is_true text.reflow_paragraph_at lines[1], 5
       assert.equals 'onetwo\nthree\nfour\n', buffer.text
 
     it 'combines lines as necessary to match <limit>', ->
       buffer.text = 'one\ntwo\nthree\nfour\n'
-      text.reflow_paragraph_at lines[1], 10
+      assert.is_true text.reflow_paragraph_at lines[1], 10
       assert.equals 'one two\nthree four\n', buffer.text
 
     it 'returns an unbreakable line as is if it can not reflow', ->
       buffer.text = 'onetwo\n'
-      text.reflow_paragraph_at lines[1], 4
+      assert.is_false text.reflow_paragraph_at lines[1], 4
       assert.equals 'onetwo\n', buffer.text
 
     it 'does not require there to be any newline at the end of the paragraph', ->
       buffer.text = 'one two'
-      text.reflow_paragraph_at lines[1], 5
+      assert.is_true text.reflow_paragraph_at lines[1], 5
       assert.equals 'one\ntwo', buffer.text
 
     it 'includes all the paragraph text in the reflowed text (boundary condition)', ->
       buffer.text = 'one t'
-      text.reflow_paragraph_at lines[1], 4
+      assert.is_true text.reflow_paragraph_at lines[1], 4
       assert.equals 'one\nt', buffer.text
 
     it 'converts an overflowing space to an eol', ->
       buffer.text = 'one \n'
-      text.reflow_paragraph_at lines[1], 3
+      assert.is_true text.reflow_paragraph_at lines[1], 3
       assert.equals 'one\n\n', buffer.text
 
     it 'does not modify the buffer unless there is a change', ->
       buffer.text = 'one two\n'
       buffer.modified = false
-      text.reflow_paragraph_at lines[1], 10
+      assert.is_false text.reflow_paragraph_at lines[1], 10
       assert.is_false buffer.modified

--- a/spec/editing/text_spec.moon
+++ b/spec/editing/text_spec.moon
@@ -80,6 +80,16 @@ describe 'text', ->
       buffer.text = '\nitty\n'
       assert.is_false text.can_reflow lines[2], 10
 
+    context "when the buffer's mode provides line_is_reflowable method", ->
+      it 'respects a negative answer from that', ->
+        buffer.text = 'hum ho hi hi'
+        line = lines[1]
+        assert.is_true text.can_reflow line, 10
+        buffer.mode.line_is_reflowable = -> true
+        assert.is_true text.can_reflow line, 10
+        buffer.mode.line_is_reflowable = -> false
+        assert.is_false text.can_reflow line, 10
+
   describe 'reflow_paragraph_at(line, limit)', ->
     it 'splits lines to enforce at most <limit> columns', ->
       buffer.text = 'one two three four\n'

--- a/spec/editing/text_spec.moon
+++ b/spec/editing/text_spec.moon
@@ -131,3 +131,9 @@ describe 'text', ->
       buffer.modified = false
       assert.is_false text.reflow_paragraph_at lines[1], 10
       assert.is_false buffer.modified
+
+    it 'does not reflow lines if the mode says no', ->
+      buffer.text = 'one\ntwo\nthree'
+      buffer.mode.line_is_reflowable = (line) => not line\find 'three'
+      assert.is_true text.reflow_paragraph_at lines[1], 20
+      assert.equals 'one two\nthree', buffer.text


### PR DESCRIPTION
Adds a new "mail" mode. Primary motivation for me was using Howl as
an external editor when writing emails.

The branch also contains some additional lexer helpers I needed, an
improved `describe-style` command and changes for allowing a mode
to control text reflowing.

Screenshot from the bundle's example file:

![mail-mode](http://nordman.org/howl/mail-mode.png)