### PR TITLE
Faster

### DIFF
--- a/lib/aullar/spec/view_spec.moon
+++ b/lib/aullar/spec/view_spec.moon
@@ -127,6 +127,45 @@ describe 'View', ->
       buffer\delete 2, 3
       assert.equals 5, cursor.pos
 
+  describe '(when text is changed)', ->
+    it 'moves the cursor up for contracting changes before the cursor', ->
+      buffer.text = '12345'
+      cursor.pos = 4
+      buffer\change 1, 3, (b) ->
+        b\delete 1, 3
+        b\insert 1, 'X'
+
+      assert.equals 2, cursor.pos
+
+    it 'moves the cursor up for expanding changes before the cursor', ->
+      buffer.text = '12345'
+      cursor.pos = 4
+      buffer\change 1, 3, (b) ->
+        b\delete 3, 1
+        b\insert 1, 'XX'
+
+      assert.equals 5, cursor.pos
+
+    it 'handles changes over the cursor position', ->
+      buffer.text = '12345'
+      cursor.pos = 3
+      buffer\change 1, 5, (b) ->
+        b\delete 2, 3 -- down to 2
+        b\insert 1, 'XXXX' -- up to 6
+        b\delete 1, 1 -- down to 5
+
+      assert.equals 5, cursor.pos
+
+    it 'leaves the cursor alone for changes after the cursor position', ->
+      buffer.text = '12345'
+      cursor.pos = 2
+      buffer\change 1, 5, (b) ->
+        b\delete 2, 1
+        b\insert 3, 'XXX'
+        b\delete 3, 1
+
+      assert.equals 2, cursor.pos
+
   describe 'when a buffer operation is undone', ->
     it 'moves the cursor to the position before action', ->
       buffer.text = '12345'

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -51,6 +51,7 @@ class Buffer extends PropertyObject
     @_buffer\add_listener
       on_inserted: self\_on_text_inserted
       on_deleted: self\_on_text_deleted
+      on_changed: self\_on_text_changed
 
   @property file:
     get: => @_file
@@ -182,6 +183,11 @@ class Buffer extends PropertyObject
 
     #matches / 2
 
+  change: (start_pos, end_pos, changer) =>
+    b_start, b_end = @byte_offset(start_pos), @byte_offset(end_pos + 1)
+    @_buffer\change b_start, b_end - b_start, ->
+      changer @
+
   save: =>
     if @file
       if @config.strip_trailing_whitespace
@@ -291,27 +297,26 @@ class Buffer extends PropertyObject
     @title = file_title file
 
   _on_text_inserted: (_, _, args) =>
-    @_len = nil
-    @_modified = true
-    args = {
-      buffer: self,
-      at_pos: @char_offset(args.offset)
-      part_of_revision: args.part_of_revision
-    }
-
-    signal.emit 'text-inserted', args
-    signal.emit 'buffer-modified', buffer: self
+    @_on_buffer_modification 'text-inserted', args
 
   _on_text_deleted: (_, _, args) =>
+    @_on_buffer_modification 'text-deleted', args
+
+  _on_text_changed: (_, _, args) =>
+    @_on_buffer_modification 'text-changed', args
+
+  _on_buffer_modification: (what, args) =>
     @_len = nil
     @_modified = true
     args = {
       buffer: self,
-      at_pos: @char_offset(args.offset)
-      part_of_revision: args.part_of_revision
+      at_pos: @char_offset(args.offset),
+      part_of_revision: args.part_of_revision,
+      text: args.text
+      prev_text: args.prev_text
     }
 
-    signal.emit 'text-deleted', args
+    signal.emit what, args
     signal.emit 'buffer-modified', buffer: self
 
   @meta {
@@ -344,7 +349,7 @@ with signal
 
   .register 'text-inserted',
     description: [[
-Signaled right after text has been inserted into an editor. No additional
+Signaled right after text has been inserted into a buffer. No additional
 modifications  may be done within the signal handler.
   ]]
     parameters:
@@ -355,15 +360,26 @@ modifications  may be done within the signal handler.
 
   .register 'text-deleted',
     description: [[
-Signaled right after text was deleted from the editor. No additional
+Signaled right after text was deleted from a buffer. No additional
 modifications may be done within the signal handler.
   ]]
     parameters:
       buffer: 'The buffer for which the text was deleted'
       at_pos: 'The start position of the deleted text'
       text: 'The text that was deleted'
-      as_undo: 'The text was deleted as part of an undo operation'
       part_of_revision: 'The text was deleted as part of an undo or redo operation'
+
+  .register 'text-changed',
+    description: [[
+Signaled right after text was changed in a buffer. No additional
+modifications may be done within the signal handler.
+  ]]
+    parameters:
+      buffer: 'The buffer for which the text was deleted'
+      at_pos: 'The start position of the deleted text'
+      text: 'The new text that was inserted'
+      prev_text: 'The text that was removed'
+      part_of_revision: 'The text was changed as part of an undo or redo operation'
 
   .register 'buffer-modified',
     description: 'Signaled right after a buffer was modified',

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -174,12 +174,18 @@ class Buffer extends PropertyObject
       pos = end_pos + 1
 
     return if #matches == 0
-    b_offsets = text\byte_offset matches
 
-    for i = #b_offsets, 1, -2
-      start_pos = b_offsets[i - 1]
-      end_pos = b_offsets[i]
-      @_buffer\replace start_pos, (end_pos - start_pos) + 1, replacement
+    if @multibyte
+      matches = [@_buffer\byte_offset(p) for p in *matches]
+
+    offset = matches[1]
+    count = matches[#matches] - offset + 1
+
+    @_buffer\change offset, count, ->
+      for i = #matches, 1, -2
+        start_pos = matches[i - 1]
+        end_pos = matches[i]
+        @_buffer\replace start_pos, (end_pos - start_pos) + 1, replacement
 
     #matches / 2
 

--- a/lib/howl/buffer_lines.moon
+++ b/lib/howl/buffer_lines.moon
@@ -55,7 +55,10 @@ Line = (nr, buffer) ->
 
     replace: (i, j, replacement) =>
       b_i, b_j = @byte_offset i, j + 1
-      a_buf\replace @byte_start_pos + b_i - 1, (b_j - b_i), replacement
+      offset = @byte_start_pos + b_i - 1
+      count = b_j - b_i
+      a_buf\change offset, count, ->
+        a_buf\replace offset, count, replacement
 
     real_column: (col) =>
       return 1 if col == 1

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -300,7 +300,10 @@ class Editor extends PropertyObject
 
   transform_active_lines: (f) =>
     lines = @active_lines
-    @buffer\as_one_undo -> f lines
+    return if #@active_lines == 0
+    start_pos = @active_lines[1].start_pos
+    end_pos = @active_lines[#@active_lines].end_pos
+    @buffer\change start_pos, end_pos, -> f lines
 
   with_position_restored: (f) =>
     line, column, indentation, top_line = @cursor.line, @cursor.column, @current_line.indentation, @line_at_top
@@ -330,7 +333,8 @@ class Editor extends PropertyObject
 
   comment: => if @buffer.mode.comment then @buffer.mode\comment self
   uncomment: => if @buffer.mode.uncomment then @buffer.mode\uncomment self
-  toggle_comment: => if @buffer.mode.toggle_comment then @buffer.mode\toggle_comment self
+  toggle_comment: =>
+    if @buffer.mode.toggle_comment then @buffer.mode\toggle_comment self
 
   delete_line: => @buffer.lines[@cursor.line] = nil
 
@@ -909,7 +913,6 @@ with config
 -- Commands
 for cmd_spec in *{
   { 'newline', 'Adds a new line at the current position', 'newline' }
-  { 'newline-and-format', 'Adds a new line, and formats as needed', 'newline_and_format' }
   { 'comment', 'Comments the selection or current line', 'comment' }
   { 'uncomment', 'Uncomments the selection or current line', 'uncomment' }
   { 'toggle-comment', 'Comments or uncomments the selection or current line', 'toggle_comment' }

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -208,6 +208,17 @@ describe 'Buffer', ->
       b = buffer 'hello\nworld\n'
       assert.equal 1, b\replace('world', 'editor')
 
+  describe 'change(start_pos, end_pos)', ->
+    it 'applies all operations as one undo for the specified region', ->
+      b = buffer 'ño señor'
+      b\change 4, 6, -> -- 'señ'
+        b\delete 4, 6
+        b\insert 'minmin', 4
+
+      assert.equal 'ño minminor', b.text
+      b\undo!
+      assert.equal 'ño señor', b.text
+
   it 'undo undoes the last operation', ->
     b = buffer 'hello'
     b\delete 1, 1
@@ -583,6 +594,13 @@ describe 'Buffer', ->
       with_signal_handler 'text-inserted', nil, (handler) ->
         b = buffer 'foo'
         b\delete 1, 2
+        assert.spy(handler).was_called!
+
+    it 'text-changed is fired whenever text is change:d from buffer', ->
+      with_signal_handler 'text-changed', nil, (handler) ->
+        b = buffer 'foo'
+        b\change 1, 2, ->
+          b\delete 1, 1
         assert.spy(handler).was_called!
 
     it 'buffer-modified is fired whenever a buffer is modified', ->


### PR DESCRIPTION
This add support for collapsing multiple edit operations into a single revision. It's restricted to the case where the size of the region to be changed is known in advance .
   
The is currently a big problem with doing a massive amount of updates for a buffer, is it causes a corresponding amounts of notifications to views. This get's very inefficient very fast. The new `change` method allows for a way around this, by allowing a range to be modified with all changes collected in one revision. In contrast to `as_one_undo`, only one notification will be fired to listeners.

Changed in this PR is buffer replace operations, as well as active lines transformations (e.g comment toggling, indenting, etc.).