### PR TITLE
Memory handling

### DIFF
--- a/.agignore
+++ b/.agignore
@@ -1,3 +1,4 @@
 site/source/versions
 site/**/*.html
 site/**/*.erb
+src/deps/

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -107,9 +107,14 @@ Buffer = {
       set: (text) =>
         old_text = @text_buffer and @tostring!
         size = #text
-        @text_buffer = GapBuffer 'char', size, initial: text
         -- +1 on styling size to account for dangling virtual line
-        @styling = Styling size + 1, @_style_listener
+        if @text_buffer
+          @text_buffer\set text, size
+          @styling\reset size + 1
+        else
+          @text_buffer = GapBuffer 'char', size, initial: text
+          @styling = Styling size + 1, @_style_listener
+
         @markers\remove!
         @_last_scanned_line = 0
         @_lines = {}

--- a/lib/aullar/cursor.moon
+++ b/lib/aullar/cursor.moon
@@ -145,6 +145,9 @@ Cursor = {
     _navigate_visual: => @view.config.view_line_wrap_navigation == 'visual'
   }
 
+  destroy: =>
+    @_disable_blink!
+
   ensure_in_view: =>
     return if @in_view
     new_line = if @line < @view.first_visible_line
@@ -388,7 +391,11 @@ Cursor = {
     flair.draw @_flair, display_line, start_offset, end_offset, x, base_y, cr
 
   _blink: =>
-    return false if not @active
+    if not @active
+      if @_blink_cb_handle
+        callbacks.unregister @_blink_cb_handle
+      return false
+
     if @_force_show
       @_force_show = false
       return true
@@ -410,10 +417,9 @@ Cursor = {
 
   _disable_blink: =>
     if @_blink_cb_handle
-      callbacks.unregister @_blink_cb_handle
+      if callbacks.unregister @_blink_cb_handle
+        C.g_source_remove @blink_cb_id
       @_blink_cb_handle = nil
-
-    -- todo unregister source? will be auto-cancelled by callbacks module though
 
   _refresh_current_line: =>
     cur_line = @buffer_line

--- a/lib/aullar/cursor.moon
+++ b/lib/aullar/cursor.moon
@@ -406,7 +406,7 @@ Cursor = {
 
     @_blink_cb_handle = callbacks.register self\_blink, "cursor-blink"
     @blink_cb_id = C.g_timeout_add_full C.G_PRIORITY_LOW, @blink_interval, timer_callback, cast_arg(@_blink_cb_handle.id), nil
-    callbacks.unref_handle @_blink_cb_handle
+    @_cb_handler = callbacks.unref_handle @_blink_cb_handle
 
   _disable_blink: =>
     if @_blink_cb_handle

--- a/lib/aullar/cursor.moon
+++ b/lib/aullar/cursor.moon
@@ -404,8 +404,9 @@ Cursor = {
     return if @_blink_cb_handle
     jit.off true, true
 
-    @_blink_cb_handle = callbacks.register self._blink, "cursor-blink", @
+    @_blink_cb_handle = callbacks.register self\_blink, "cursor-blink"
     @blink_cb_id = C.g_timeout_add_full C.G_PRIORITY_LOW, @blink_interval, timer_callback, cast_arg(@_blink_cb_handle.id), nil
+    callbacks.unref_handle @_blink_cb_handle
 
   _disable_blink: =>
     if @_blink_cb_handle

--- a/lib/aullar/gap_buffer.moon
+++ b/lib/aullar/gap_buffer.moon
@@ -20,7 +20,7 @@ define_class {
     @type_size = ffi.sizeof type
     @arr_ptr = ffi.typeof "const #{type} *"
     @new_arr = (size) ->
-      ffi_gc(ffi_cast("#{@type} *", C.calloc(size, @type_size)), C.free)
+      ffi_gc(ffi_cast("#{@type} *", C.g_malloc0(size * @type_size)), C.g_free)
 
     @set opts.initial, size
 

--- a/lib/aullar/gap_buffer.moon
+++ b/lib/aullar/gap_buffer.moon
@@ -167,8 +167,14 @@ define_class {
 
   set: (data, size = #data) =>
     arr_size = size + @default_gap_size
-    @array = self.new_arr(arr_size + 1) -- + 1 = one final zero
-    @array[arr_size] = 0 -- which we set here
+    if @array and @size + @gap_size >= arr_size
+      arr_size = @size + @gap_size
+      ffi_fill @array, size * @type_size
+    else
+      -- allocate new array
+      @array = self.new_arr(arr_size + 1) -- + 1 = with one final zero
+      @array[arr_size] = 0 -- which we set here
+
     if data
       ffi_copy @array, data, size * @type_size
     @size = size

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -907,3 +907,25 @@ describe 'Buffer', ->
         end_line: 2,
         invalidated: false
       }
+
+  context 'resource management', ->
+    it 'memory is released properly', ->
+      -- references should be gone
+      b = Buffer 'foobar'
+      l = on_styled: spy.new -> nil
+      b\add_listener l
+      buffers = setmetatable { b }, __mode: 'v'
+      b = nil
+      collect_memory!
+      assert.is_nil buffers[1]
+
+      -- and memory should be back to normal
+      before = collectgarbage('count')
+      for i = 1, 50
+        Buffer 'collect me!'
+
+      collect_memory!
+      after = collectgarbage('count')
+      diff = after - before
+      print "diff: #{diff}"
+      assert.is_true (after - before) < 2

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -926,6 +926,4 @@ describe 'Buffer', ->
 
       collect_memory!
       after = collectgarbage('count')
-      diff = after - before
-      print "diff: #{diff}"
       assert.is_true (after - before) < 2

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -909,8 +909,8 @@ describe 'Buffer', ->
       }
 
   context 'resource management', ->
-    it 'memory is released properly', ->
-      -- references should be gone
+
+    it 'buffers are collected properly', ->
       b = Buffer 'foobar'
       l = on_styled: spy.new -> nil
       b\add_listener l

--- a/lib/aullar/spec/gap_buffer_spec.moon
+++ b/lib/aullar/spec/gap_buffer_spec.moon
@@ -40,6 +40,38 @@ describe 'GapBuffer', ->
       b\set 'second'
       assert.equals 'second', get_text(b)
 
+    it 're-uses and resets the same memory if possible', ->
+      b = buffer '12345'
+      arr = b.array
+      gap_size = b.gap_size
+      b\set '123'
+      assert.equals arr, b.array
+      assert.equals gap_size + 2, b.gap_size
+      -- two previously occupied positions should be zeroed
+      assert.equals 0, arr[3]
+      assert.equals 0, arr[4]
+
+      -- setting with same size should re-use
+      b\set '12345'
+      assert.equals arr, b.array
+
+      -- setting with greater size should realloc
+      b\set '123456'
+      assert.not_equals arr, b.array
+
+    describe 'when <data> is not provided', ->
+      it 'provides zeroed memory', ->
+        b = buffer ''
+        b\set nil, 2
+        assert.equals 0, b.array[0]
+        assert.equals 0, b.array[1]
+
+      it 'resets previous data when the memory is re-used', ->
+        b = buffer '12345'
+        b\set nil, 2
+        assert.equals 0, b.array[0]
+        assert.equals 0, b.array[1]
+
   describe 'fill(start_offset, end_offset, value)', ->
     it 'fills the specified range with <value>', ->
       b = buffer '0123456789'

--- a/lib/aullar/spec/view_spec.moon
+++ b/lib/aullar/spec/view_spec.moon
@@ -208,7 +208,7 @@ describe 'View', ->
       assert.is_nil views[1]
 
     it 'does not leave lingering memory', ->
-      assert_memory_stays_within 1, ->
+      assert_memory_stays_within '20Kb', ->
         for i = 1, 30
           v = View!
           v\destroy!

--- a/lib/aullar/spec/view_spec.moon
+++ b/lib/aullar/spec/view_spec.moon
@@ -14,6 +14,7 @@ describe 'View', ->
     buffer = Buffer ''
     view = View buffer
     view.config.view_line_padding = 0
+    view.margin = 0
     cursor = view.cursor
     selection = view.selection
     window = Gtk.OffscreenWindow default_width: 800, default_height: 640
@@ -198,20 +199,16 @@ describe 'View', ->
 
   context 'resource management', ->
 
-    it 'memory is released properly', ->
-      -- views themselves should be collected
+    it 'references are collected properly', ->
       v = View!
       views = setmetatable { v }, __mode: 'v'
+      v\destroy!
       v = nil
       collect_memory!
       assert.is_nil views[1]
 
-      -- and memory should be back to "normalish" levels
-      before = collectgarbage('count')
-      for i = 1, 30
-        View!
-
-      collect_memory!
-      after = collectgarbage('count')
-      assert.is_true (after - before) < 100
-
+    it 'does not leave lingering memory', ->
+      assert_memory_stays_within 1, ->
+        for i = 1, 30
+          v = View!
+          v\destroy!

--- a/lib/aullar/spec/view_spec.moon
+++ b/lib/aullar/spec/view_spec.moon
@@ -195,3 +195,23 @@ describe 'View', ->
       assert.equals 2, cursor.pos
       buffer\redo!
       assert.equals 4, cursor.pos
+
+  context 'resource management', ->
+
+    it 'memory is released properly', ->
+      -- views themselves should be collected
+      v = View!
+      views = setmetatable { v }, __mode: 'v'
+      v = nil
+      collect_memory!
+      assert.is_nil views[1]
+
+      -- and memory should be back to "normalish" levels
+      before = collectgarbage('count')
+      for i = 1, 30
+        View!
+
+      collect_memory!
+      after = collectgarbage('count')
+      assert.is_true (after - before) < 100
+

--- a/lib/aullar/spec/view_spec.moon
+++ b/lib/aullar/spec/view_spec.moon
@@ -208,7 +208,6 @@ describe 'View', ->
       assert.is_nil views[1]
 
     it 'does not leave lingering memory', ->
-      assert_memory_stays_within '20Kb', ->
-        for i = 1, 30
-          v = View!
-          v\destroy!
+      assert_memory_stays_within '20Kb', 30, ->
+        v = View!
+        v\destroy!

--- a/lib/aullar/styling.moon
+++ b/lib/aullar/styling.moon
@@ -26,6 +26,10 @@ define_class {
     @style_buffer = GapBuffer 'uint16_t', size
     @last_pos_styled = 0
 
+  reset: (size) =>
+    @style_buffer\set nil, size
+    @last_pos_styled = 0
+
   sub: (styling, start_offset, end_offset) ->
     styles = {}
 

--- a/lib/aullar/util.moon
+++ b/lib/aullar/util.moon
@@ -1,3 +1,6 @@
+-- Copyright 2014-2015 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
 {
   define_class: (base, meta = {}) ->
     props = base.properties or {}

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -558,6 +558,7 @@ View = {
   _on_destroy: =>
     @listener = nil
     @selection = nil
+    @cursor\destroy!
     @cursor = nil
     @config\detach!
     @_buffer\remove_listener(@_buffer_listener) if @_buffer

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -45,7 +45,7 @@ class Buffer extends PropertyObject
     @read_only = false
     @_len = nil
     @_eol = '\n'
-    @_views = {}
+    @viewers = 0
     @_modified = false
 
     @_buffer\add_listener
@@ -123,10 +123,10 @@ class Buffer extends PropertyObject
 
       @_eol = eol
 
-  @property showing: get: => #@_views > 0
+  @property showing: get: => @viewers > 0
 
   @property last_shown:
-    get: => #@views > 0 and os.time! or @_last_shown
+    get: => @viewers > 0 and os.time! or @_last_shown
     set: (timestamp) => @_last_shown = timestamp
 
   @property multibyte: get: =>
@@ -284,14 +284,11 @@ class Buffer extends PropertyObject
       b_end_pos = @byte_offset end_pos
       @_buffer\ensure_styled_to pos: b_end_pos
 
-  add_view_ref: (view) =>
-    append @_views, view
+  add_view_ref: =>
+    @viewers += 1
 
   remove_view_ref: (view) =>
-    @_views = [v for v in *@_views when v != view and v != nil]
-
-  @property views: get: =>
-    [view for _, view in pairs @_views when view != nil]
+    @viewers -= 1
 
   _ensure_writable: =>
     if @read_only

--- a/lib/howl/commands/ui_commands.moon
+++ b/lib/howl/commands/ui_commands.moon
@@ -79,12 +79,12 @@ command.register
       log.warn "No other view found"
 
 for cmd in *{
-  { 'left', 'left_of', 'Goes to the left view, creating it if necessary' }
-  { 'right', 'right_of', 'Goes to the right view, creating it if necessary' }
-  { 'up', 'above', 'Goes to the view above, creating it if necessary' }
-  { 'down', 'below', 'Goes to the view below, creating it if necessary' }
+  { 'left', 'left_of' }
+  { 'right', 'right_of' }
+  { 'up', 'above' }
+  { 'down', 'below' }
 }
-  { direction, placement, description } = cmd
+  { direction, placement } = cmd
   human_placement = placement\gsub '_', ' '
 
   command.register

--- a/lib/howl/dispatch.moon
+++ b/lib/howl/dispatch.moon
@@ -9,6 +9,7 @@ _resume = (handle, ...) ->
   parking = parked[handle]
   error "Unknown handle #{handle}", 3 unless parking
   ret = if parking.co
+    parked[handle] = nil
     pack coroutine.resume parking.co, ...
   else
     parking.resumer = coroutine.running!
@@ -16,7 +17,6 @@ _resume = (handle, ...) ->
     coroutine.yield!
     { true }
 
-  parked[handle] = nil
   ret
 
 {
@@ -42,6 +42,7 @@ _resume = (handle, ...) ->
     local ret
 
     if parking.resumer
+      parked[handle] = nil
       coroutine.resume parking.resumer
       ret = parking.pending
     else

--- a/lib/howl/init.lua
+++ b/lib/howl/init.lua
@@ -128,6 +128,11 @@ local function main(args)
   if args.compile then
     compile(args)
   else
+    -- set up the the GC to be more aggressive, we have a lot
+    -- of cdata that needs to be collected
+    collectgarbage('setstepmul', 400)
+    collectgarbage('setpause', 99)
+
     local callbacks = require 'ljglibs.callbacks'
     callbacks.configure({
       dispatch_in_coroutine = true,

--- a/lib/howl/interactions/file_selection.moon
+++ b/lib/howl/interactions/file_selection.moon
@@ -5,7 +5,7 @@ glib = require 'ljglibs.glib'
 
 import app, clipboard, config, interact, log, Project from howl
 import File from howl.io
-import preview from howl.interactions.util
+import Preview from howl.interactions.util
 import icon, markup, style, ListWidget from howl.ui
 import file_matcher, subtree_matcher, subtree_reader, get_dir_and_leftover from howl.util.paths
 
@@ -83,10 +83,11 @@ class FileSelector
 
   _preview: (selection) =>
     return unless config.preview_files
+    @preview or= Preview!
 
     file = selection.file
     if file.exists
-      app.editor\preview preview.get_preview_buffer file
+      app.editor\preview @preview\get_buffer file
     else
       app.editor\cancel_preview!
 

--- a/lib/howl/interactions/location_selection.moon
+++ b/lib/howl/interactions/location_selection.moon
@@ -2,7 +2,7 @@
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 import app, interact, mode, Buffer from howl
-import preview from howl.interactions.util
+import Preview from howl.interactions.util
 import highlight from howl.ui
 import Matcher from howl.util
 
@@ -16,9 +16,10 @@ interact.register
 
     if howl.config.preview_files or opts.force_preview
       on_change = opts.on_change
+      preview = Preview!
       opts.on_change = (selection, text, items) ->
         if selection
-          buffer = selection.buffer or preview.get_preview_buffer selection.file
+          buffer = selection.buffer or preview\get_buffer selection.file
           editor\preview buffer
           if selection.line_nr
             editor.line_at_center = selection.line_nr

--- a/lib/howl/interactions/util/preview.moon
+++ b/lib/howl/interactions/util/preview.moon
@@ -19,7 +19,7 @@ get_preview_buffer = (file) ->
 
   buffer_mode = nil
   title = file.basename
-  ok, text = pcall -> file\read 8192
+  ok, text = pcall -> file\read(8192) or ''
 
   if ok
     size = file.size

--- a/lib/howl/interactions/util/preview.moon
+++ b/lib/howl/interactions/util/preview.moon
@@ -1,43 +1,44 @@
+-- Copyright 2014-2015 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
 import app, Buffer, mode from howl
 
-get_preview_buffer = (file) ->
-  for buffer in *app.buffers
-    return buffer if buffer.file == file
+new_buffer = (title, text, mode = {}) ->
+  buffer = Buffer mode
+  buffer.title = title
+  buffer.text = text
+  buffer.read_only = true
+  buffer
 
+get_preview_buffer = (file) ->
   if file.is_directory
-    buffer = Buffer {}
-    buffer.title = 'Directory: '..file.basename
-    buffer.text = file.path
-    buffer.read_only = true
-    return buffer
+    return new_buffer "Directory: #{file.basename}", file.path
 
   unless file.is_regular
-    buffer = Buffer {}
-    buffer.title = 'No preview: '..file.basename
-    buffer.text = "Preview not available for #{file.type} file."
-    buffer.read_only = true
-    return buffer
+    return new_buffer "No preview: #{file.basename}", "Preview not available for #{file.type} file."
 
-  buffer = Buffer mode.for_file file
+  buffer_mode = nil
   title = file.basename
-  local contents
-  ok, result = pcall ->
-    contents = file\read 8192
+  ok, text = pcall -> file\read 8192
 
   if ok
     size = file.size
-    title ..= ' (~'..tostring(math.floor(size / 1024))..'KB)'
-    if size == 0 or contents.is_valid_utf8
-      buffer.title = "Preview: #{title}"
-      buffer.text = contents or ''
+    title = "#{title} (~#{math.floor(size / 1024)}KB)"
+    if size == 0 or text.is_valid_utf8
+      title = "Preview: #{title}"
+      buffer_mode = mode.for_file file
     else
-      buffer.title = "No Preview: #{title}"
-      buffer.text = 'Preview not available.'
+      title = "No Preview: #{title}"
+      text = 'Preview not available.'
   else
-    buffer.title = "No Preview: #{title}"
-    buffer.text = result
+    title = "No Preview: #{title}"
 
-  buffer.read_only = true
-  return buffer
+  new_buffer title, text, buffer_mode
 
-return { :get_preview_buffer }
+->
+  open_buffers = { b.file.path, b for b in *app.buffers when b.file }
+  {
+    get_buffer: (file) =>
+      open_buffer = open_buffers[file.path]
+      open_buffer or get_preview_buffer(file)
+  }

--- a/lib/howl/io/input_stream.moon
+++ b/lib/howl/io/input_stream.moon
@@ -38,6 +38,7 @@ class InputStream extends PropertyObject
     table.concat contents
 
   close: =>
+    return if @stream.is_closed
     handle = dispatch.park 'input-stream-close'
 
     @stream\close_async (status, ret, err_code) ->

--- a/lib/howl/io/output_stream.moon
+++ b/lib/howl/io/output_stream.moon
@@ -24,6 +24,7 @@ class OutputStream extends PropertyObject
     dispatch.wait handle
 
   close: =>
+    return if @stream.is_closed
     handle = dispatch.park 'output-stream-close'
 
     @stream\close_async (status, ret, err_code) ->

--- a/lib/howl/io/process.moon
+++ b/lib/howl/io/process.moon
@@ -152,7 +152,6 @@ class Process
   _handle_finish: (status) =>
     callbacks.unregister @_exit_handle
     @@running[@pid] = nil
-
     @_exit_handle = nil
     @exited = true
     @successful = false

--- a/lib/howl/timer.moon
+++ b/lib/howl/timer.moon
@@ -12,13 +12,27 @@ timer_callback = ffi.cast 'GSourceFunc', callbacks.bool1
 jit.off true, true
 
 asap = (f, ...) ->
-  handle = callbacks.register f, 'timer-asap', ...
-  C.g_idle_add_full C.G_PRIORITY_LOW, timer_callback, cast_arg(handle.id), nil
+  local handle, tag
+
+  handler = (...) ->
+    callbacks.unregister handle
+    C.g_source_remove tag
+    f ...
+
+  handle = callbacks.register handler, 'timer-asap', ...
+  tag = C.g_idle_add_full C.G_PRIORITY_LOW, timer_callback, cast_arg(handle.id), nil
 
 after = (seconds, f, ...) ->
+  local handle, tag
+
+  handler = (...) ->
+    callbacks.unregister handle
+    C.g_source_remove tag
+    f ...
+
   handle = callbacks.register f, "timer-after-#{seconds}", ...
   interval = seconds * 1000
-  C.g_timeout_add_full C.G_PRIORITY_LOW, interval, timer_callback, cast_arg(handle.id), nil
+  tag = C.g_timeout_add_full C.G_PRIORITY_LOW, interval, timer_callback, cast_arg(handle.id), nil
 
 {
   :asap

--- a/lib/howl/ui/command_line.moon
+++ b/lib/howl/ui/command_line.moon
@@ -471,7 +471,8 @@ class CommandLine extends PropertyObject
 
   remove_widget: (name) =>
     widget = @_widgets[name]
-    @box\remove widget\to_gobject! if widget
+    return unless widget
+    widget\to_gobject!\destroy!
     @_widgets[name] = nil
 
   get_widget: (name) => @_widgets[name]

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -122,7 +122,7 @@ class Editor extends PropertyObject
 
       on_destroy: gobject_signal.unref_handle @bin\on_destroy ->
         theme.unregister_background_widget @view\to_gobject!
-        @buffer\remove_view_ref @view
+        @buffer\remove_view_ref!
         @buffer.last_shown = os.time! unless @_is_previewing
         signal.emit 'editor-destroyed', editor: self
     }
@@ -562,7 +562,7 @@ class Editor extends PropertyObject
     @view.buffer = buffer._buffer
 
     @_set_config_settings!
-    buffer\add_view_ref @view
+    buffer\add_view_ref!
 
     if buffer.properties.line_at_top
       @line_at_top = buffer.properties.line_at_top

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -495,13 +495,21 @@ class Editor extends PropertyObject
 
   remove_popup: =>
     if @popup
-      @popup.window\close!
+      if @popup.options.keep_alive
+        @popup.window\close!
+      else
+        @popup.window\destroy!
+
       @popup = nil
 
   complete: =>
     @completion_popup\complete!
     if not @completion_popup.empty
-      @show_popup @completion_popup, position: @completion_popup.position, persistent: true
+      @show_popup @completion_popup, {
+        position: @completion_popup.position,
+        persistent: true,
+        keep_alive: true
+      }
 
   undo: => @buffer\undo!
   redo: => @buffer\redo!

--- a/lib/howl/ui/popup.moon
+++ b/lib/howl/ui/popup.moon
@@ -26,6 +26,7 @@ class Popup extends PropertyObject
   show: (widget, options = position: 'center') =>
     error('Missing argument #1: widget', 2) if not widget
     @window.transient_for = widget.toplevel
+    @window.destroy_with_parent = true
     @window\realize!
     @widget = widget
     @showing = true
@@ -42,6 +43,9 @@ class Popup extends PropertyObject
     @window\hide!
     @showing = false
     @widget = nil
+
+  destroy: =>
+    @window\destroy!
 
   move_to: (x, y) =>
     error('Attempt to move a closed popup', 2) if not @showing

--- a/lib/howl/ui/text_widget.moon
+++ b/lib/howl/ui/text_widget.moon
@@ -22,8 +22,8 @@ class TextWidget extends PropertyObject
       .view_line_padding = config.line_padding
       .view_show_h_scrollbar = false
 
-    @cursor = Cursor self, Selection @view
     @selection = Selection @view
+    @cursor = Cursor self, @selection
     @view_gobject = @view\to_gobject!
 
     padding_box = Gtk.Alignment {

--- a/lib/ljglibs/callbacks.moon
+++ b/lib/ljglibs/callbacks.moon
@@ -19,8 +19,10 @@ cb_cast = (cb_type, handler) -> ffi_cast('GCallback', ffi_cast(cb_type, handler)
 
 unregister = (handle) ->
   error "callbacks.unregister(): Missing argument #1 (handle)", 2 unless handle
+  return false unless handles[handle.id]
   unrefed_handlers[handle.handler] = nil if type(handle.handler) == 'number'
   handles[handle.id] = nil
+  true
 
 do_dispatch = (data, ...) ->
   ref_id = tonumber ffi_cast('gint', data)

--- a/lib/ljglibs/callbacks.moon
+++ b/lib/ljglibs/callbacks.moon
@@ -9,6 +9,7 @@ ref_id_cnt = 0
 weak_handler_id_cnt = 0
 handles = {}
 unrefed_handlers = setmetatable {}, __mode: 'v'
+unrefed_args = setmetatable {}, __mode: 'k'
 options = {
   dispatch_in_coroutine: false
   on_error: error
@@ -16,33 +17,38 @@ options = {
 
 cb_cast = (cb_type, handler) -> ffi_cast('GCallback', ffi_cast(cb_type, handler))
 
+unregister = (handle) ->
+  error "callbacks.unregister(): Missing argument #1 (handle)", 2 unless handle
+  unrefed_handlers[handle.handler] = nil if type(handle.handler) == 'number'
+  handles[handle.id] = nil
+
 do_dispatch = (data, ...) ->
   ref_id = tonumber ffi_cast('gint', data)
   handle = handles[ref_id]
   if handle
     handler = handle.handler
-    handler = unrefed_handlers[handler] if type(handler) == 'number'
+    handler_args = handle.args
+
+    if type(handler) == 'number'
+      handler = unrefed_handlers[handler]
+      handler_args = unrefed_args[handler]
+
     if handler
       args = pack ...
-      for i = 1, handle.args.n
-        args[args.n + i] = handle.args[i]
+      for i = 1, handler_args.n
+        args[args.n + i] = handler_args[i]
 
       if options.dispatch_in_coroutine
         target = handler
         handler = coroutine.wrap (...) -> target ...
 
-      status, ret = pcall handler, unpack(args, 1, args.n + handle.args.n)
+      status, ret = pcall handler, unpack(args, 1, args.n + handler_args.n)
       return ret == true if status
       options.on_error "callbacks: error in '#{handle.description}' handler: '#{ret}'"
     else
       unregister handle
 
   false
-
-unregister = (handle) ->
-  error "callbacks.unregister(): Missing argument #1 (handle)", 2 unless handle
-  unrefed_handlers[handle.handler] = nil if type(handle.handler) == 'number'
-  handles[handle.id] = nil
 
 dispatch = (data, ...) ->
   status, ret = pcall do_dispatch, data, ...
@@ -72,7 +78,9 @@ dispatch = (data, ...) ->
     if type(handler) != 'number'
       weak_handler_id_cnt += 1
       unrefed_handlers[weak_handler_id_cnt] = handler
+      unrefed_args[handler] = handle.args
       handle.handler = weak_handler_id_cnt
+      handle.args = nil
       handler
 
   cast_arg: (arg) -> ffi.cast('gpointer', arg)

--- a/lib/ljglibs/cdefs/glib.moon
+++ b/lib/ljglibs/cdefs/glib.moon
@@ -108,6 +108,8 @@ ffi.cdef [[
                            gpointer data,
                            GDestroyNotify notify);
 
+  gboolean g_source_remove (guint tag);
+
   guint g_child_watch_add (GPid pid, GChildWatchFunc function, gpointer data);
 
   enum GPriority {

--- a/lib/ljglibs/cdefs/glib.moon
+++ b/lib/ljglibs/cdefs/glib.moon
@@ -213,8 +213,12 @@ ffi.cdef [[
   const gchar * g_get_home_dir (void);
   gchar * g_get_current_dir (void);
   gchar * g_strndup (const gchar *str, gsize n);
+  gpointer g_malloc0 (gsize n_bytes);
   void g_free(gpointer mem);
   void g_strfreev (gchar **str_array);
+  gpointer g_slice_alloc (gsize block_size);
+  gpointer g_slice_alloc0 (gsize block_size);
+  void g_slice_free1 (gsize block_size, gpointer mem_block);
 
   /* Process spawning */
   typedef enum {

--- a/lib/ljglibs/core.moon
+++ b/lib/ljglibs/core.moon
@@ -74,6 +74,9 @@ setup_signals = (name, def, gtype, instance_cast) ->
       ret_type = info.return_type == types.base_types.gboolean and 'bool' or 'void'
       cb_type = "#{ret_type}#{info.n_params + 2}"
       def[name] = (instance, handler, ...) ->
+        unless handler
+          error "`nil` handler passed as handler for '#{name}'"
+
         casting_handler = (...) ->
           args = pack ...
           args[1] = instance_cast args[1]

--- a/lib/ljglibs/gtk/drawing_area.moon
+++ b/lib/ljglibs/gtk/drawing_area.moon
@@ -10,6 +10,8 @@ require 'ljglibs.gtk.widget'
 gc_ptr = gobject.gc_ptr
 C = ffi.C
 
+jit.off true, true
+
 core.define 'GtkDrawingArea < GtkWidget', {
   new: -> gc_ptr C.gtk_drawing_area_new!
 }, (spec) -> spec.new!

--- a/lib/ljglibs/gtk/im_context.moon
+++ b/lib/ljglibs/gtk/im_context.moon
@@ -12,6 +12,8 @@ signal = gobject.signal
 C, ffi_string, ffi_new, ffi_gc = ffi.C, ffi.string, ffi.new, ffi.gc
 pack, unpack = table.pack, table.unpack
 
+jit.off true, true
+
 GtkIMContext = ffi.typeof 'GtkIMContext *'
 
 core.define 'GtkIMContext < GObject', {

--- a/lib/ljglibs/gtk/im_context_simple.moon
+++ b/lib/ljglibs/gtk/im_context_simple.moon
@@ -9,6 +9,8 @@ gobject = require 'ljglibs.gobject'
 ref_ptr = gobject.ref_ptr
 C = ffi.C
 
+jit.off true, true
+
 core.define 'GtkIMContextSimple < GtkIMContext', {
   new: ->
     ref_ptr C.gtk_im_context_simple_new!

--- a/lib/ljglibs/gtk/misc.moon
+++ b/lib/ljglibs/gtk/misc.moon
@@ -6,6 +6,8 @@ require 'ljglibs.cdefs.gtk'
 core = require 'ljglibs.core'
 require 'ljglibs.gtk.widget'
 
+jit.off true, true
+
 core.define 'GtkMisc < GtkWidget', {
   properties: {
     xalign: 'gfloat'

--- a/lib/ljglibs/gtk/range.moon
+++ b/lib/ljglibs/gtk/range.moon
@@ -5,6 +5,8 @@ require 'ljglibs.cdefs.gtk'
 core = require 'ljglibs.core'
 require 'ljglibs.gtk.adjustment'
 
+jit.off true, true
+
 core.define 'GtkRange < GtkWidget', {
   properties: {
     adjustment: 'GtkAdjustment *'

--- a/lib/ljglibs/gtk/settings.moon
+++ b/lib/ljglibs/gtk/settings.moon
@@ -10,6 +10,8 @@ gobject = require 'ljglibs.gobject'
 ref_ptr = gobject.ref_ptr
 C = ffi.C
 
+jit.off true, true
+
 core.define 'GtkSettings < GObject', {
   properties: {
     gtk_cursor_blink: 'gboolean'

--- a/lib/ljglibs/spec/callbacks_spec.moon
+++ b/lib/ljglibs/spec/callbacks_spec.moon
@@ -61,6 +61,12 @@ describe 'callbacks', ->
       collectgarbage!
       assert.is_nil holder[1]
 
+    it 'returns true if there was a handler to unregister', ->
+      handle = callbacks.register handler, 'test handler'
+      assert.is_true callbacks.unregister handle
+      assert.is_false callbacks.unregister handle
+
+
   describe 'unref_handle(handle)', ->
     collect = ->
       -- twice to allow for multiple levels of weak refs to be collected

--- a/lib/ljglibs/spec/callbacks_spec.moon
+++ b/lib/ljglibs/spec/callbacks_spec.moon
@@ -64,8 +64,7 @@ describe 'callbacks', ->
   describe 'unref_handle(handle)', ->
     collect = ->
       -- twice to allow for multiple levels of weak refs to be collected
-      collectgarbage!
-      collectgarbage!
+      collect_memory!
 
     it 'un-anchors a handle, allowing the handler to be garbage collected', ->
       holder = setmetatable { handler: -> }, __mode: 'v'

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -636,7 +636,6 @@ describe 'Buffer', ->
       assert.is_nil buffers[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within '5Kb', ->
-        for i = 1, 30
-          buffer 'collect me!'
+      assert_memory_stays_within '5Kb', 30, ->
+        buffer 'collect me!'
 

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -628,3 +628,11 @@ describe 'Buffer', ->
         b = buffer 'foo'
         b.title = 'Sir Buffer'
         assert.spy(handler).was_called!
+
+  context 'resource management', ->
+    it 'buffers are collected properly', ->
+      b = buffer 'foobar'
+      buffers = setmetatable { b }, __mode: 'v'
+      b = nil
+      collectgarbage!
+      assert.is_nil buffers[1]

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -636,7 +636,7 @@ describe 'Buffer', ->
       assert.is_nil buffers[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within 0.5, ->
+      assert_memory_stays_within '5Kb', ->
         for i = 1, 30
           buffer 'collect me!'
 

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -107,7 +107,7 @@ describe 'Buffer', ->
   it '.showing is true if the buffer is currently referenced in any view', ->
     b = buffer ''
     assert.false b.showing
-    b\add_view_ref {}
+    b\add_view_ref!
     assert.true b.showing
 
   describe '.multibyte', ->
@@ -517,20 +517,18 @@ describe 'Buffer', ->
     b.title = 'foo'
     assert.equal tostring(b), 'foo'
 
-  describe '.add_view_ref(view)', ->
-    it 'adds the specified view to .views', ->
+  describe '.add_view_ref()', ->
+    it 'increments the number of viewers', ->
       b = buffer ''
-      view = {}
-      b\add_view_ref view
-      assert.same b.views, { view }
+      b\add_view_ref!
+      assert.equal 1, b.viewers
 
-  describe '.remove_view_ref(view)', ->
-    it 'removes the specified view from .views', ->
+  describe '.remove_view_ref()', ->
+    it 'decrements the number of viewers', ->
       b = buffer ''
-      view = {}
-      b\add_view_ref view
-      b\remove_view_ref view
-      assert.same b.views, {}
+      b\add_view_ref!
+      b\remove_view_ref!
+      assert.equal 0, b.viewers
 
   describe 'ensuring that buffer titles are globally unique', ->
     context 'when setting a file for a buffer', ->
@@ -636,3 +634,9 @@ describe 'Buffer', ->
       b = nil
       collectgarbage!
       assert.is_nil buffers[1]
+
+    it 'memory usage is stable', ->
+      assert_memory_stays_within 0.5, ->
+        for i = 1, 30
+          buffer 'collect me!'
+

--- a/spec/support/spec_helper.moon
+++ b/spec/support/spec_helper.moon
@@ -125,3 +125,10 @@ export close_all_buffers = ->
   for b in *howl.app.buffers
     howl.app\close_buffer b, true
 
+export collect_memory = ->
+  mem = collectgarbage('count')
+  while true
+    collectgarbage!
+    used = collectgarbage('count')
+    break if used >= mem
+    mem = used

--- a/spec/support/spec_helper.moon
+++ b/spec/support/spec_helper.moon
@@ -134,7 +134,6 @@ export collect_memory = ->
     mem = used
 
 export assert_memory_stays_within = (units, f) ->
-  units = "#{units}%" if type(units) == 'number'
   val, unit = units\match '(%d+)(%S+)'
   if not (val and unit) and (unit == '%' or unit == 'Kb')
     error "Unknown unit specifier '#{units}'"
@@ -152,3 +151,4 @@ export assert_memory_stays_within = (units, f) ->
       err = string.format "Memory increased from %dKb -> %dKb (diff = %dKb, %.2f%%)",
         baseline, used, diff, percentual
       error err
+

--- a/spec/timer_spec.moon
+++ b/spec/timer_spec.moon
@@ -1,3 +1,5 @@
+-- Copyright 2014-2015 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 timer = howl.timer
 
 describe 'timer', ->

--- a/spec/ui/action_buffer_spec.moon
+++ b/spec/ui/action_buffer_spec.moon
@@ -111,3 +111,18 @@ describe 'ActionBuffer', ->
       assert.equal 'keyword', (style.at_pos(buf, 2))
       assert.equal 'keyword', (style.at_pos(buf, 4))
       assert.is_nil (style.at_pos(buf, 5))
+
+  context 'resource management', ->
+    it 'buffers are collected properly', ->
+      b = ActionBuffer!
+      buffers = setmetatable { b }, __mode: 'v'
+      b = nil
+      collectgarbage!
+      assert.is_nil buffers[1]
+
+    it 'memory usage is stable', ->
+      assert_memory_stays_within '15Kb', ->
+        for i = 1, 30
+          b = ActionBuffer!
+          b.text = 'collect me!'
+

--- a/spec/ui/action_buffer_spec.moon
+++ b/spec/ui/action_buffer_spec.moon
@@ -121,8 +121,7 @@ describe 'ActionBuffer', ->
       assert.is_nil buffers[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within '15Kb', ->
-        for i = 1, 30
-          b = ActionBuffer!
-          b.text = 'collect me!'
+      assert_memory_stays_within '15Kb', 30, ->
+        b = ActionBuffer!
+        b.text = 'collect me!'
 

--- a/spec/ui/completion_popup_spec.moon
+++ b/spec/ui/completion_popup_spec.moon
@@ -17,7 +17,7 @@ describe 'CompletionPopup', ->
       assert.is_nil list[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within '30Kb', 20, ->
+      assert_memory_stays_within '50Kb', 20, ->
         p = CompletionPopup editor
         p\close!
         p\destroy!

--- a/spec/ui/completion_popup_spec.moon
+++ b/spec/ui/completion_popup_spec.moon
@@ -17,7 +17,7 @@ describe 'CompletionPopup', ->
       assert.is_nil list[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within '50Kb', 20, ->
+      assert_memory_stays_within '70Kb', 30, ->
         p = CompletionPopup editor
         p\close!
         p\destroy!

--- a/spec/ui/completion_popup_spec.moon
+++ b/spec/ui/completion_popup_spec.moon
@@ -17,8 +17,7 @@ describe 'CompletionPopup', ->
       assert.is_nil list[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within '30Kb', ->
-        for i = 1, 20
-          p = CompletionPopup editor
-          p\close!
-          p\destroy!
+      assert_memory_stays_within '30Kb', 20, ->
+        p = CompletionPopup editor
+        p\close!
+        p\destroy!

--- a/spec/ui/completion_popup_spec.moon
+++ b/spec/ui/completion_popup_spec.moon
@@ -1,0 +1,24 @@
+-- Copyright 2012-2015 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+import Buffer from howl
+import Editor, CompletionPopup from howl.ui
+
+describe 'CompletionPopup', ->
+  context 'resource management', ->
+    editor = Editor Buffer!
+
+    it 'popups are collected as they should', ->
+      o = CompletionPopup editor
+      list = setmetatable {o}, __mode: 'v'
+      o\destroy!
+      o = nil
+      collectgarbage!
+      assert.is_nil list[1]
+
+    it 'memory usage is stable', ->
+      assert_memory_stays_within '30Kb', ->
+        for i = 1, 20
+          p = CompletionPopup editor
+          p\close!
+          p\destroy!

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -650,9 +650,10 @@ describe 'Editor', ->
     it 'editors are collected as they should', ->
       e = Editor Buffer {}
       editors = setmetatable {e}, __mode: 'v'
+      e\to_gobject!\destroy!
       e = nil
-      collectgarbage!
-      assert.is_nil editors[1]
+      collect_memory!
+      assert.is_true editors[1] == nil
 
     it 'releases resources after buffer switching', ->
       b1 = Buffer {}
@@ -662,6 +663,7 @@ describe 'Editor', ->
       editors = setmetatable { e }, __mode: 'v'
       e.buffer = b2
       e.buffer = b1
+      e\to_gobject!\destroy!
       e = nil
       b1 = nil
       b2 = nil
@@ -669,3 +671,11 @@ describe 'Editor', ->
       assert.is_nil editors[1]
       assert.is_nil buffers[1]
       assert.is_nil buffers[2]
+
+    it 'memory usage is stable', ->
+      pinned = Editor Buffer!
+
+      assert_memory_stays_within '50Kb', ->
+        for i = 1, 20
+          e = Editor Buffer!
+          e\to_gobject!\destroy!

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -654,3 +654,19 @@ describe 'Editor', ->
       e = nil
       collectgarbage!
       assert.is_nil editors[1]
+
+    it 'releases resources after buffer switching', ->
+      b1 = Buffer {}
+      b2 = Buffer {}
+      e = Editor b1
+      buffers = setmetatable { b1, b2 }, __mode: 'v'
+      editors = setmetatable { e }, __mode: 'v'
+      e.buffer = b2
+      e.buffer = b1
+      e = nil
+      b1 = nil
+      b2 = nil
+      collectgarbage!
+      assert.is_nil editors[1]
+      assert.is_nil buffers[1]
+      assert.is_nil buffers[2]

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -647,7 +647,7 @@ describe 'Editor', ->
         assert.equals 'hello\nhello\nwörld', buffer.text
 
   context 'resource management', ->
-    pending 'editors are collected as they should', ->
+    it 'editors are collected as they should', ->
       e = Editor Buffer {}
       editors = setmetatable {}, __mode: 'v'
       append editors, e

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -675,7 +675,6 @@ describe 'Editor', ->
     it 'memory usage is stable', ->
       pinned = Editor Buffer!
 
-      assert_memory_stays_within '50Kb', ->
-        for i = 1, 20
-          e = Editor Buffer!
-          e\to_gobject!\destroy!
+      assert_memory_stays_within '40Kb', 20, ->
+        e = Editor Buffer!
+        e\to_gobject!\destroy!

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -649,8 +649,7 @@ describe 'Editor', ->
   context 'resource management', ->
     it 'editors are collected as they should', ->
       e = Editor Buffer {}
-      editors = setmetatable {}, __mode: 'v'
-      append editors, e
+      editors = setmetatable {e}, __mode: 'v'
       e = nil
       collectgarbage!
       assert.is_nil editors[1]

--- a/spec/ui/list_widget_spec.moon
+++ b/spec/ui/list_widget_spec.moon
@@ -359,7 +359,7 @@ three    four    ]] .. '\n', buf.text
 
     it 'memory usage is stable', ->
       items = {'one', 'two', 'three'}
-      assert_memory_stays_within '10Kb', ->
+      assert_memory_stays_within '30Kb', ->
         for i = 1, 20
           w = ListWidget (-> items)
           w\show!

--- a/spec/ui/list_widget_spec.moon
+++ b/spec/ui/list_widget_spec.moon
@@ -347,4 +347,21 @@ three    four    ]] .. '\n', buf.text
     it 'selects the last item by default', ->
       assert.equal 'one', rlist.selection
 
+  context 'resource management', ->
+
+    it 'widgets are collected as they should', ->
+      w = ListWidget (->)
+      list = setmetatable {w}, __mode: 'v'
+      w\to_gobject!\destroy!
+      w = nil
+      collectgarbage!
+      assert.is_nil list[1]
+
+    it 'memory usage is stable', ->
+      items = {'one', 'two', 'three'}
+      assert_memory_stays_within '10Kb', ->
+        for i = 1, 20
+          w = ListWidget (-> items)
+          w\show!
+          w\to_gobject!\destroy!
 

--- a/spec/ui/list_widget_spec.moon
+++ b/spec/ui/list_widget_spec.moon
@@ -359,9 +359,8 @@ three    four    ]] .. '\n', buf.text
 
     it 'memory usage is stable', ->
       items = {'one', 'two', 'three'}
-      assert_memory_stays_within '30Kb', ->
-        for i = 1, 20
-          w = ListWidget (-> items)
-          w\show!
-          w\to_gobject!\destroy!
+      assert_memory_stays_within '30Kb', 20, ->
+        w = ListWidget (-> items)
+        w\show!
+        w\to_gobject!\destroy!
 

--- a/spec/ui/menu_popup_spec.moon
+++ b/spec/ui/menu_popup_spec.moon
@@ -1,0 +1,22 @@
+-- Copyright 2012-2015 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+import MenuPopup from howl.ui
+
+describe 'MenuPopup', ->
+  context 'resource management', ->
+    items = {'one', 'two', 'three'}
+
+    it 'popups are collected as they should', ->
+      o = MenuPopup items, (->)
+      list = setmetatable {o}, __mode: 'v'
+      o\destroy!
+      o = nil
+      collectgarbage!
+      assert.is_nil list[1]
+
+    it 'memory usage is stable', ->
+      assert_memory_stays_within '50Kb', ->
+        for i = 1, 20
+          p = MenuPopup items, (->)
+          p\destroy!

--- a/spec/ui/menu_popup_spec.moon
+++ b/spec/ui/menu_popup_spec.moon
@@ -16,7 +16,6 @@ describe 'MenuPopup', ->
       assert.is_nil list[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within '50Kb', ->
-        for i = 1, 20
-          p = MenuPopup items, (->)
-          p\destroy!
+      assert_memory_stays_within '50Kb', 20, ->
+        p = MenuPopup items, (->)
+        p\destroy!

--- a/spec/ui/menu_popup_spec.moon
+++ b/spec/ui/menu_popup_spec.moon
@@ -16,6 +16,6 @@ describe 'MenuPopup', ->
       assert.is_nil list[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within '50Kb', 20, ->
+      assert_memory_stays_within '70Kb', 30, ->
         p = MenuPopup items, (->)
         p\destroy!

--- a/spec/ui/popup_spec.moon
+++ b/spec/ui/popup_spec.moon
@@ -17,7 +17,6 @@ describe 'Popup', ->
       assert.is_nil list[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within '5Kb', ->
-        for i = 1, 20
-          p = Popup child
-          p\destroy!
+      assert_memory_stays_within '5Kb', 20, ->
+        p = Popup child
+        p\destroy!

--- a/spec/ui/popup_spec.moon
+++ b/spec/ui/popup_spec.moon
@@ -1,0 +1,23 @@
+-- Copyright 2012-2015 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+import Popup from howl.ui
+Gtk = require 'ljglibs.gtk'
+
+describe 'Popup', ->
+  context 'resource management', ->
+    child = Gtk.Box Gtk.ORIENTATION_VERTICAL, {}
+
+    it 'widgets are collected as they should', ->
+      o = Popup child
+      list = setmetatable {o}, __mode: 'v'
+      o\destroy!
+      o = nil
+      collectgarbage!
+      assert.is_nil list[1]
+
+    it 'memory usage is stable', ->
+      assert_memory_stays_within '5Kb', ->
+        for i = 1, 20
+          p = Popup child
+          p\destroy!

--- a/spec/ui/text_widget_spec.moon
+++ b/spec/ui/text_widget_spec.moon
@@ -13,8 +13,7 @@ describe 'TextWidget', ->
       assert.is_nil list[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within '30Kb', ->
-        for i = 1, 20
-          w = TextWidget!
-          w\show!
-          w\to_gobject!\destroy!
+      assert_memory_stays_within '30Kb', 20, ->
+        w = TextWidget!
+        w\show!
+        w\to_gobject!\destroy!

--- a/spec/ui/text_widget_spec.moon
+++ b/spec/ui/text_widget_spec.moon
@@ -1,0 +1,20 @@
+{:TextWidget} = howl.ui
+
+describe 'TextWidget', ->
+
+  context 'resource management', ->
+
+    it 'widgets are collected as they should', ->
+      w = TextWidget!
+      list = setmetatable {w}, __mode: 'v'
+      w\to_gobject!\destroy!
+      w = nil
+      collectgarbage!
+      assert.is_nil list[1]
+
+    it 'memory usage is stable', ->
+      assert_memory_stays_within '30Kb', ->
+        for i = 1, 20
+          w = TextWidget!
+          w\show!
+          w\to_gobject!\destroy!

--- a/spec/ui/window_spec.moon
+++ b/spec/ui/window_spec.moon
@@ -201,3 +201,12 @@ describe 'Window', ->
       win\remove_view middle
       assert.same { x: 1, y: 1, width: 1, height: 1, view: left }, win\get_view left
       assert.same { x: 2, y: 1, width: 1, height: 1, view: right }, win\get_view right
+
+  context 'resource management', ->
+    it 'added views are not anchored', ->
+      v = Gtk.Entry!
+      views = setmetatable {v}, __mode: 'v'
+      win\add_view v
+      v = nil
+      collectgarbage!
+      assert.is_nil views[1]


### PR DESCRIPTION
The main focus of this has been to go through all kinds of memory and ref handling to verify that resources are released correctly, and to re-enable the last pending Editor GC spec after the aullar rewrite. Contains fixes for two bigger leaks  - the aforementioned editor spec and also an issue with popups not being released that I found. It also configures the GC to be more aggressive, which prevents RSS from ballooning up.

Also contains a fix for a "bad callback" case, a fix for the view spec which failed on newer Gtk versions, and some various small tweakings.