### PR TITLE
Faster markers

### DIFF
--- a/bundles/solarized-themes/light.moon
+++ b/bundles/solarized-themes/light.moon
@@ -144,6 +144,11 @@ return {
       background: blue
       background_alpha: 0.2
 
+    list_highlight:
+      type: highlight.UNDERLINE
+      text_color: black
+      line_width: 2
+
     cursor:
       type: highlight.RECTANGLE
       background: base01
@@ -269,11 +274,6 @@ return {
     warning:
       font: italic: true
       color: orange
-
-    list_highlight:
-      color: foreground
-      underline: true
-      font: bold: true
 
     h1:
       color: white

--- a/bundles/tomorrow-themes/tm_night_blue.moon
+++ b/bundles/tomorrow-themes/tm_night_blue.moon
@@ -108,6 +108,7 @@ return {
       type: flair.ROUNDED_RECTANGLE
       background: lightblue
       text_color: black
+      height: 'text'
 
     replace_strikeout:
       type: flair.ROUNDED_RECTANGLE
@@ -126,6 +127,12 @@ return {
       type: flair.RECTANGLE
       background: white
       background_alpha: 0.4
+
+    list_highlight:
+      type: highlight.UNDERLINE
+      foreground: white
+      text_color: white
+      line_width: 2
 
     cursor:
       type: flair.RECTANGLE
@@ -233,10 +240,6 @@ return {
     warning:
       font: italic: true
       color: orange
-
-    list_highlight:
-      color: white
-      underline: true
 
     h1:
       color: white

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -543,8 +543,7 @@ Buffer = {
     @notify('styled', styled)
 
   _on_markers_changed: (_, markers) =>
-    for marker in *markers
-      @notify('marker_changed', marker)
+    @notify('markers_changed', markers)
 
 }
 

--- a/lib/aullar/flair.moon
+++ b/lib/aullar/flair.moon
@@ -8,7 +8,7 @@ Cairo = require 'ljglibs.cairo.cairo'
 {:define_class} = require 'aullar.util'
 styles = require 'aullar.styles'
 Styling = require 'aullar.styling'
-{:min, :max, :floor} = math
+{:min, :max, :floor, :pi} = math
 copy = moon.copy
 
 flairs = {}
@@ -52,9 +52,9 @@ draw_ops = {
     radius = flair['corner_radius'] or 3
 
     if width < radius * 3 or height < radius * 3
-      radius = math.min(width, height) / 3
+      radius = min(width, height) / 3
 
-    quadrant = math.pi / 2
+    quadrant = pi / 2
     right, bottom, left, top = 0, quadrant, quadrant * 2, quadrant * 3
     cr\move_to x, y + radius
     cr\arc x + radius, y + radius, radius, left, top

--- a/lib/aullar/flair.moon
+++ b/lib/aullar/flair.moon
@@ -191,7 +191,7 @@ need_text_object = (flair) ->
       f_end_offset = min line.line_end, end_offset
       start_rect = layout\index_to_pos f_start_offset - 1
       flair_y = y + start_rect.y / SCALE
-      text_start_x = x + max((start_rect.x / SCALE) - 1, 0) - base_x
+      text_start_x = x + max((start_rect.x / SCALE), 0) - base_x
       start_x = max(text_start_x, view.edit_area_x)
 
       width = get_defined_width(start_x, flair, cr, clip)

--- a/lib/aullar/markers.moon
+++ b/lib/aullar/markers.moon
@@ -14,19 +14,21 @@ define_class {
   new: (@listener) =>
     @markers = {}
 
-  add: (data) =>
-    for f in *{ 'name', 'start_offset', 'end_offset' }
-      error "Missing field '#{f}'", 2 unless data[f]
+  add: (markers) =>
+    for marker in *markers
+      for f in *{ 'name', 'start_offset', 'end_offset' }
+        error "Missing field '#{f}'", 2 unless marker[f]
 
-    idx = #@markers + 1
-    for i = 1, #@markers
-      m = @markers[i]
-      if m.start_offset > data.start_offset
-        idx = i
-        break
+      idx = #@markers + 1
+      for i = 1, #@markers
+        m = @markers[i]
+        if m.start_offset > marker.start_offset
+          idx = i
+          break
 
-    insert @markers, idx, data
-    @_notify 'added', {data}
+      insert @markers, idx, marker
+
+    @_notify 'added', markers
 
   remove: (selector = {}) =>
     indices = {}
@@ -37,6 +39,8 @@ define_class {
       if selector_matches(selector, marker)
         insert(indices, i)
         insert markers, marker
+
+    return if #markers == 0
 
     for i = #indices, 1, -1
       remove @markers, indices[i]
@@ -50,6 +54,7 @@ define_class {
     for i = #indices, 1, -1
       insert markers, (remove @markers, indices[i])
 
+    return if #markers == 0
     @_notify 'removed', markers
 
   at: (offset, selector) =>

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -209,7 +209,7 @@ describe 'Buffer', ->
       markers = buffer.markers
 
     it 'updates markers with inserts', ->
-      markers\add name: 'test', start_offset: 2, end_offset: 4
+      markers\add { {name: 'test', start_offset: 2, end_offset: 4} }
       buffer\insert 1, '!'
       assert.same {}, markers\at 2
       assert.same { name: 'test', start_offset: 3, end_offset: 5 }, markers\at(3)[1]
@@ -218,7 +218,7 @@ describe 'Buffer', ->
       assert.same { name: 'test', start_offset: 3, end_offset: 6 }, markers\at(3)[1]
 
     it 'updates markers with deletes', ->
-      markers\add name: 'test', start_offset: 2, end_offset: 5
+      markers\add { {name: 'test', start_offset: 2, end_offset: 5} }
       buffer\delete 1, 1
       assert.same {}, markers\at 5
       assert.same { name: 'test', start_offset: 1, end_offset: 4 }, markers\at(1)[1]

--- a/lib/aullar/spec/markers_spec.moon
+++ b/lib/aullar/spec/markers_spec.moon
@@ -18,35 +18,33 @@ describe 'markers', ->
     table.sort n
     n
 
-  describe 'add(data)', ->
+  describe 'add(markers)', ->
     it 'raises an error if <data.name> is missing', ->
-      assert.raises 'name', -> markers\add start_offset: 1, end_offset: 2
+      assert.raises 'name', -> markers\add { {start_offset: 1, end_offset: 2} }
 
     it 'raises an error if <data.start_offset> is missing', ->
-      assert.raises 'start_offset', -> markers\add name: 'test', end_offset: 2
+      assert.raises 'start_offset', -> markers\add { {name: 'test', end_offset: 2} }
 
     it 'raises an error if <data.end_offset> is missing', ->
-      assert.raises 'end_offset', -> markers\add name: 'test', start_offset: 2
+      assert.raises 'end_offset', -> markers\add { {name: 'test', start_offset: 2} }
 
     it 'adds the specified marker for the designated span', ->
       data = name: 'test', my_key: 'my_val', start_offset: 2, end_offset: 4
-      markers\add data
+      markers\add { data }
       assert.same {}, markers\at(1)
       assert.same {data}, markers\at(2)
       assert.same {data}, markers\at(3)
       assert.same {}, markers\at(4)
 
     it 'notifies the listener', ->
-      data = name: 'test', start_offset: 2, end_offset: 4
-      markers\add data
-      assert.spy(listener.on_markers_added).was_called_with listener, {
-        data
-      }
+      mks = { {name: 'test', start_offset: 2, end_offset: 4} }
+      markers\add mks
+      assert.spy(listener.on_markers_added).was_called_with listener, mks
 
   describe 'for_range(start_offset, end_offset [, selector])', ->
     it 'returns all markers that intersects with the specified span', ->
-      markers\add name: 'test1', start_offset: 2, end_offset: 5
-      markers\add name: 'test2', start_offset: 4, end_offset: 6
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 5} }
+      markers\add { {name: 'test2', start_offset: 4, end_offset: 6} }
 
       assert.same {'test1'}, names(markers\for_range(1, 4))
       assert.same {'test1', 'test2'}, names(markers\for_range(1, 5))
@@ -57,29 +55,29 @@ describe 'markers', ->
 
     describe 'when <selector> is specified', ->
       it 'only returns markers with fields matching selector', ->
-        markers\add name: 'test1', start_offset: 2, end_offset: 5, foo: 'bar'
-        markers\add name: 'test2', start_offset: 4, end_offset: 6, frob: 'nic'
+        markers\add { {name: 'test1', start_offset: 2, end_offset: 5, foo: 'bar'} }
+        markers\add { {name: 'test2', start_offset: 4, end_offset: 6, frob: 'nic'} }
         assert.same {}, markers\for_range(1, 6, foo: 'other')
 
   it 'markers can overlap', ->
-    markers\add name: 'test1', start_offset: 2, end_offset: 4
-    markers\add name: 'test2', start_offset: 3, end_offset: 4
+    markers\add { {name: 'test1', start_offset: 2, end_offset: 4} }
+    markers\add { {name: 'test2', start_offset: 3, end_offset: 4} }
     assert.equals 1, #markers\at(2)
     assert.equals 2, #markers\at(3)
     assert.same {'test1', 'test2'}, names(markers\at(3))
 
   describe 'remove(selector)', ->
     it 'removes all markers matching the selector', ->
-      markers\add name: 'test1', start_offset: 2, end_offset: 3, foo: 'bar'
-      markers\add name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob'
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 3, foo: 'bar'} }
+      markers\add { {name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob'} }
       markers\remove foo: 'frob'
       assert.same {'test1'}, names(markers\for_range(1, 7))
       markers\remove!
       assert.same {}, markers\for_range(1, 7)
 
     it 'notifies the listener', ->
-      markers\add name: 'test1', start_offset: 2, end_offset: 3, foo: 'bar'
-      markers\add name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob'
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 3, foo: 'bar'} }
+      markers\add { {name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob'} }
       markers\remove foo: 'frob'
       assert.spy(listener.on_markers_removed).was_called_with listener, {
         { name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob' }
@@ -87,8 +85,8 @@ describe 'markers', ->
 
   describe 'remove_for_range(start_offset, end_offset [, selector])', ->
     it 'removes all markers within the range', ->
-      markers\add name: 'test1', start_offset: 2, end_offset: 3
-      markers\add name: 'test2', start_offset: 5, end_offset: 6
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 3} }
+      markers\add { {name: 'test2', start_offset: 5, end_offset: 6} }
 
       markers\remove_for_range 1, 4
       assert.same {}, markers\at(2)
@@ -97,8 +95,8 @@ describe 'markers', ->
       assert.same {}, markers\at(5)
 
     it 'notifies the listener', ->
-      markers\add name: 'test1', start_offset: 2, end_offset: 3
-      markers\add name: 'test2', start_offset: 5, end_offset: 6
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 3} }
+      markers\add { {name: 'test2', start_offset: 5, end_offset: 6} }
       markers\remove_for_range 1, 4
       assert.spy(listener.on_markers_removed).was_called_with listener, {
         { name: 'test1', start_offset: 2, end_offset: 3 }
@@ -106,14 +104,14 @@ describe 'markers', ->
 
     describe 'when <selector> is specified', ->
       it 'only removes markers matching the selector', ->
-        markers\add name: 'test1', start_offset: 2, end_offset: 3, foo: 'bar'
-        markers\add name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob'
+        markers\add { {name: 'test1', start_offset: 2, end_offset: 3, foo: 'bar'} }
+        markers\add { {name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob'} }
         markers\remove_for_range 1, 7, foo: 'frob'
         assert.same {'test1'}, names(markers\for_range(1, 7))
 
   describe 'expand(offset, count)', ->
     it 'bumps all markers below or at <offset> by <count> positions', ->
-      markers\add name: 'test1', start_offset: 3, end_offset: 4
+      markers\add { {name: 'test1', start_offset: 3, end_offset: 4} }
       markers\expand 2, 3
       assert.same {}, markers\at(3)
       assert.same {
@@ -131,7 +129,7 @@ describe 'markers', ->
       }, markers\at(7)[1]
 
     it 'expands enclosing markers by <count> positions', ->
-      markers\add name: 'test1', start_offset: 2, end_offset: 4
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 4} }
       markers\expand 3, 2
       assert.same {
         name: 'test1',
@@ -149,7 +147,7 @@ describe 'markers', ->
 
   describe 'shrink(offset, count)', ->
     it 'moves all markers above the end offset down by <count> positions', ->
-      markers\add name: 'test1', start_offset: 5, end_offset: 10
+      markers\add { {name: 'test1', start_offset: 5, end_offset: 10} }
       markers\shrink 4, 1
       assert.same {}, markers\at(9)
       assert.same {
@@ -167,7 +165,7 @@ describe 'markers', ->
       }, markers\at(3)[1]
 
     it 'shrinks enclosing markers by <count> positions', ->
-      markers\add name: 'test1', start_offset: 2, end_offset: 8
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 8} }
       markers\shrink 2, 2
       assert.same {
         name: 'test1',
@@ -184,8 +182,8 @@ describe 'markers', ->
       assert.equals 5, markers\at(2)[1].end_offset
 
     it 'removes partially affected markers', ->
-      markers\add name: 'test1', start_offset: 2, end_offset: 4
-      markers\add name: 'test2', start_offset: 5, end_offset: 10
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 4} }
+      markers\add { {name: 'test2', start_offset: 5, end_offset: 10} }
 
       markers\shrink 8, 3
       assert.same {}, markers\at(5)

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -160,7 +160,7 @@ View = {
       on_styled: (_, b, args) -> @\_on_buffer_styled b, args
       on_undo: (_, b, args) -> @\_on_buffer_undo b, args
       on_redo: (_, b, args) -> @\_on_buffer_redo b, args
-      on_marker_changed: (_, b, args) -> @\_on_buffer_marker_changed b, args
+      on_markers_changed: (_, b, args) -> @\_on_buffer_markers_changed b, args
       last_line_shown: (_, b) -> @last_visible_line
     }
 
@@ -698,9 +698,10 @@ View = {
       if @_first_visible_line > 1 and @lines_showing < lines_showing
         @last_visible_line = @buffer.nr_lines
 
-  _on_buffer_marker_changed: (buffer, marker) =>
-    if marker.flair
-      @refresh_display from_offset: marker.start_offset, to_offset: marker.end_offset, invalidate: true
+  _on_buffer_markers_changed: (buffer, markers) =>
+    from_offset = markers[1].start_offset
+    to_offset = markers[#markers].end_offset
+    @refresh_display :from_offset, :to_offset, invalidate: true
 
   _on_buffer_undo: (buffer, revision) =>
     pos = revision.meta.cursor_before or revision.offset

--- a/lib/howl/interactions/line_selection.moon
+++ b/lib/howl/interactions/line_selection.moon
@@ -22,8 +22,8 @@ line_match_highlighter = (editor) ->
 
     if segments
       start_pos = line.start_pos
-      for segment in *segments
-        highlight.apply 'search', buffer, start_pos + segment[1] - 1, segment[2]
+      ranges = [{start_pos + s[1] - 1, s[2]} for s in *segments]
+      highlight.apply 'search', buffer, ranges
     else
       highlight.apply 'search', buffer, line.start_pos, line.end_pos - line.start_pos
 
@@ -38,6 +38,8 @@ line_match_highlighter = (editor) ->
           break
 
       if idx
+        ranges = {}
+
         for i = idx, #items
           continue unless items[i].buffer == buffer
           nr = items[i].line_nr
@@ -50,7 +52,9 @@ line_match_highlighter = (editor) ->
           segments = Matcher.explain text, line.text
           if segments
             for segment in *segments
-              highlight.apply 'search_secondary', buffer, start_pos + segment[1] - 1, segment[2]
+              ranges[#ranges + 1] = { start_pos + segment[1] - 1, segment[2] }
+
+        highlight.apply 'search_secondary', buffer, ranges
 
 interact.register
   name: 'select_line'

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -697,12 +697,12 @@ class Editor extends PropertyObject
       buffer\pair_match_backward(start_pos, matching, search_to)
 
     if match_pos and abs(match_pos - start_pos) > 1
-      buffer.markers\add {
+      buffer.markers\add {{
         name: 'brace_highlight',
         flair: 'brace_highlight',
         start_offset: match_pos,
         end_offset: match_pos + 1
-      }
+      }}
       @_brace_highlighted = true
 
   _update_position: =>

--- a/lib/howl/ui/highlight.moon
+++ b/lib/howl/ui/highlight.moon
@@ -22,12 +22,18 @@ setmetatable {
     flair.define_default name, definition
 
   apply: (name, buffer, pos, length) ->
-    buffer.markers\add {
-      name: 'highlight',
-      flair: name,
-      start_offset: pos,
-      end_offset: pos + length
-    }
+    ranges = pos
+    ranges = { {pos, length} } unless type(ranges) == 'table'
+    markers = {}
+    for range in *ranges
+      markers[#markers + 1] = {
+        name: 'highlight',
+        flair: name,
+        start_offset: range[1],
+        end_offset: range[1] + range[2]
+      }
+
+    buffer.markers\add markers
 
   remove_all: (name, buffer) ->
     buffer.markers\remove name: 'highlight', flair: name

--- a/lib/howl/ui/list_widget.moon
+++ b/lib/howl/ui/list_widget.moon
@@ -17,6 +17,11 @@ highlight.define_default 'list_selection', {
   outline_alpha: 100
 }
 
+highlight.define_default 'list_selection', {
+  type: highlight.UNDERLINE
+  text_color: '#000000'
+}
+
 reversed = (list) -> [item for item in *list[#list, 1, -1]]
 
 class ListWidget extends PropertyObject
@@ -109,9 +114,11 @@ class ListWidget extends PropertyObject
 
     segments = highlighter text
     if segments
+      ranges = {}
       for segment in *segments
-        p = start_pos + segment[1] - 1
-        @text_widget.buffer\style p, p + segment[2] - 1, 'list_highlight'
+        ranges[#ranges + 1] = { start_pos + segment[1] - 1, segment[2] }
+
+      highlight.apply 'list_highlight', @text_widget.buffer, ranges
 
   _write_status: =>
     return unless @has_status

--- a/lib/howl/ui/searcher.moon
+++ b/lib/howl/ui/searcher.moon
@@ -160,14 +160,16 @@ class Searcher
     -- scan the displayed lines and a few more for good measure
     start_boundary = buffer.lines[math.max(1, @editor.line_at_top - 5)].start_pos
     end_boundary = buffer.lines[math.min(#buffer.lines, @editor.line_at_bottom + 5)].end_pos
+    ranges = {}
 
     -- match at match_pos gets a different highlight than other matches
     for start_pos, end_pos in @_find_matches search, start_boundary, end_boundary
       if not ensure_word or @_is_word(start_pos, search)
         if start_pos != match_pos
-          highlight.apply 'search_secondary', buffer, start_pos, end_pos - start_pos + 1
+          ranges[#ranges + 1] = { start_pos, end_pos - start_pos + 1 }
 
     highlight.apply 'search', buffer, match_pos, search.ulen
+    highlight.apply 'search_secondary', buffer, ranges
 
   _find_matches: (search, start_boundary, end_boundary) =>
     match_start_pos = nil

--- a/spec/buffer_markers_spec.moon
+++ b/spec/buffer_markers_spec.moon
@@ -12,48 +12,48 @@ describe 'BufferMarkers', ->
     buffer = Buffer {}
     markers = buffer.markers
 
-  describe 'add(data)', ->
+  describe 'add(markers)', ->
     it 'raises an error if <.name> is missing', ->
-      assert.raises 'name', -> markers\add start_offset: 1, end_offset: 2
+      assert.raises 'name', -> markers\add { {start_offset: 1, end_offset: 2} }
 
     it 'raises an error if <.start_offset> is missing', ->
       buffer.text = '12'
-      assert.raises 'start_offset', -> markers\add name: 'test', end_offset: 2
+      assert.raises 'start_offset', -> markers\add { {name: 'test', end_offset: 2} }
 
     it 'raises an error if <.end_offset> is missing', ->
       buffer.text = '12'
-      assert.raises 'end_offset', -> markers\add name: 'test', start_offset: 2
+      assert.raises 'end_offset', -> markers\add { {name: 'test', start_offset: 2} }
 
     it 'raises an error if <.start_offset> is out of bounds', ->
       buffer.text = '12'
       assert.raises 'offset', ->
-        markers\add name: 'test', start_offset: 4, end_offset: 4
+        markers\add { {name: 'test', start_offset: 4, end_offset: 4} }
 
       assert.raises 'offset', ->
-        markers\add name: 'test', start_offset: 0, end_offset: 2
+        markers\add { {name: 'test', start_offset: 0, end_offset: 2} }
 
     it 'raises an error if <.end_offset> is out of bounds', ->
       buffer.text = '12'
       assert.raises 'offset', ->
-        markers\add name: 'test', start_offset: 1, end_offset: 4
+        markers\add { {name: 'test', start_offset: 1, end_offset: 4} }
 
       assert.raises 'offset', ->
-        markers\add name: 'test', start_offset: 1, end_offset: 0
+        markers\add { {name: 'test', start_offset: 1, end_offset: 0} }
 
     it 'adds the specified marker for the designated span', ->
       buffer.text = 'åäöx'
-      data = name: 'test', start_offset: 2, end_offset: 4
-      markers\add data
+      mks = { {name: 'test', start_offset: 2, end_offset: 4} }
+      markers\add mks
       assert.same {}, markers\at(1)
-      assert.same {data}, markers\at(2)
-      assert.same {data}, markers\at(3)
+      assert.same mks, markers\at(2)
+      assert.same mks, markers\at(3)
       assert.same {}, markers\at(4)
 
   describe 'for_range(start_offset, end_offset)', ->
     it 'returns all markers that intersects with the specified span', ->
       buffer.text = 'åäö€ᛖ'
-      markers\add name: 'test1', start_offset: 2, end_offset: 5
-      markers\add name: 'test2', start_offset: 4, end_offset: 6
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 5} }
+      markers\add { {name: 'test2', start_offset: 4, end_offset: 6} }
 
       assert.same {'test1'}, names(markers\for_range(1, 4))
       assert.same {'test1', 'test2'}, names(markers\for_range(1, 5))
@@ -65,8 +65,8 @@ describe 'BufferMarkers', ->
   describe 'remove(selector)', ->
     it 'removes all markers matching the selector', ->
       buffer.text = 'åäö€ᛖ'
-      markers\add name: 'test1', start_offset: 2, end_offset: 3, foo: 'bar'
-      markers\add name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob'
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 3, foo: 'bar'} }
+      markers\add { {name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob'} }
       markers\remove foo: 'frob'
       assert.same {'test1'}, names(markers\for_range(1, 7))
       markers\remove!
@@ -75,8 +75,8 @@ describe 'BufferMarkers', ->
   describe 'remove_for_range(start_offset, end_offset, selector)', ->
     it 'removes all markers within the range', ->
       buffer.text = 'åäö€ᛖ'
-      markers\add name: 'test1', start_offset: 2, end_offset: 3
-      markers\add name: 'test2', start_offset: 5, end_offset: 6
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 3} }
+      markers\add { {name: 'test2', start_offset: 5, end_offset: 6} }
 
       markers\remove_for_range 1, 4
       assert.same {}, markers\at(2)
@@ -87,8 +87,8 @@ describe 'BufferMarkers', ->
     describe 'when <selector> is specified', ->
       it 'only removes markers matching the selector', ->
         buffer.text = 'åäö€ᛖ'
-        markers\add name: 'test1', start_offset: 2, end_offset: 3, foo: 'bar'
-        markers\add name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob'
+        markers\add { {name: 'test1', start_offset: 2, end_offset: 3, foo: 'bar'} }
+        markers\add { {name: 'test2', start_offset: 5, end_offset: 6, foo: 'frob'} }
 
         markers\remove_for_range 1, 6, foo: 'frob'
         assert.same {'test1'}, names(markers\for_range(1, 7))
@@ -96,7 +96,7 @@ describe 'BufferMarkers', ->
   describe 'upon buffer modifications', ->
     it 'markers move with inserts', ->
       buffer.text = 'åäö€ᛖ'
-      markers\add name: 'test1', start_offset: 2, end_offset: 3
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 3} }
       buffer\insert '∀', 1
       assert.same {
         { name: 'test1', start_offset: 3, end_offset: 4 }
@@ -104,7 +104,7 @@ describe 'BufferMarkers', ->
 
     it 'markers expand with inserts', ->
       buffer.text = 'åäö€ᛖ'
-      markers\add name: 'test1', start_offset: 2, end_offset: 4
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 4} }
       buffer\insert '∀', 3
       assert.same {
         { name: 'test1', start_offset: 2, end_offset: 5 }
@@ -112,7 +112,7 @@ describe 'BufferMarkers', ->
 
     it 'markers move with deletes', ->
       buffer.text = 'åäö€ᛖ'
-      markers\add name: 'test1', start_offset: 3, end_offset: 5
+      markers\add { {name: 'test1', start_offset: 3, end_offset: 5} }
       buffer\delete 2, 2
       assert.same {
         { name: 'test1', start_offset: 2, end_offset: 4 }
@@ -120,7 +120,7 @@ describe 'BufferMarkers', ->
 
     it 'markers shrink with deletes', ->
       buffer.text = 'åäö€ᛖ'
-      markers\add name: 'test1', start_offset: 2, end_offset: 5
+      markers\add { {name: 'test1', start_offset: 2, end_offset: 5} }
       buffer\delete 3, 3
       assert.same {
         { name: 'test1', start_offset: 2, end_offset: 4 }

--- a/spec/ui/highlight_spec.moon
+++ b/spec/ui/highlight_spec.moon
@@ -17,7 +17,7 @@ describe 'highlight', ->
       highlight.define_default 'new_one', type: highlight.UNDERLINE, color: '#101010'
       assert.equal highlight.new_one.color, '#334455'
 
-  describe '.apply(name, buffer, pos, length)', ->
+  describe '.apply(name, buffer, <table-or-range>)', ->
     it 'sets a highlight marker for the buffer', ->
       buffer = Buffer {}
       buffer.text = 'hƏllo'
@@ -25,6 +25,16 @@ describe 'highlight', ->
       highlight.apply 'custom', buffer, 2, 2
       assert.same {
         { name: 'highlight', flair: 'custom', start_offset: 2, end_offset: 4 }
+      }, buffer.markers.all
+
+    it 'accepts a table ranges', ->
+      buffer = Buffer {}
+      buffer.text = '123456'
+      highlight.define 'custom', type: highlight.UNDERLINE, color: '#334455'
+      highlight.apply 'custom', buffer, { {2, 2}, {5, 1} }
+      assert.same {
+        { name: 'highlight', flair: 'custom', start_offset: 2, end_offset: 4 },
+        { name: 'highlight', flair: 'custom', start_offset: 5, end_offset: 6 }
       }, buffer.markers.all
 
   it '.at_pos(buffer, pos) returns a list of the active highlights at pos', ->

--- a/spec/ui/list_widget_spec.moon
+++ b/spec/ui/list_widget_spec.moon
@@ -41,28 +41,23 @@ describe 'ListWidget', ->
       list\update 'o'
       assert.equal 'one\n', buf.text
 
-    it 'styles matching parts of text with list_highlight', ->
+    it 'highlights matching parts of text with list_highlight', ->
       list.matcher = Matcher {'one', 'twö', 'three'}
       list\update 'ne'
       assert.equal 'one\n', buf.text
-      hstyle = style.at_pos(buf, 1)
-      assert.not_equal 'list_highlight', hstyle
-      hstyle = style.at_pos(buf, 2)
-      assert.equal 'list_highlight', hstyle
-      hstyle = style.at_pos(buf, 3)
-      assert.equal 'list_highlight', hstyle
+
+      assert.not_includes highlight.at_pos(buf, 1), 'list_highlight'
+      assert.includes highlight.at_pos(buf, 2), 'list_highlight'
+      assert.includes highlight.at_pos(buf, 3), 'list_highlight'
 
     it 'handles higlighting of multibyte chars', ->
       list.matcher = Matcher {'åne', 'twö'}
       list\update 'ån'
       assert.equal 'åne\n', buf.text
 
-      hstyle = style.at_pos(buf, 1)
-      assert.equal 'list_highlight', hstyle
-      hstyle = style.at_pos(buf, 2)
-      assert.equal 'list_highlight', hstyle
-      hstyle = style.at_pos(buf, 3)
-      assert.not_equal 'list_highlight', hstyle
+      assert.includes highlight.at_pos(buf, 1), 'list_highlight'
+      assert.includes highlight.at_pos(buf, 2), 'list_highlight'
+      assert.not_includes highlight.at_pos(buf, 3), 'list_highlight'
 
   context 'when `never_shrink:` is not provided', ->
     it 'shrinks the height while matching', ->


### PR DESCRIPTION
The twin to the previous optimization PR. This makes the adding of aullar markers, and in extension Howl highlights a multi-op affair, meaning we cut down on useless invalidations and refreshes.

Also included in this is changing the ListWidget to use highlights instead of styles for marking search hits (see commit message for a more elaborate discussion of the rationale).