### PR TITLE
Line wrapping

### DIFF
--- a/bundles/solarized-themes/light.moon
+++ b/bundles/solarized-themes/light.moon
@@ -194,6 +194,7 @@ return {
       font: bold: true
 
     char: color: green
+    wrap_indicator: 'blue'
 
     fdecl:
       color: key

--- a/bundles/tomorrow-themes/tm_night_blue.moon
+++ b/bundles/tomorrow-themes/tm_night_blue.moon
@@ -11,7 +11,7 @@ aqua = '#99ffff'
 blue = '#bbdaff'
 purple = '#ebbbff'
 
-embedded_bg = '#25384f'
+embedded_bg = '#25389f'
 
 return {
   window:

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -452,9 +452,17 @@ Buffer = {
     part_of_revision = @revisions.processing
     revision = part_of_revision and nil or @revisions\push(type, offset, text)
 
-    args = :offset, :text, :size, :invalidate_offset, :revision, :part_of_revision
-    lines_modified = text\find('[\n\r]') != nil
-    @_nr_lines = nil if lines_modified
+    lines_changed = text\find('[\n\r]') != nil
+    args = {
+      :offset,
+      :text,
+      :size,
+      :invalidate_offset,
+      :revision,
+      :part_of_revision,
+      :lines_changed
+    }
+    @_nr_lines = nil if lines_changed
 
     if @lexer
       at_line = @get_line_at_offset(offset)
@@ -462,7 +470,7 @@ Buffer = {
         last_line_shown = max at_line.nr, @_get_last_line_shown!
         style_to = min(last_line_shown + 20, @nr_lines)
         args.styled = @refresh_styling_at at_line.nr, style_to, {
-          force_full: lines_modified
+          force_full: lines_changed
           no_notify: true
         }
 

--- a/lib/aullar/config.moon
+++ b/lib/aullar/config.moon
@@ -74,6 +74,11 @@ define_options = ->
       default: 1
     }
 
+    view_line_wrap: {
+      type: 'string',
+      default: 'none'
+    }
+
     cursor_blink_interval: {
       type: 'number',
       default: 500

--- a/lib/aullar/config.moon
+++ b/lib/aullar/config.moon
@@ -79,6 +79,11 @@ define_options = ->
       default: 'none'
     },
 
+    view_line_wrap_symbol: {
+      type: 'string',
+      default: '⏎'
+    }
+
     view_line_wrap_navigation: {
       type: 'string',
       default: 'visual'

--- a/lib/aullar/config.moon
+++ b/lib/aullar/config.moon
@@ -72,12 +72,17 @@ define_options = ->
     view_line_padding: {
       type: 'number',
       default: 1
-    }
+    },
 
     view_line_wrap: {
       type: 'string',
       default: 'none'
-    }
+    },
+
+    view_line_wrap_navigation: {
+      type: 'string',
+      default: 'visual'
+    },
 
     cursor_blink_interval: {
       type: 'number',

--- a/lib/aullar/current_line_marker.moon
+++ b/lib/aullar/current_line_marker.moon
@@ -8,9 +8,9 @@ flair = require 'aullar.flair'
 
 flair.define 'current-line', {
   type: flair.RECTANGLE,
-  background: '#8294ab'
-  background_alpha: 0.2
-  width: 'full'
+  background: '#8294ab',
+  background_alpha: 0.2,
+  width: 'full',
 }
 
 flair.define 'current-line-overlay', {
@@ -22,11 +22,14 @@ CurrentLineMarker = {
   new: (@view) =>
 
   draw_before: (x, y, display_line, cr, clip) =>
+    current_flair = flair.get 'current-line'
+    current_flair.height = display_line.height
     flair.draw 'current-line', display_line, 1, 1, x, y, cr
 
   draw_after: (x, y, display_line, cr, clip) =>
     block = display_line.block
     overlay_flair = flair.get 'current-line-overlay'
+    overlay_flair.height = display_line.height
 
     if block
       overlay_flair.width = block.width

--- a/lib/aullar/current_line_marker.moon
+++ b/lib/aullar/current_line_marker.moon
@@ -23,10 +23,16 @@ CurrentLineMarker = {
 
   draw_before: (x, y, display_line, cr, clip, col) =>
     @_offset = 1
-    if display_line.is_wrapped
-      @_offset = display_line.lines\at(col).line_start
+    @_height = display_line.height
+    current_flair = flair.get 'current-line'
 
-    flair.draw 'current-line', display_line, @_offset, @_offset, x, y, cr
+    if display_line.is_wrapped
+      if @view.config.view_line_wrap_navigation == 'visual'
+        @_offset = display_line.lines\at(col).line_start
+        @_height = nil -- defaults to visual line
+
+    current_flair.height = @_height
+    flair.draw current_flair, display_line, @_offset, @_offset, x, y, cr
 
   draw_after: (x, y, display_line, cr, clip, col) =>
     block = display_line.block
@@ -34,9 +40,11 @@ CurrentLineMarker = {
 
     if block
       overlay_flair.width = block.width
+      overlay_flair.height = @_height
       flair.draw overlay_flair, display_line, @_offset, @_offset, x, y, cr
     else
       overlay_flair.width = nil
+      overlay_flair.height = nil
       bg_ranges = display_line.background_ranges
       return unless #bg_ranges > 0
 

--- a/lib/aullar/current_line_marker.moon
+++ b/lib/aullar/current_line_marker.moon
@@ -21,19 +21,20 @@ flair.define 'current-line-overlay', {
 CurrentLineMarker = {
   new: (@view) =>
 
-  draw_before: (x, y, display_line, cr, clip) =>
-    current_flair = flair.get 'current-line'
-    current_flair.height = display_line.height
-    flair.draw 'current-line', display_line, 1, 1, x, y, cr
+  draw_before: (x, y, display_line, cr, clip, col) =>
+    @_offset = 1
+    if display_line.is_wrapped
+      @_offset = display_line.lines\at(col).line_start
 
-  draw_after: (x, y, display_line, cr, clip) =>
+    flair.draw 'current-line', display_line, @_offset, @_offset, x, y, cr
+
+  draw_after: (x, y, display_line, cr, clip, col) =>
     block = display_line.block
     overlay_flair = flair.get 'current-line-overlay'
-    overlay_flair.height = display_line.height
 
     if block
       overlay_flair.width = block.width
-      flair.draw overlay_flair, display_line, 1, 1, x, y, cr
+      flair.draw overlay_flair, display_line, @_offset, @_offset, x, y, cr
     else
       overlay_flair.width = nil
       bg_ranges = display_line.background_ranges

--- a/lib/aullar/cursor.moon
+++ b/lib/aullar/cursor.moon
@@ -372,10 +372,13 @@ Cursor = {
     end_offset, new_trailing = display_line.layout\move_cursor_visually true, start_offset - 1, 0, 1
     end_offset += 1
 
-    at_eol = not display_line.is_wrapped and new_trailing > 0
-    at_eol or= start_offset + 1 > display_line.size
-    if at_eol
-      end_offset = display_line.size + 1
+    if new_trailing > 0
+      if display_line.is_wrapped
+        l = display_line.lines\at @column
+        l = display_line.lines[l.nr + 1]
+        end_offset = l and l.line_start or display_line.size + 1
+      else
+        end_offset = display_line.size + 1
 
     flair.draw @_flair, display_line, start_offset, end_offset, x, base_y, cr
 

--- a/lib/aullar/cursor.moon
+++ b/lib/aullar/cursor.moon
@@ -340,13 +340,12 @@ Cursor = {
     return unless @_showing and (@active or @show_when_inactive)
     start_offset = @column
     end_offset, new_trailing = display_line.layout\move_cursor_visually true, start_offset - 1, 0, 1
+    end_offset += 1
 
     at_eol = not display_line.is_wrapped and new_trailing > 0
-    at_eol or= end_offset > display_line.size + 1
+    at_eol or= start_offset + 1 > display_line.size
     if at_eol
       end_offset = display_line.size + 1
-    else
-      end_offset += 1
 
     flair.draw @_flair, display_line, start_offset, end_offset, x, base_y, cr
 

--- a/lib/aullar/cursor.moon
+++ b/lib/aullar/cursor.moon
@@ -270,11 +270,33 @@ Cursor = {
     @move_to pos: line_start + new_index, extend: opts.extend
 
   up: (opts = {}) =>
+    d_line = @display_line
+    if d_line.is_wrapped
+      wrapped_line = d_line.lines\at(@column)
+      if wrapped_line.nr != 1
+        l_line = d_line.layout\get_line_readonly wrapped_line.nr - 1
+        x = l_line\index_to_x @column - 1, 0
+        prev_l_line = d_line.layout\get_line_readonly wrapped_line.nr - 2
+        inside, offset = prev_l_line\x_to_index x
+        @move_to pos: @buffer_line.start_offset + offset, extend: opts.extend
+        return
+
     prev = @line - 1
     if prev >= 1
       @move_to line: prev, extend: opts.extend
 
   down: (opts = {}) =>
+    d_line = @display_line
+    if d_line.is_wrapped
+      wrapped_line = d_line.lines\at(@column)
+      if wrapped_line.nr != d_line.line_count
+        l_line = d_line.layout\get_line_readonly wrapped_line.nr - 1
+        x = l_line\index_to_x @column - 1, 0
+        next_l_line = d_line.layout\get_line_readonly wrapped_line.nr
+        inside, offset = next_l_line\x_to_index x
+        @move_to pos: @buffer_line.start_offset + offset, extend: opts.extend
+        return
+
     next = @line + 1
     if next <= @view.buffer.nr_lines
       @move_to line: next, extend: opts.extend

--- a/lib/aullar/cursor.moon
+++ b/lib/aullar/cursor.moon
@@ -133,6 +133,8 @@ Cursor = {
     current_x: =>
       cur_rect = @display_line.layout\index_to_pos @column - 1
       cur_rect.x
+
+    _navigate_visual: => @view.config.view_line_wrap_navigation == 'visual'
   }
 
   ensure_in_view: =>
@@ -274,7 +276,7 @@ Cursor = {
 
   up: (opts = {}) =>
     d_line = @display_line
-    if d_line.is_wrapped
+    if d_line.is_wrapped and @_navigate_visual
       wrapped_line = d_line.lines\at(@column)
       if wrapped_line.nr != 1
         -- move up into the previous visual (wrapped) line
@@ -285,7 +287,7 @@ Cursor = {
 
     prev = d_line.prev
     if prev
-      if prev.is_wrapped
+      if prev.is_wrapped and @_navigate_visual
         -- move up into the previous visual (wrapped) line
         prev_l_line = prev.layout\get_line_readonly prev.line_count - 1
         inside, offset = prev_l_line\x_to_index @_sticky_x or @current_x
@@ -296,7 +298,7 @@ Cursor = {
 
   down: (opts = {}) =>
     d_line = @display_line
-    if d_line.is_wrapped
+    if d_line.is_wrapped and @_navigate_visual
       wrapped_line = d_line.lines\at(@column)
       if wrapped_line.nr != d_line.line_count
         -- move down into the next visual (wrapped) line
@@ -332,7 +334,7 @@ Cursor = {
 
   start_of_line: (opts = {}) =>
     d_line = @display_line
-    if d_line.is_wrapped
+    if d_line.is_wrapped and @_navigate_visual
       wrapped_line = d_line.lines\at(@column)
       -- move to the start of this visual (wrapped) line
       @move_to pos: @buffer_line.start_offset + wrapped_line.line_start - 1, extend: opts.extend
@@ -341,7 +343,7 @@ Cursor = {
 
   end_of_line: (opts = {}) =>
     d_line = @display_line
-    if d_line.is_wrapped
+    if d_line.is_wrapped and @_navigate_visual
       wrapped_line = d_line.lines\at(@column)
       -- move to the end of this visual (wrapped) line
       @move_to pos: @buffer_line.start_offset + wrapped_line.line_end - 1, extend: opts.extend

--- a/lib/aullar/cursor.moon
+++ b/lib/aullar/cursor.moon
@@ -247,10 +247,16 @@ Cursor = {
 
   forward: (opts = {}) =>
     return if @_pos > @view.buffer.size
+    layout = @display_line.layout
     line_start = @buffer_line.start_offset
     z_col = (@_pos - line_start)
-    new_index, new_trailing = @display_line.layout\move_cursor_visually true, z_col, 0, 1
-    new_index = @display_line.size if new_trailing > 0
+    new_index, new_trailing = layout\move_cursor_visually true, z_col, 0, 1
+    if new_trailing > 0
+      if not layout.is_wrapped
+        new_index = @display_line.size
+      else
+        new_index += new_trailing
+
     if new_index > @display_line.size -- move to next line
       @move_to pos: @buffer_line.end_offset + 1, extend: opts.extend
     else
@@ -305,7 +311,9 @@ Cursor = {
     start_offset = @column
     end_offset, new_trailing = display_line.layout\move_cursor_visually true, start_offset - 1, 0, 1
 
-    if new_trailing > 0 or end_offset > display_line.size + 1
+    at_eol = not display_line.is_wrapped and new_trailing > 0
+    at_eol or= end_offset > display_line.size + 1
+    if at_eol
       end_offset = display_line.size + 1
     else
       end_offset += 1

--- a/lib/aullar/cursor.moon
+++ b/lib/aullar/cursor.moon
@@ -331,10 +331,22 @@ Cursor = {
     @move_to line: first_visible + cursor_line_offset, extend: opts.extend
 
   start_of_line: (opts = {}) =>
-    @move_to pos: @buffer_line.start_offset, extend: opts.extend
+    d_line = @display_line
+    if d_line.is_wrapped
+      wrapped_line = d_line.lines\at(@column)
+      -- move to the start of this visual (wrapped) line
+      @move_to pos: @buffer_line.start_offset + wrapped_line.line_start - 1, extend: opts.extend
+    else
+      @move_to pos: @buffer_line.start_offset, extend: opts.extend
 
   end_of_line: (opts = {}) =>
-    @move_to pos: @buffer_line.start_offset + @buffer_line.size, extend: opts.extend
+    d_line = @display_line
+    if d_line.is_wrapped
+      wrapped_line = d_line.lines\at(@column)
+      -- move to the end of this visual (wrapped) line
+      @move_to pos: @buffer_line.start_offset + wrapped_line.line_end - 1, extend: opts.extend
+    else
+      @move_to pos: @buffer_line.start_offset + @buffer_line.size, extend: opts.extend
 
   draw: (x, base_y, cr, display_line) =>
     return unless @_showing and (@active or @show_when_inactive)

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -201,6 +201,15 @@ LinesMt = {
         return line
 
     nil
+
+  at_pixel_y: (y) =>
+    cur_y = 0
+    for line in *@
+      cur_y += line.height
+      if cur_y > y
+        return line
+
+    nil
 }
 
 DisplayLine = define_class {

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -191,6 +191,15 @@ draw_edge_line = (at_col, x, y, base_x, line, cr, width_of_space) ->
     f\draw x, y, f.line_width or 0.5, line.height, cr
     cr\restore!
 
+LinesMt = {
+  at: (col) =>
+    for line in *@
+      if col >= line.line_start and col <= line.line_end
+        return line
+
+    nil
+}
+
 DisplayLine = define_class {
   new: (@display_lines, @view, buffer, @pango_context, line, width) =>
     @layout = Layout pango_context
@@ -259,7 +268,7 @@ DisplayLine = define_class {
 
     lines: =>
       unless @_lines
-        @_lines = {}
+        @_lines = setmetatable {}, __index: LinesMt
         for nr = 1, @layout.line_count
           layout_line = @layout\get_line_readonly nr - 1
           _, extents = layout_line\get_pixel_extents!

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -208,6 +208,7 @@ DisplayLine = define_class {
     @nr = line.nr
     @size = line.size
     @indent = get_indent view, line
+    @width_of_space = @view.width_of_space
 
     config = view.config
     wrap = config.view_line_wrap
@@ -215,7 +216,7 @@ DisplayLine = define_class {
     WRAP_LIMIT = 2000 -- xxx replace
     if wrap != 'none' and @size <= WRAP_LIMIT
       wrap_indicator = @display_lines.wrap_indicator
-      width = view.edit_area_width - (wrap_indicator.layout\get_pixel_size!)
+      width = view.edit_area_width - wrap_indicator.width - @width_of_space
       @layout.width = width * SCALE
       wrap_mode = wrap == 'word' and Pango.WRAP_WORD or Pango.WRAP_CHAR
       @layout.wrap = wrap_mode
@@ -236,7 +237,6 @@ DisplayLine = define_class {
     @text_height = height
     @height = height + @y_offset * 2
     @width = width + view.cursor.width
-    @width_of_space = @view.width_of_space
     @is_wrapped = @layout.is_wrapped
     @line_count = @layout.line_count
 
@@ -328,12 +328,13 @@ DisplayLine = define_class {
       wrap_indicator = @display_lines.wrap_indicator
       cr\save!
       wrap_y_offset = @y_offset
+      max_x = (@layout.width / SCALE) + base_x
       for line in *@lines
         break if line.nr == @line_count
         wrap_y = y + wrap_y_offset
-
+        indicator_x = min max_x, line.extents.width + @width_of_space / 2
         line_y_offset = (line.extents.height - wrap_indicator.height) / 2
-        cr\move_to x - base_x + line.extents.width + @width_of_space, wrap_y + line_y_offset
+        cr\move_to x - base_x + indicator_x, wrap_y + line_y_offset
         pango_cairo.show_layout cr, wrap_indicator.layout
         wrap_y_offset += line.extents.height + (@y_offset * 2)
 

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -248,6 +248,9 @@ DisplayLine = define_class {
 
      next: =>
       @display_lines[@nr + 1]
+
+    is_wrapped: =>
+      @layout.is_wrapped
    }
 
   draw: (x, y, cr, clip, opts = {}) =>

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -342,7 +342,8 @@ DisplayLine = define_class {
 
 get_wrap_indicator = (pango_context, view) ->
   layout = Layout pango_context
-  layout\set_text '⏎'
+  layout\set_text view.config.view_line_wrap_symbol
+
   list = AttrList()
   styles.apply list, 'wrap_indicator'
   layout.attributes = list

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -331,7 +331,9 @@ DisplayLine = define_class {
       for line in *@lines
         break if line.nr == @line_count
         wrap_y = y + wrap_y_offset
-        cr\move_to x - base_x + line.extents.width + @width_of_space, wrap_y
+
+        line_y_offset = (line.extents.height - wrap_indicator.height) / 2
+        cr\move_to x - base_x + line.extents.width + @width_of_space, wrap_y + line_y_offset
         pango_cairo.show_layout cr, wrap_indicator.layout
         wrap_y_offset += line.extents.height + (@y_offset * 2)
 
@@ -347,7 +349,9 @@ get_wrap_indicator = (pango_context, view) ->
   list = AttrList()
   styles.apply list, 'wrap_indicator'
   layout.attributes = list
-  :layout
+  width, height = layout\get_pixel_size!
+
+  :layout, :width, :height
 
 (view, tab_array, buffer, pango_context) ->
   setmetatable {

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -191,10 +191,18 @@ draw_edge_line = (at_col, x, y, base_x, line, cr, width_of_space) ->
     cr\restore!
 
 DisplayLine = define_class {
-  new: (@display_lines, @view, buffer, @pango_context, line) =>
+  new: (@display_lines, @view, buffer, @pango_context, line, width) =>
     @layout = Layout pango_context
     @layout\set_text line.ptr, line.size
     @layout.tabs = display_lines.tab_array
+    wrap = view.config.view_line_wrap
+
+    if wrap != 'none'
+      width = view.edit_area_width
+      @layout.width = width * Pango.SCALE
+      wrap_mode = wrap == 'word' and Pango.WRAP_WORD or Pango.WRAP_CHAR
+      @layout.wrap = wrap_mode
+
     @nr = line.nr
     @size = line.size
     @indent = get_indent view, line

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -173,6 +173,9 @@ draw_indentation_guides = (x, y, base_x, line, cr, config, width_of_space) ->
 
   guide_x = x
   indentation_flair = flair.get 'indentation_guide'
+  height = line.height
+  if line.is_wrapped
+    height = line.lines[1].extents.height
 
   for i = 1, (indent / view_indent) - 1
     guide_x += width_of_space * view_indent
@@ -180,7 +183,7 @@ draw_indentation_guides = (x, y, base_x, line, cr, config, width_of_space) ->
     continue if adjusted_x < 0
     f = flair.get("indentation_guide_#{i}") or indentation_flair
     cr\save!
-    f\draw adjusted_x, y, f.line_width or 0.5, line.height, cr
+    f\draw adjusted_x, y, f.line_width or 0.5, height, cr
     cr\restore!
 
 draw_edge_line = (at_col, x, y, base_x, line, cr, width_of_space) ->

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -276,6 +276,7 @@ DisplayLine = define_class {
           line_end = layout_line.length + line_start
           line_end -= 1 unless nr == @layout.line_count
           @_lines[#@_lines + 1] = {
+            :nr,
             :line_start,
             :line_end,
             :extents

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -268,7 +268,7 @@ DisplayLine = define_class {
 
     lines: =>
       unless @_lines
-        @_lines = setmetatable {}, __index: LinesMt
+        @_lines = {}
         for nr = 1, @layout.line_count
           layout_line = @layout\get_line_readonly nr - 1
           _, extents = layout_line\get_pixel_extents!
@@ -282,6 +282,7 @@ DisplayLine = define_class {
             :extents
             height: extents.height + @y_offset * 2
           }
+        setmetatable @_lines, __index: LinesMt
 
       @_lines
    }

--- a/lib/aullar/flair.moon
+++ b/lib/aullar/flair.moon
@@ -178,6 +178,7 @@ need_text_object = (flair) ->
     clip = cr.clip_extents
     base_x = view.base_x
     rect = layout\index_to_pos start_offset - 1
+    y += rect.y / SCALE
     text_start_x = x + max((rect.x / SCALE) - 1, 0) - base_x
     start_x = max(text_start_x, view.edit_area_x)
     rect = layout\index_to_pos end_offset - 1

--- a/lib/aullar/flair.moon
+++ b/lib/aullar/flair.moon
@@ -198,8 +198,6 @@ need_text_object = (flair) ->
       unless width
         end_rect = layout\index_to_pos f_end_offset - 1
         end_x = end_rect.x / SCALE
-        -- if flair is overshooting we need to add the space ourselves
-        end_x += width_of_space if end_offset > f_end_offset
         width = x + end_x - start_x - base_x
 
       if flair.min_width
@@ -213,7 +211,8 @@ need_text_object = (flair) ->
       text_object = flair.text_object
 
       if not text_object and need_text_object(flair)
-        text_object = get_text_object display_line, f_start_offset, f_end_offset, flair
+        ft_end_offset = min line.line_end + 1, end_offset
+        text_object = get_text_object display_line, f_start_offset, ft_end_offset, flair
 
       -- height calculations
       height = type(flair.height) == 'number' and flair.height or line.height

--- a/lib/aullar/flair.moon
+++ b/lib/aullar/flair.moon
@@ -158,7 +158,7 @@ need_text_object = (flair) ->
   compile: (flair, start_offset, end_offset, display_line) ->
     flair = flairs[flair] if type(flair) == 'string'
     return nil unless flair
-    if need_text_object flair
+    if need_text_object(flair) and not display_line.is_wrapped
       flair = moon.copy flair
       flair.text_object = get_text_object display_line, start_offset, end_offset, flair
 
@@ -174,55 +174,71 @@ need_text_object = (flair) ->
     flair = flairs[flair] if type(flair) == 'string'
     return unless flair
 
-    {:layout, :view} = display_line
+    {:layout, :view, :y_offset, :is_wrapped, :lines} = display_line
     clip = cr.clip_extents
     base_x = view.base_x
-    rect = layout\index_to_pos start_offset - 1
-    y += rect.y / SCALE
-    text_start_x = x + max((rect.x / SCALE) - 1, 0) - base_x
-    start_x = max(text_start_x, view.edit_area_x)
-    rect = layout\index_to_pos end_offset - 1
-    width = get_defined_width(start_x, flair, cr, clip)
-    width or= x + (rect.x / SCALE) - start_x - base_x
+    line_count = display_line.line_count
+    width_of_space = display_line.width_of_space
 
-    if flair.min_width
-      flair_min_width = flair.min_width
+    for nr = 1, #lines
+      line = lines[nr]
 
-      if flair_min_width == 'letter'
-        flair_min_width = display_line.width_of_space
+      off_line = start_offset > line.line_end or end_offset < line.line_start
+      if off_line or end_offset == line.line_start and (start_offset != end_offset)
+        continue -- flair not within this layout line
 
-      width = max(flair_min_width - base_x, width)
+      f_start_offset = max start_offset, line.line_start
+      f_end_offset = min line.line_end, end_offset
+      start_rect = layout\index_to_pos f_start_offset - 1
+      flair_y = y + start_rect.y / SCALE
+      text_start_x = x + max((start_rect.x / SCALE) - 1, 0) - base_x
+      start_x = max(text_start_x, view.edit_area_x)
 
-    return if width <= 0
+      width = get_defined_width(start_x, flair, cr, clip)
+      unless width
+        end_rect = layout\index_to_pos f_end_offset - 1
+        end_x = end_rect.x / SCALE
+        -- if flair is overshooting we need to add the space ourselves
+        end_x += width_of_space if end_offset > f_end_offset
+        width = x + end_x - start_x - base_x
 
-    text_object = flair.text_object
+      if flair.min_width
+        flair_min_width = flair.min_width
+        flair_min_width = width_of_space if flair_min_width == 'letter'
+        width = max(flair_min_width - base_x, width)
 
-    if not text_object and need_text_object(flair)
-      text_object = get_text_object display_line, start_offset, end_offset, flair
+      -- why draw a zero-width flair?
+      return if width <= 0
 
-    {:height, :y_offset} = display_line
-    adjusted_for_text_height = false
+      text_object = flair.text_object
 
-    if flair.height == 'text' and height > text_object.height
-      y += y_offset + (display_line.layout.baseline - text_object.layout.baseline) / SCALE
-      height = text_object.height
-      adjusted_for_text_height = true
+      if not text_object and need_text_object(flair)
+        text_object = get_text_object display_line, f_start_offset, f_end_offset, flair
 
-    cr\save!
-    flair.draw flair, start_x, y, width, height, cr
-    cr\restore!
+      -- height calculations
+      height = type(flair.height) == 'number' and flair.height or line.height
+      adjusted_for_text_height = false
 
-    if flair.text_color
-      if not adjusted_for_text_height and height > text_object.height
-        y += y_offset + (display_line.layout.baseline - text_object.layout.baseline) / SCALE
+      if flair.height == 'text' and height > text_object.height
+        flair_y += floor (line.height - text_object.height) / 2
+        height = text_object.height
+        adjusted_for_text_height = true
 
       cr\save!
-      if base_x > 0
-        cr\rectangle x, y, clip.x2 - x, clip.y2
-        cr\clip!
-
-      cr\move_to text_start_x, y
-      cairo.show_layout cr, text_object.layout
+      flair.draw flair, start_x, flair_y, width, height, cr
       cr\restore!
+
+      if flair.text_color
+        if not adjusted_for_text_height and height > text_object.height
+          flair_y += floor (line.height - text_object.height) / 2
+
+        cr\save!
+        if base_x > 0
+          cr\rectangle x, flair_y, clip.x2 - x, clip.y2
+          cr\clip!
+
+        cr\move_to text_start_x, flair_y
+        cairo.show_layout cr, text_object.layout
+        cr\restore!
 
 }

--- a/lib/aullar/flair.moon
+++ b/lib/aullar/flair.moon
@@ -29,7 +29,7 @@ set_line_type_from_flair = (cr, flair) ->
   cr.line_width = flair._line_width
   switch flair.line_type
     when 'dotted'
-      cr.dash = {1, 1.5}
+      cr.dash = {0.5, 1}
     when 'dashed'
       cr.dash = {6, 3}
 

--- a/lib/aullar/gutter.moon
+++ b/lib/aullar/gutter.moon
@@ -32,7 +32,7 @@ define_class {
     @_foreground = RGBA(styling.foreground or '#000000')
     @_foreground_alpha = styling.foreground_alpha or 1
 
-  draw_for_line: (line_nr, x, y, display_line, styling) =>
+  draw_for_line: (line_nr, x, y, display_line) =>
     return unless @layout
 
     cr = @cairo_context
@@ -41,7 +41,14 @@ define_class {
     cr\set_source_rgba color.red, color.green, color.blue, @_foreground_alpha
     @layout.text = tostring line_nr
     _, text_height = @layout\get_pixel_size!
-    cr\move_to x, y + (display_line.height - text_height) / 2
+    line_height = display_line.height
+
+    if display_line.is_wrapped
+      layout_line = display_line.layout\get_line 0
+      _, log_rect = layout_line\get_pixel_extents!
+      line_height = log_rect.height
+
+    cr\move_to x, y + (line_height - text_height) / 2
     pango_cairo.show_layout cr, @layout
     cr\restore!
 

--- a/lib/aullar/gutter.moon
+++ b/lib/aullar/gutter.moon
@@ -44,7 +44,7 @@ define_class {
     line_height = display_line.height
 
     if display_line.is_wrapped
-      layout_line = display_line.layout\get_line 0
+      layout_line = display_line.layout\get_line_readonly 0
       _, log_rect = layout_line\get_pixel_extents!
       line_height = log_rect.height
 

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -710,7 +710,8 @@ describe 'Buffer', ->
           size: 2,
           invalidate_offset: 3,
           revision: b.revisions[1]
-          part_of_revision: false
+          part_of_revision: false,
+          lines_changed: false
         }
         assert.spy(l1.on_inserted).was_called_with l1, b, args
         assert.spy(l2.on_inserted).was_called_with l2, b, args
@@ -727,7 +728,8 @@ describe 'Buffer', ->
           size: 2,
           invalidate_offset: 3,
           revision: b.revisions[1],
-          part_of_revision: false
+          part_of_revision: false,
+          lines_changed: false
         }
 
     it 'fires on_styled notifications for styling changes outside of lexing', ->

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -21,9 +21,6 @@ config = require 'aullar.config'
 {:parse_key_event} = require 'ljglibs.util'
 {:max, :min, :abs, :floor} = math
 
-contains_newlines = (s) ->
-  s\find('[\n\r]') != nil
-
 notify = (view, event, ...) ->
   listener = view.listener
   if listener and listener[event]
@@ -622,12 +619,12 @@ View = {
     cur_pos = @cursor.pos
     sel_anchor, sel_end = @selection.anchor, @selection.end_pos
     lines_showing = type == 'delete' and @lines_showing
+    lines_changed = args.lines_changed
 
     if not @showing
       @_reset_display!
     else
       start_dline = args.styled and @display_lines[args.styled.start_line]
-      lines_changed = contains_newlines(args.text)
 
       if lines_changed
         @_last_visible_line = nil

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -493,7 +493,6 @@ View = {
 
   _draw: (cr) =>
     p_ctx = @area.pango_context
-    cursor_pos = @cursor.pos - 1
     clip = cr.clip_extents
     conf = @config
     line_draw_opts = config: conf, buffer: @_buffer
@@ -522,13 +521,14 @@ View = {
 
     current_line = @cursor.line
     y = start_y
+    cursor_col = @cursor.column
 
     for line_info in *lines
       {:display_line, :line} = line_info
       line_draw_opts.line = line
 
       if line.nr == current_line and conf.view_highlight_current_line
-        @current_line_marker\draw_before edit_area_x, y, display_line, cr, clip
+        @current_line_marker\draw_before edit_area_x, y, display_line, cr, clip, cursor_col
 
       if @selection\affects_line line
         @selection\draw edit_area_x, y, cr, display_line, line
@@ -543,7 +543,7 @@ View = {
 
       if line.nr == current_line
         if conf.view_highlight_current_line
-          @current_line_marker\draw_after edit_area_x, y, display_line, cr, clip
+          @current_line_marker\draw_after edit_area_x, y, display_line, cr, clip, cursor_col
 
         if conf.view_show_cursor
           @cursor\draw edit_area_x, y, cr, display_line

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -427,9 +427,14 @@ View = {
       if (y >= cur_y and y <= end_y)
         line = @_buffer\get_line(line_nr)
         pango_x = (x - @edit_area_x + @base_x) * Pango.SCALE
-        inside, index = d_line.layout\xy_to_index pango_x, 1
+        line_y = (y - cur_y) * Pango.SCALE
+        inside, index = d_line.layout\xy_to_index pango_x, line_y
         if not inside
-          return line.start_offset + line.size
+          if d_line.is_wrapped
+            v_line = d_line.lines\at_pixel_y(y - cur_y)
+            return line.start_offset + v_line.line_end - 1
+          else
+            return line.start_offset + line.size
         else
           -- are we aiming for the next grapheme?
           rect = d_line.layout\index_to_pos index

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -379,12 +379,16 @@ View = {
       d_line = d_lines[line_nr]
 
       if not before
-        d_lines[line.nr] = nil if opts.invalidate
+        if opts.invalidate
+          d_lines[line.nr] = nil
+          -- recreate the display line since subsequent modifications has to
+          -- know what the display properties was for the modified lines
+          d_lines[line.nr]
+
         min_y or= y
         max_y = y + d_line.height
-      else
-        last_valid = max last_valid, line.nr
 
+      last_valid = max last_valid, line.nr
       y += d_line.height
 
     if opts.invalidate -- invalidate any lines after visibly affected block
@@ -488,7 +492,7 @@ View = {
 
     to_offset = min to_offset, @buffer.size + 1
     from_line = @buffer\get_line_at_offset(from_offset).nr
-    to_line = max @display_lines.max, @buffer\get_line_at_offset(to_offset).nr
+    to_line = max @display_lines.max, @buffer\get_line_at_offset(to_offset).nr - 1
 
     for line_nr = from_line, to_line
       @display_lines[line_nr] = nil

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -176,6 +176,14 @@ class Editor extends PropertyObject
 
       @view.config.view_line_wrap = value
 
+  @property line_wrapping_navigation:
+    get: => @view.config.view_line_wrap_navigation
+    set: (value) =>
+      unless value\umatch(r'^(?:real|visual)$')
+        error "Unknown value for line_wrapping_navigation: #{value}", 2
+
+      @view.config.view_line_wrap_navigation = value
+
   @property cursor_line_highlighted:
     get: => @view.config.view_highlight_current_line
     set: (flag) =>
@@ -568,6 +576,7 @@ class Editor extends PropertyObject
     with config
       @indentation_guides = .indentation_guides
       @line_wrapping = .line_wrapping
+      @line_wrapping_navigation = .line_wrapping_navigation
       @horizontal_scrollbar = .horizontal_scrollbar
       @vertical_scrollbar = .vertical_scrollbar
       @cursor_line_highlighted = .cursor_line_highlighted
@@ -813,6 +822,15 @@ with config
     }
 
   .define
+    name: 'line_wrapping_navigation'
+    description: 'Controls how wrapped lines are navigated'
+    default: 'visual'
+    options: {
+      { 'real', 'Lines are navigated by real lines' }
+      { 'visual', 'Lines are navigated by visual (wrapped) lines' }
+    }
+
+  .define
     name: 'horizontal_scrollbar'
     description: 'Whether horizontal scrollbars are shown'
     default: true
@@ -858,6 +876,7 @@ with config
     'indentation_guides',
     'edge_column',
     'line_wrapping',
+    'line_wrapping_navigation',
     'horizontal_scrollbar',
     'vertical_scrollbar',
     'cursor_line_highlighted',

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -588,6 +588,7 @@ class Editor extends PropertyObject
       view_conf.view_tab_size = .tab_width
       view_conf.view_font_name = .font_name
       view_conf.view_font_size = .font_size
+      view_conf.view_line_wrap_symbol = .line_wrapping_symbol
 
   _create_indicator: (indics, id) =>
     def = indicators[id]
@@ -831,6 +832,12 @@ with config
     }
 
   .define
+    name: 'line_wrapping_symbol'
+    description: 'The symbol used for indicating a line wrap'
+    type_of: 'string'
+    default: '⏎'
+
+  .define
     name: 'horizontal_scrollbar'
     description: 'Whether horizontal scrollbars are shown'
     default: true
@@ -892,6 +899,7 @@ with config
     { 'line_numbers', 'view_show_line_numbers' }
     { 'indent', 'view_indent' }
     { 'cursor_blink_interval', 'cursor_blink_interval' }
+    { 'line_wrapping_symbol', 'view_line_wrap_symbol' }
 
   }
     .watch live_update[1], (_, value) -> apply_variable live_update[2], value

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -169,21 +169,12 @@ class Editor extends PropertyObject
     set: (v) => @view.config.view_line_padding = v
 
   @property line_wrapping:
-    get: =>
-      -- sci_val = @sci\get_wrap_mode!
-      -- switch sci_val
-      --   when Scintilla.SC_WRAP_NONE then 'none'
-      --   when Scintilla.SC_WRAP_WORD then 'word'
-      --   when Scintilla.SC_WRAP_CHAR then 'character'
-      --   else '(unknown)'
-
+    get: => @view.config.view_line_wrap
     set: (value) =>
-      -- sci_value = switch value
-      --   when 'none' then Scintilla.SC_WRAP_NONE
-      --   when 'word' then Scintilla.SC_WRAP_WORD
-      --   when 'character' then Scintilla.SC_WRAP_CHAR
-      -- error "Unknown value for line_wrapping: #{value}", 2 unless sci_value
-      -- @sci\set_wrap_mode sci_value
+      unless value\umatch(r'^(?:none|word|character)$')
+        error "Unknown value for line_wrapping: #{value}", 2
+
+      @view.config.view_line_wrap = value
 
   @property cursor_line_highlighted:
     get: => @view.config.view_highlight_current_line

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -171,7 +171,7 @@ class Editor extends PropertyObject
   @property line_wrapping:
     get: => @view.config.view_line_wrap
     set: (value) =>
-      unless value\umatch(r'^(?:none|word|character)$')
+      unless value\umatch r'^(?:none|word|character)$'
         error "Unknown value for line_wrapping: #{value}", 2
 
       @view.config.view_line_wrap = value
@@ -179,7 +179,7 @@ class Editor extends PropertyObject
   @property line_wrapping_navigation:
     get: => @view.config.view_line_wrap_navigation
     set: (value) =>
-      unless value\umatch(r'^(?:real|visual)$')
+      unless value\umatch r'^(?:real|visual)$'
         error "Unknown value for line_wrapping_navigation: #{value}", 2
 
       @view.config.view_line_wrap_navigation = value

--- a/lib/ljglibs/cdefs/pango.moon
+++ b/lib/ljglibs/cdefs/pango.moon
@@ -284,6 +284,12 @@ ffi.cdef [[
 
   /* PangoLayout */
 
+  typedef enum {
+    PANGO_WRAP_WORD,
+    PANGO_WRAP_CHAR,
+    PANGO_WRAP_WORD_CHAR
+  } PangoWrapMode;
+
   typedef struct {} PangoLayout;
 
   typedef struct {
@@ -315,7 +321,9 @@ ffi.cdef [[
   void pango_layout_set_font_description (PangoLayout *layout, const PangoFontDescription *desc);
   const PangoFontDescription * pango_layout_get_font_description (PangoLayout *layout);
   int pango_layout_get_baseline (PangoLayout *layout);
-
+  gboolean pango_layout_is_wrapped (PangoLayout *layout);
+  PangoWrapMode pango_layout_get_wrap (PangoLayout *layout);
+  void pango_layout_set_wrap (PangoLayout *layout, PangoWrapMode wrap);
   void pango_layout_index_to_pos (PangoLayout *layout, int index, PangoRectangle *pos);
 
   gboolean pango_layout_xy_to_index (PangoLayout *layout,

--- a/lib/ljglibs/cdefs/pango.moon
+++ b/lib/ljglibs/cdefs/pango.moon
@@ -325,6 +325,9 @@ ffi.cdef [[
   PangoWrapMode pango_layout_get_wrap (PangoLayout *layout);
   void pango_layout_set_wrap (PangoLayout *layout, PangoWrapMode wrap);
   void pango_layout_index_to_pos (PangoLayout *layout, int index, PangoRectangle *pos);
+  int pango_layout_get_line_count (PangoLayout *layout);
+  void pango_layout_set_indent (PangoLayout *layout, int indent);
+  int pango_layout_get_indent (PangoLayout *layout);
 
   gboolean pango_layout_xy_to_index (PangoLayout *layout,
                                      int x,

--- a/lib/ljglibs/pango/init.moon
+++ b/lib/ljglibs/pango/init.moon
@@ -103,6 +103,11 @@ core.auto_loading 'pango', {
     'ATTR_ABSOLUTE_SIZE'
     'ATTR_GRAVITY'
     'ATTR_GRAVITY_HINT'
+
+    -- PangoWrapMode
+    'WRAP_WORD',
+    'WRAP_CHAR',
+    'WRAP_WORD_CHAR'
   },
 
   SCALE: 1024

--- a/lib/ljglibs/pango/layout.moon
+++ b/lib/ljglibs/pango/layout.moon
@@ -67,6 +67,11 @@ core.define 'PangoLayout', {
       set: (spacing) => C.pango_layout_set_spacing @, spacing
     }
 
+    indent: {
+      get: => tonumber C.pango_layout_get_indent @
+      set: (indent) => C.pango_layout_set_indent @, indent
+    }
+
     alignment: {
       get: => tonumber C.pango_layout_get_alignment @
       set: (alignment) => C.pango_layout_set_alignment @, alignment
@@ -101,6 +106,8 @@ core.define 'PangoLayout', {
       get: => C.pango_layout_get_wrap(@)
       set: (w) => C.pango_layout_set_wrap(@, w)
     }
+
+    line_count: => tonumber C.pango_layout_get_line_count(@)
   }
 
   new: (ctx) -> gc_ptr C.pango_layout_new ctx

--- a/lib/ljglibs/pango/layout.moon
+++ b/lib/ljglibs/pango/layout.moon
@@ -48,7 +48,7 @@ core.define 'PangoLayout', {
 
   properties: {
     text: {
-      get: => ffi_string @get_text
+      get: => ffi_string @get_text!
       set: (text) => @set_text text
     }
 

--- a/lib/ljglibs/pango/layout.moon
+++ b/lib/ljglibs/pango/layout.moon
@@ -94,6 +94,13 @@ core.define 'PangoLayout', {
 
     iter: =>
       ffi_gc C.pango_layout_get_iter(@), C.pango_layout_iter_free
+
+    is_wrapped: => C.pango_layout_is_wrapped(@) != 0
+
+    wrap: {
+      get: => C.pango_layout_get_wrap(@)
+      set: (w) => C.pango_layout_set_wrap(@, w)
+    }
   }
 
   new: (ctx) -> gc_ptr C.pango_layout_new ctx

--- a/lib/ljglibs/pango/layout.moon
+++ b/lib/ljglibs/pango/layout.moon
@@ -18,6 +18,16 @@ core.define 'PangoLayoutLine', {
     ink_rect = PangoRectangle!
     C.pango_layout_line_get_pixel_extents @, ink_rect, logical_rect
     ink_rect, logical_rect
+
+  index_to_x: (index, trailing) =>
+    arr = ffi_new 'int[1]'
+    C.pango_layout_line_index_to_x @, index, trailing, arr
+    tonumber arr[0]
+
+  x_to_index: (x_pos) =>
+    arr = ffi_new 'int[2]'
+    outside = C.pango_layout_line_x_to_index @, x_pos, arr, arr + 1
+    outside == 1, tonumber(arr[0]), tonumber(arr[1])
 }
 
 core.define 'PangoLayoutIter', {

--- a/spec/ui/cursor_spec.moon
+++ b/spec/ui/cursor_spec.moon
@@ -1,11 +1,16 @@
 import Buffer, config from howl
 import Editor, theme from howl.ui
+Gtk = require 'ljglibs.gtk'
 
 describe 'Cursor', ->
   buffer = Buffer {}
   editor = Editor buffer
   cursor = editor.cursor
   selection = editor.selection
+  window = Gtk.OffscreenWindow default_width: 800, default_height: 640
+  window\add editor\to_gobject!
+  window\show_all!
+  pump_mainloop!
 
   before_each ->
     cursor.pos = 1


### PR DESCRIPTION
This adds line wrapping support for aullar.  It supports the previously existing `line_wrapping` configuration variable, which supports wrapping on either character or word (or none). It also introduces two new configuration variables related to wrapping:

- `line_wrapping_navigation`

This provides control over how wrapped lines are navigated. "real" means cursor movement will step over the line in an ordinary fashion even if it's wrapped, and "visual" means that cursor movement will walk into a wrapped line. The mode is also reflected in the current line marker which will highlight the entire line for the former, and the visual line for the latter.

- `line_wrapping_symbol`

This is the symbol used for indicating wrapping at the right side of the wrapped visual line. The appearance of the symbol itself is controlled using ordinary styles.

The one (big) thing that is not present is "proper" scrolling of lines when the navigation mode is set to visual. We currently only support scrolling by real lines, meaning scrolling can now appear a bit jagged since scrolling one line might mean actually shifting the screen by two or more visual lines. The plan is not to include that in this PR however, but instead leave that for the  future.