### PR TITLE
Os bindings

### DIFF
--- a/lib/howl/bindings.moon
+++ b/lib/howl/bindings.moon
@@ -4,7 +4,7 @@
 _G = _G
 import table, coroutine, pairs from _G
 import tostring, pcall, callable, type, print, setmetatable, typeof from _G
-import signal, command from howl
+import signal, command, sys from howl
 append = table.insert
 
 signal.register 'key-press',
@@ -70,16 +70,22 @@ substitute_keyname = (event) ->
 
 find_handlers = (event, source, translations, keymaps, ...) ->
   handlers = {}
+  empty = {}
+  os = sys.info.os
+
   for map in *keymaps
     continue unless map
-    source_map = map[source] or {}
+
+    source_map = map[source] or empty
     handler = nil
 
-    source_map_binding_for = source_map.binding_for
     map_binding_for = map.binding_for
+    source_map_binding_for = source_map.binding_for
+    os_map = map.for_os and map.for_os[os] or empty
+    os_source_map = os_map[source] or empty
 
     for t in *translations
-      handler = source_map[t] or map[t]
+      handler = os_source_map[t] or source_map[t] or os_map[t] or map[t]
       break if handler
 
       if source_map_binding_for or map_binding_for

--- a/lib/howl/bindings.moon
+++ b/lib/howl/bindings.moon
@@ -138,12 +138,14 @@ export translate_key = (event) ->
 
   translations = {}
   append translations, ctrl .. meta .. alt .. event.character if event.character
+  modifiers = ctrl .. meta .. shift .. alt
 
   if event.key_name and event.key_name != event.character
-    append translations, ctrl .. meta .. shift .. alt .. event.key_name
+    append translations, modifiers .. event.key_name
 
-  append translations, ctrl .. meta .. shift .. alt .. alternate if alternate
-  append translations, ctrl .. meta .. shift .. alt .. event.key_code
+  append translations, modifiers .. alternate if alternate
+  append translations, modifiers .. event.key_code
+
   translations
 
 export dispatch = (event, source, keymaps, ...) ->

--- a/lib/howl/bindings.moon
+++ b/lib/howl/bindings.moon
@@ -219,12 +219,17 @@ export keystrokes_for = (handler, source = nil) ->
 
   keystrokes
 
-export action_for = (translation, source='editor') ->
+export action_for = (tr, source='editor') ->
+  os = sys.info.os
+  empty = {}
+
   for i = #keymaps, 1, -1
     km = keymaps[i]
     continue unless km
-    source_km = km[source] or {}
-    handler = source_km[translation] or km[translation]
+    source_km = km[source] or empty
+    os_map = km.for_os and km.for_os[os] or empty
+    os_source_map = os_map[source] or empty
+    handler = os_source_map[tr] or os_map[tr] or source_km[tr] or km[tr]
     return handler if handler
   nil
 

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -1,10 +1,32 @@
 {
+  ------------------------------------------------------------------------------
+  -- Default bindings
+  ------------------------------------------------------------------------------
+
   editor: {
+    left:             'cursor-left'
+    right:            'cursor-right'
+    up:               'cursor-up'
+    down:             'cursor-down'
+    shift_left:       'cursor-left-extend'
+    shift_right:      'cursor-right-extend'
+    shift_up:         'cursor-up-extend'
+    shift_down:       'cursor-down-extend'
+
     tab:              'editor-smart-tab'
     shift_tab:        'editor-smart-back-tab'
     backspace:        'editor-delete-back'
     delete:           'editor-delete-forward'
     return:           'editor-newline'
+
+    page_up:          'cursor-page-up'
+    shift_page_up:    'cursor-page-up-extend'
+    page_down:        'cursor-page-down'
+    shift_page_down:  'cursor-page-down-extend'
+    end:              'cursor-line-end'
+    shift_end:        'cursor-line-end-extend'
+    home:             'cursor-home'
+    shift_home:       'cursor-home-extend'
 
     ctrl_b:           'switch-buffer'
     ctrl_c:           'editor-copy'
@@ -39,15 +61,6 @@
     alt_s:            'buffer-structure'
     alt_q:            'editor-reflow-paragraph'
 
-    left:             'cursor-left'
-    right:            'cursor-right'
-    up:               'cursor-up'
-    down:             'cursor-down'
-    shift_left:       'cursor-left-extend'
-    shift_right:      'cursor-right-extend'
-    shift_up:         'cursor-up-extend'
-    shift_down:       'cursor-down-extend'
-
     ctrl_left:        'cursor-word-left'
     ctrl_right:       'cursor-word-right'
     ctrl_up:          'editor-scroll-up'
@@ -61,14 +74,6 @@
     ctrl_shift_d:     'vc-diff-file'
     ctrl_alt_d:       'vc-diff'
 
-    page_up:          'cursor-page-up'
-    shift_page_up:    'cursor-page-up-extend'
-    page_down:        'cursor-page-down'
-    shift_page_down:  'cursor-page-down-extend'
-    end:              'cursor-line-end'
-    shift_end:        'cursor-line-end-extend'
-    home:             'cursor-home'
-    shift_home:       'cursor-home-extend'
   }
 
   ctrl_o:           'open'
@@ -88,4 +93,68 @@
   shift_alt_right: 'view-right-or-create'
   shift_alt_up:    'view-up-or-create'
   shift_alt_down:  'view-down-or-create'
+
+  ------------------------------------------------------------------------------
+  -- OS specific bindings
+  ------------------------------------------------------------------------------
+
+  for_os:
+
+    osx:
+      editor: {
+        meta_shift_a:     'editor-select-all'
+        meta_b:           'switch-buffer'
+        meta_c:           'editor-copy'
+        meta_d:           'editor-duplicate-current'
+        meta_f:           'buffer-search-forward'
+        meta_r:           'buffer-search-backward'
+        meta_comma:       'buffer-search-word-backward'
+        meta_period:      'buffer-search-word-forward'
+        meta_g:           'buffer-grep'
+        meta_i:           'editor-indent'
+        meta_k:           'editor-delete-to-end-of-line'
+        meta_shift_i:     'editor-indent-all'
+        meta_h:           'buffer-replace'
+        meta_n:           'new-buffer'
+        meta_s:           'save'
+        meta_shift_s:     'save-as'
+        meta_v:           'editor-paste'
+        meta_shift_v:     'editor-paste..'
+        meta_x:           'editor-cut'
+        meta_z:           'editor-undo'
+        meta_Z:           'editor-redo'
+        meta_space:       'editor-complete'
+        meta_slash:       'editor-toggle-comment'
+        meta_insert:      'editor-copy'
+
+        ctrl_tab:         'view-right-wraparound'
+        ctrl_shift_tab:   'view-left-wraparound'
+        ctrl_meta_d:      'show-doc-at-cursor'
+
+        ctrl_shift_s:     'buffer-structure'
+        ctrl_q:           'editor-reflow-paragraph'
+
+        meta_up:          'editor-scroll-up'
+        meta_down:        'editor-scroll-down'
+
+        -- needs option key
+        -- meta_shift_left:  'cursor-word-left-extend'
+        -- meta_shift_right: 'cursor-word-right-extend'
+
+        ctrl_shift_d:     'vc-diff-file'
+        ctrl_meta_d:      'vc-diff'
+      }
+
+      meta_o:           'open'
+      meta_p:           'project-open'
+      meta_q:           'quit'
+      meta_shift_r:     'project-exec'
+      meta_shift_b:     'project-build'
+
+      meta_w:           'view-close'
+      'meta_-':         'zoom-out'
+      'meta_+':         'zoom-in'
+
+      ctrl_meta_f:      'window-toggle-fullscreen'
+      ctrl_meta_x:      'run'
 }

--- a/lib/howl/sys.moon
+++ b/lib/howl/sys.moon
@@ -24,8 +24,10 @@ find_executable = (name) ->
     if exe.exists and not exe.is_directory
       return exe.path
 
-
 {
   :env,
   :find_executable
+  info: {
+    os: jit.os\lower!
+  }
 }

--- a/spec/bindings_spec.moon
+++ b/spec/bindings_spec.moon
@@ -55,11 +55,11 @@ describe 'bindings', ->
         assert.same tr, { '123' }
 
     context 'with modifiers', ->
-      it 'prepends a modifier string representation to all translations for ctrl and alt', ->
+      it 'prepends a modifier string representation to all translations for ctrl, meta and alt', ->
         tr = bindings.translate_key
           character: 'A', key_name: 'a', key_code: 123,
-          control: true, alt: true
-        mods = 'ctrl_alt_'
+          control: true, alt: true, meta: true
+        mods = 'ctrl_meta_alt_'
         assert.same tr, { mods .. 'A', mods .. 'a', mods .. '123' }
 
       it 'emits the shift modifier if the character is known', ->

--- a/spec/bindings_spec.moon
+++ b/spec/bindings_spec.moon
@@ -369,5 +369,22 @@ describe 'bindings', ->
       bindings.push ctrl_x: 'my-new-command'
       assert.equals 'my-new-command', bindings.action_for 'ctrl_x'
 
+    it 'prefers source specific bindings over generic ones', ->
+      bindings.push {
+        ctrl_x: 'my-old-command'
+        my_source:
+          ctrl_x: 'my-source-command'
+      }
+      assert.equals 'my-source-command', bindings.action_for('ctrl_x', 'my_source')
+
+    it 'prefers OS specific bindings over generic ones', ->
+      bindings.push {
+        ctrl_x: 'my-old-command'
+        for_os:
+          [sys.info.os]:
+            ctrl_x: 'my-os-command'
+      }
+      assert.equals 'my-os-command', bindings.action_for 'ctrl_x'
+
     it 'returns nil if no command was found', ->
       assert.is_nil bindings.action_for 'ctrl_x'

--- a/spec/sys_spec.moon
+++ b/spec/sys_spec.moon
@@ -1,26 +1,31 @@
 sys = howl.sys
 
-describe 'env', ->
-  env = sys.env
+describe 'sys', ->
+  describe '.env', ->
+    env = sys.env
 
-  it 'allows reading environment variables using plain indexing', ->
-    assert.equals 'string', type env.HOME
-    assert.equals 'string', type env['HOME']
-    assert.equals os.getenv('HOME'), env.HOME
+    it 'allows reading environment variables using plain indexing', ->
+      assert.equals 'string', type env.HOME
+      assert.equals 'string', type env['HOME']
+      assert.equals os.getenv('HOME'), env.HOME
 
-  it 'allows setting variables via assignment', ->
-    env.MY_VAR = 'myval'
-    assert.equals 'myval', env.MY_VAR
-    assert.equals 'myval', os.getenv('MY_VAR')
+    it 'allows setting variables via assignment', ->
+      env.MY_VAR = 'myval'
+      assert.equals 'myval', env.MY_VAR
+      assert.equals 'myval', os.getenv('MY_VAR')
 
-  it 'allows unsetting variables using a nil assignment', ->
-    env.MY_VAR = 'myval'
-    assert.equals 'myval', os.getenv('MY_VAR')
-    env.MY_VAR = nil
-    assert.is_nil env.MY_VAR
-    assert.is_nil os.getenv('MY_VAR')
+    it 'allows unsetting variables using a nil assignment', ->
+      env.MY_VAR = 'myval'
+      assert.equals 'myval', os.getenv('MY_VAR')
+      env.MY_VAR = nil
+      assert.is_nil env.MY_VAR
+      assert.is_nil os.getenv('MY_VAR')
 
-  it 'allows iterating over the env using pairs', ->
-    env.MY_VAR = 'yowser!'
-    as_table = {k,v for k,v in pairs env}
-    assert.equals 'yowser!', as_table.MY_VAR
+    it 'allows iterating over the env using pairs', ->
+      env.MY_VAR = 'yowser!'
+      as_table = {k,v for k,v in pairs env}
+      assert.equals 'yowser!', as_table.MY_VAR
+
+  describe '.info', ->
+    it '.os is the lower case OS name', ->
+      assert.equals jit.os\lower!, sys.info.os


### PR DESCRIPTION
This adds support for OS specific bindings, by allowing for an optional `for_os` sub table in a key map. Included is a crude, incomplete and most likely incorrect set of base bindings for OS X.