### PR TITLE
Implement PEP 498 string interpolation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased (in master)
 
+- Added `buffer-grep-exact` and `buffer-grep-regex` commands similar to
+`buffer-grep` but using exact and regular expression matches, respectively.
+
 - Changed how Howl loads files specified on the command line. Previously files
 were loaded in different views, and now they're all loaded with one file being
 shown (issue #123).

--- a/bundles/python/misc/examples.py
+++ b/bundles/python/misc/examples.py
@@ -70,6 +70,16 @@ double "quotes" ok too!
 
 adjacent_strings_auto_concat = "hello " "world"
 same_as_above = "hello""world"
+raw_string = r'abc\d'
+
+simple_f_string = f'abc{de}fgh{ij}klm'
+conv_f_string = f'ab{cd!s}ef'
+complicated_triple_f_string = f'''abc{a+'!':a=+#0{abc},.{prec}b}def'''
+brace_f_string = f'{value:abc{f() + g()}}abc'
+spaced_f_string = f'{a + b}abc'
+f_string_spec = f'{v!r}'
+another_braced_f_string = f'{v:a4c{abc}}abc'
+f_string_with_bang = f'{v!=0}'
 
 if False:
   # Dictionaries

--- a/bundles/python/python_lexer.moon
+++ b/bundles/python/python_lexer.moon
@@ -1,6 +1,8 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
+pairs = pairs
+
 howl.aux.lpeg_lexer ->
   c = capture
 
@@ -83,11 +85,49 @@ howl.aux.lpeg_lexer ->
 
   decorator = c 'preproc', P'@' * name * ('.' * name)^0
 
-  P {
+  f_prefix = c 'special', any {
+    S'rR' * S'fF'
+    S'fF' * S'rR'
+    S'fF'
+  }
+
+  format_conv = c('operator', P'!') * c('special', S'sra')
+  format_number = any {
+    c 'number', integer
+    c('operator', P'{') * ((V'all' + space + P 1) - P'}')^0 * c('operator', P'}')
+  }
+  format_part = any {
+    format_number
+    c 'special', (P 1) - S'{}'
+  }
+  format_spec = c('operator', ':') * format_part^0
+
+  string_kinds =
+    sq_string: "'"
+    dq_string: '"'
+    tsq_string: "'''"
+    tdq_string: '"""'
+  interpolations = {}
+  f_strings = {}
+  for kind, quote in pairs string_kinds
+    interpolations["#{kind}_interpolation"] = sequence {
+      ((V'all' + space + P 1) - (S'}:' + format_conv))^0
+      format_conv^-1
+      format_spec^-1
+      c 'operator', '}'
+      V"#{kind}_chunk"
+    }
+    interpolations["#{kind}_chunk"] = sequence {
+      c 'string', scan_to P(quote) + #P'{', P'\\'
+      V"#{kind}_interpolation"^0
+    }
+    f_strings[#f_strings+1] = c('string', quote) * V"#{kind}_chunk"
+
+  rules = {
     'all'
 
     all: any {
-      string,
+      V'string',
       comment,
       number,
       operator,
@@ -100,4 +140,14 @@ howl.aux.lpeg_lexer ->
       identifier,
       decorator
     }
+
+    f_string: any f_strings
+
+    string: any {
+      f_prefix * V'f_string'
+      string
+    }
   }
+
+  rules[k] = v for k, v in pairs interpolations
+  P rules

--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -198,7 +198,7 @@ command.register
 
 command.register
   name: 'buffer-grep'
-  description: 'Matches certain buffer lines in realtime'
+  description: 'Shows buffer lines containing boundary and exact matches in real time'
   input: ->
     buffer = app.editor.buffer
     return interact.select_line
@@ -207,6 +207,41 @@ command.register
       lines: buffer.lines
   handler: (selection) ->
     app.editor.cursor\move_to line: selection.line.nr, column: selection.column
+
+command.register
+  name: 'buffer-grep-exact'
+  description: 'Shows buffer lines containing exact matches in real time'
+  input: ->
+    buffer = app.editor.buffer
+    return interact.select_line
+      title: "Buffer grep exact in #{buffer.title}"
+      editor: app.editor
+      lines: buffer.lines
+      find: (query, text) ->
+        start_pos, end_pos = text\ufind query, 1, true
+        if start_pos
+          return {{start_pos, end_pos - start_pos + 1}}
+  handler: (selection) ->
+    app.editor.cursor\move_to line: selection.line.nr, column:  selection.column
+
+command.register
+  name: 'buffer-grep-regex'
+  description: 'Shows buffer lines containing regular expression matches in real time'
+  input: ->
+    buffer = app.editor.buffer
+    return interact.select_line
+      title: "Buffer grep exact in #{buffer.title}"
+      editor: app.editor
+      lines: buffer.lines
+      find: (query, text) ->
+        ok, rex = pcall -> r(query)
+        return unless ok
+
+        start_pos, end_pos = rex\find text
+        if start_pos
+          return {{start_pos, end_pos - start_pos + 1}}
+  handler: (selection) ->
+    app.editor.cursor\move_to line: selection.line.nr, column:  selection.column
 
 command.register
   name: 'buffer-structure'

--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -205,6 +205,9 @@ command.register
       title: "Buffer grep in #{buffer.title}"
       editor: app.editor
       lines: buffer.lines
+      keymap:
+        ctrl_r: -> app.window.command_line\switch_to 'buffer-grep-regex'
+        ctrl_e: -> app.window.command_line\switch_to 'buffer-grep-exact'
   handler: (selection) ->
     app.editor.cursor\move_to line: selection.line.nr, column: selection.column
 
@@ -221,6 +224,9 @@ command.register
         start_pos, end_pos = text\ufind query, 1, true
         if start_pos
           return {{start_pos, end_pos - start_pos + 1}}
+      keymap:
+        ctrl_g: -> app.window.command_line\switch_to 'buffer-grep'
+        ctrl_r: -> app.window.command_line\switch_to 'buffer-grep-regex'
   handler: (selection) ->
     app.editor.cursor\move_to line: selection.line.nr, column:  selection.column
 
@@ -240,6 +246,9 @@ command.register
         start_pos, end_pos = rex\find text
         if start_pos
           return {{start_pos, end_pos - start_pos + 1}}
+      keymap:
+        ctrl_g: -> app.window.command_line\switch_to 'buffer-grep'
+        ctrl_e: -> app.window.command_line\switch_to 'buffer-grep-exact'
   handler: (selection) ->
     app.editor.cursor\move_to line: selection.line.nr, column:  selection.column
 

--- a/lib/howl/interactions/line_selection.moon
+++ b/lib/howl/interactions/line_selection.moon
@@ -56,16 +56,13 @@ line_match_highlighter = (editor, explain) ->
 
         highlight.apply 'search_secondary', buffer, ranges
 
-create_matcher = (find) ->
-  class CustomMatcher
-    new: (@line_items) =>
-
+create_matcher = (line_items, find) ->
+  mt = {
     __call: (query) =>
-      unless query
-        return moon.copy @line_items
-      return [item for item in *@line_items when find query, item[2].text]
-
-    explain: (query, text) -> find query, text
+      return moon.copy(line_items) unless query
+      return [item for item in *line_items when find query, item[2].text]
+  }
+  return setmetatable {explain: (query, text) -> find query, text}, mt
 
 interact.register
   name: 'select_line'
@@ -94,7 +91,7 @@ interact.register
 
     local matcher
     if opts.find
-      matcher = create_matcher(opts.find)(line_items)
+      matcher = create_matcher(line_items, opts.find)
     else
       matcher = Matcher line_items, preserve_order: true
     opts.matcher = matcher

--- a/lib/howl/ui/command_line.moon
+++ b/lib/howl/ui/command_line.moon
@@ -56,7 +56,7 @@ class CommandLine extends PropertyObject
           @current.state = 'running'
           @show!
           bindings.cancel_capture!
-          if @spillover
+          if @spillover and not @spillover.is_empty
             -- allow editor to resize for correct focussing behavior
             howl.timer.asap ->
               @write @spillover if not @spillover.is_empty
@@ -132,6 +132,11 @@ class CommandLine extends PropertyObject
     if not (@stack_depth > 0)
       error 'Cannot run_after_finish - no running activity'
     table.insert @next_run_queue, f
+
+  switch_to: (new_command) =>
+    captured_text = @text
+    @abort_all!
+    howl.command.run new_command .. ' ' .. captured_text
 
   _process_run_after_finish: =>
     while true

--- a/lib/howl/ui/list_widget.moon
+++ b/lib/howl/ui/list_widget.moon
@@ -110,7 +110,8 @@ class ListWidget extends PropertyObject
       return
 
     highlighter = self.highlighter or (text) ->
-      Matcher.explain @highlight_matches_for, text
+      explain = type(@matcher) == 'table' and @matcher.explain or Matcher.explain
+      explain @highlight_matches_for, text
 
     segments = highlighter text
     if segments

--- a/site/source/doc/manual/editing.md
+++ b/site/source/doc/manual/editing.md
@@ -86,15 +86,17 @@ The `up` and `down` keys jump between the matches for these commands as well.
 
 ## Buffer grep
 
-Buffer grep works as an alternative to the regular `buffer-search-forward` command for
-searching for something in the current buffer. It let's you grep all lines in
-the current buffer for a search string and displays all matching lines in
-real-time as you type:
+Buffer grep commands are an alternative to the regular `buffer-search-` commands
+for searching the current buffer. These commands search the entire buffer as you
+type and display all matching lines in real-time:
 
 ![Buffer grep](/images/doc/buffer-grep.png)
 
-This is decidedly less effective than doing a plain search, which can be a
-factor for large buffers.
+There are three buffer grep commands available for three types of searches:
+
+1. `buffer-grep` (bound to `ctrl_g`) shows exact and boundary matches.
+2. `buffer-grep-exact` shows exact matches only.
+3. `buffer-grep-regex` shows regular expression matches.
 
 ## Replacement
 

--- a/site/source/doc/manual/editing.md
+++ b/site/source/doc/manual/editing.md
@@ -98,6 +98,10 @@ There are three buffer grep commands available for three types of searches:
 2. `buffer-grep-exact` shows exact matches only.
 3. `buffer-grep-regex` shows regular expression matches.
 
+After invoking `buffer-grep` with `ctrl_g`, you can switch between the commands
+using `ctrl_e` for  `buffer-grep-exact`, `ctrl_r` for `buffer-grep-regex` and
+`ctrl_g` to switch back to `buffer-grep`.
+
 ## Replacement
 
 The `buffer-replace` and `buffer-replace-regex` commands provide a way to

--- a/spec/interactions/line_selection_spec.moon
+++ b/spec/interactions/line_selection_spec.moon
@@ -48,3 +48,13 @@ describe 'select_line', ->
       assert.same {'one', 'two'}, lines[2]
       assert.same {'one'}, lines[3]
       assert.same {'one', 'two', 'three'}, lines[4]
+
+    context 'when `find` function is provided', ->
+      it 'uses the find function to find matching lines', ->
+        find = (query, text) ->
+          return {{1,3}} if text == 'two'
+        local lines
+        within_activity (-> interact.select_line(:editor, lines: buffer.lines, :find)), ->
+          command_line\write 'abc'
+          lines = get_ui_list_widget_column 2
+        assert.same {'two'}, lines

--- a/spec/ui/command_line_spec.moon
+++ b/spec/ui/command_line_spec.moon
@@ -99,6 +99,19 @@ describe 'CommandLine', ->
             command_line\run_after_finish nextf
         assert.spy(nextf).was_called 1
 
+    describe '\\switch_to(new_command)', ->
+      it 'cancels current command and runs new command, preserving text', ->
+        command_run = howl.command.run
+        howl.command.run = spy.new ->
+        command_line\run
+          name: 'run-activity'
+          handler: ->
+            command_line.text = 'hello arg'
+            command_line\switch_to 'new-command'
+
+        assert.spy(howl.command.run).was_called_with 'new-command hello arg'
+        howl.command.run = command_run
+
     describe '.text', ->
       it 'cannot be set when no running activity', ->
         f = -> command_line.text = 'hello'


### PR DESCRIPTION
This implements [Python PEP 498 string interpolation](https://www.python.org/dev/peps/pep-0498/). [Again](https://github.com/howl-editor/howl/pull/117). The syntax is more complicated than it looks!