### PR TITLE
Timers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,8 +4,7 @@
 
 - Added a new command, `cursor-goto-line` for going to a specified line.
 
-- Added two signals, `idle` and `every-second`, which can be used for performing
-operations upon idle or periodically.
+- Added Timer.on_idle, for performing operations upon idle.
 
 - Added a new property, Application.idle, for determining how long the
 application has been idle.

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 - Added a new command, `cursor-goto-line` for going to a specified line.
 
+- Added a new property, Application.idle, for determining how long the
+application has been idle.
+
 - Added new configuration variable, `undo_limit`, for controlling the maximum
 number of revisions for each buffer.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 - Added a new command, `cursor-goto-line` for going to a specified line.
 
+- Added two signals, `idle` and `every-second`, which can be used for performing
+operations upon idle or periodically.
+
 - Added a new property, Application.idle, for determining how long the
 application has been idle.
 

--- a/lib/aullar/cursor.moon
+++ b/lib/aullar/cursor.moon
@@ -39,7 +39,7 @@ flair.define_default 'inactive_cursor', {
 {:max, :min, :abs} = math
 {:define_class} = require 'aullar.util'
 
-timer_callback = ffi.cast 'GSourceFunc', callbacks.bool1
+timer_callback = callbacks.source_func
 
 is_showing_line = (view, line) ->
   line >= view.first_visible_line and line <= view.last_visible_line

--- a/lib/howl/init.lua
+++ b/lib/howl/init.lua
@@ -133,12 +133,6 @@ local function main(args)
     collectgarbage('setstepmul', 400)
     collectgarbage('setpause', 99)
 
-    local callbacks = require 'ljglibs.callbacks'
-    callbacks.configure({
-      dispatch_in_coroutine = true,
-      on_error = _G.log.error
-    })
-
     howl.app = howl.Application(howl.io.File(app_root), args)
     assert(jit.status(), "JIT is inadvertently switched off")
 

--- a/lib/howl/timer.moon
+++ b/lib/howl/timer.moon
@@ -7,7 +7,7 @@ ffi = require 'ffi'
 jit = require 'jit'
 C = ffi.C
 
-timer_callback = ffi.cast 'GSourceFunc', callbacks.bool1
+timer_callback = callbacks.source_func
 
 jit.off true, true
 

--- a/lib/howl/timer.moon
+++ b/lib/howl/timer.moon
@@ -1,6 +1,7 @@
 -- Copyright 2014-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
+{:signal, :config} = howl
 callbacks = require 'ljglibs.callbacks'
 cast_arg = callbacks.cast_arg
 ffi = require 'ffi'
@@ -10,6 +11,22 @@ C = ffi.C
 timer_callback = callbacks.source_func
 
 jit.off true, true
+
+idle_fired = false
+
+check_for_idle = ->
+  app = howl.app
+  if app.idle > config.idle_timeout
+    if not idle_fired
+      idle_fired = true
+      signal.emit 'idle'
+  else
+    idle_fired = false
+
+every_second = ->
+  check_for_idle!
+  signal.emit 'every-second'
+  true
 
 cancel = (handle) ->
   if callbacks.unregister handle.cb
@@ -23,7 +40,10 @@ asap = (f, ...) ->
     f ...
 
   t_handle.cb = callbacks.register handler, 'timer-asap', ...
-  t_handle.tag = C.g_idle_add_full C.G_PRIORITY_LOW, timer_callback, cast_arg(t_handle.cb.id), nil
+  t_handle.tag = C.g_idle_add_full C.G_PRIORITY_LOW,
+    timer_callback,
+    cast_arg(t_handle.cb.id),
+    nil
   t_handle
 
 after = (seconds, f, ...) ->
@@ -35,8 +55,34 @@ after = (seconds, f, ...) ->
 
   interval = seconds * 1000
   t_handle.cb = callbacks.register f, "timer-after-#{seconds}", ...
-  t_handle.tag = C.g_timeout_add_full C.G_PRIORITY_LOW, interval, timer_callback, cast_arg(t_handle.cb.id), nil
+  t_handle.tag = C.g_timeout_add_full C.G_PRIORITY_LOW,
+    interval,
+    timer_callback,
+    cast_arg(t_handle.cb.id),
+    nil
   t_handle
+
+-- set up a shared timer to run every second
+second_handle = {}
+second_handle.cb = callbacks.register every_second, "timer-every-second"
+second_handle.tag = C.g_timeout_add_full C.G_PRIORITY_LOW,
+  1000,
+  timer_callback,
+  cast_arg(second_handle.cb.id),
+  nil
+
+signal.register 'idle',
+  description: 'Signaled once whenever Howl becomes idle'
+
+signal.register 'every-second',
+  description: 'Signaled once every second'
+
+config.define
+  name: 'idle_timeout'
+  description: 'Number of idle time in seconds before the "idle" signal is fired'
+  default: 60
+  type_of: 'number'
+  scope: 'global'
 
 {
   :after

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -128,6 +128,7 @@ class Editor extends PropertyObject
 
     @buffer = buffer
     @_is_previewing = false
+    @has_focus = false
 
     append _editors, self
 
@@ -733,10 +734,12 @@ class Editor extends PropertyObject
 
   _on_focus: (args) =>
     howl.app.editor = self
+    @has_focus = true
     signal.emit 'editor-focused', editor: self
     false
 
   _on_focus_lost: (args) =>
+    @has_focus = false
     @remove_popup!
     signal.emit 'editor-defocused', editor: self
     false

--- a/lib/ljglibs/callbacks.moon
+++ b/lib/ljglibs/callbacks.moon
@@ -108,4 +108,5 @@ dispatch = (data, ...) ->
   bool5: cb_cast 'GBCallback5', (a1, a2, a3, a4, data) -> dispatch data, a1, a2, a3, a4
   bool6: cb_cast 'GBCallback6', (a1, a2, a3, a4, a5, data) -> dispatch data, a1, a2, a3, a4, a5
   bool7: cb_cast 'GBCallback7', (a1, a2, a3, a4, a5, a6, data) -> dispatch data, a1, a2, a3, a4, a5, a6
+  source_func: ffi_cast 'GSourceFunc', (data) -> dispatch data
 }

--- a/site/source/doc/api/application.md
+++ b/site/source/doc/api/application.md
@@ -27,6 +27,12 @@ A list of all existing [Editor]:s. Each editor can be placed in only one window
 at a time, but this list holds all editors present for the current Howl instance
 - regardless of whether they're placed in the currently focused window or not.
 
+### idle
+
+A number providing information on how long the application has been idle, in
+seconds (with fractions). As the idle is reset upon activity this is useful
+primarily in timers and idle callbacks.
+
 ### next_buffer
 
 This is the most recent buffer that is currently not showing in any editor. If

--- a/site/source/doc/api/timer.md
+++ b/site/source/doc/api/timer.md
@@ -11,6 +11,8 @@ at a later time. All callbacks are always invoked on the main GUI thread.
 
 _See also_:
 
+- The signals `idle` and `every-second` can also be used for handling periodic
+tasks and for operations that should be run when the application is idle.
 - The [spec](../spec/timer_spec.html) for timer
 
 ## Functions

--- a/site/source/doc/api/timer.md
+++ b/site/source/doc/api/timer.md
@@ -11,8 +11,6 @@ at a later time. All callbacks are always invoked on the main GUI thread.
 
 _See also_:
 
-- The signals `idle` and `every-second` can also be used for handling periodic
-tasks and for operations that should be run when the application is idle.
 - The [spec](../spec/timer_spec.html) for timer
 
 ## Functions
@@ -54,3 +52,12 @@ Cancels the timer associated with `handle`. `handle` must be one the values
 returned from either [asap](#asap) or [after](#after).
 
 [cancel]: #cancel
+
+### on_idle (seconds, callback, ...)
+
+Invokes `callback` after the application has been idle for approximately
+`seconds` seconds, passing along any optional extra parameters passed to
+`on_idle`. The precision of idle timers are whole `seconds`.
+
+Returns an opaque handle for the timer, which can be passed to [cancel] in order
+to cancel the timer.

--- a/site/source/doc/api/timer.md
+++ b/site/source/doc/api/timer.md
@@ -49,7 +49,7 @@ timer.after 0.5, callback, 'Log me!'
 ### cancel (handle)
 
 Cancels the timer associated with `handle`. `handle` must be one the values
-returned from either [asap](#asap) or [after](#after).
+returned from [asap](#asap), [after](#after) or [on_idle](#on_idle).
 
 [cancel]: #cancel
 

--- a/site/source/doc/api/timer.md
+++ b/site/source/doc/api/timer.md
@@ -24,11 +24,17 @@ rationale for this is that there are cases where you want to schedule
 destructive buffer modifications, but are not allowed to do so at the current
 point in time (e.g. when in a signal handler for the `text-deleted` signal).
 
+Returns an opaque handle for the timer, which can be passed to [cancel] in order
+to cancel the timer.
+
 ### after (seconds, callback, ...)
 
 Invokes `callback` after approximately `seconds` seconds, passing along any
 optional extra parameters passed to `after`. `seconds` can contain fractions,
 allowing you schedule callbacks at sub-second rates.
+
+Returns an opaque handle for the timer, which can be passed to [cancel] in order
+to cancel the timer.
 
 As an example, the below snippet would cause the text "I was invoked with Log
 me!" to be logged after approximately 500 milliseconds:
@@ -39,3 +45,10 @@ callback = (text) ->
 
 timer.after 0.5, callback, 'Log me!'
 ```
+
+### cancel (handle)
+
+Cancels the timer associated with `handle`. `handle` must be one the values
+returned from either [asap](#asap) or [after](#after).
+
+[cancel]: #cancel

--- a/site/source/doc/api/ui/editor.md
+++ b/site/source/doc/api/ui/editor.md
@@ -57,6 +57,10 @@ current cursor position. Read-only.
 Contains the currently active [line][Line], i.e. the line that the cursor is
 currently positioned on. Read-only.
 
+### has_focus
+
+True if the editor is currently focused, and false otherwise.
+
 ### horizontal_scrollbar
 
 A boolean controlling whether the editor shows a horizontal scrollbar or not.

--- a/spec/timer_spec.moon
+++ b/spec/timer_spec.moon
@@ -21,3 +21,22 @@ describe 'timer', ->
     it 'invokes <f> once after approximately <seconds>', (done) ->
       timer.after 0, async ->
         done!
+
+  describe 'cancel(handle)', ->
+    it 'cancels an asap timer', (done) ->
+      invoked = false
+      handle = timer.asap async -> invoked = true
+      timer.cancel handle
+
+      timer.after 0.05, async ->
+        assert.is_false invoked
+        done!
+
+    it 'cancels an after timer', (done) ->
+      invoked = false
+      handle = timer.after 0.05, async -> invoked = true
+      timer.cancel handle
+
+      timer.after 0.1, async ->
+        assert.is_false invoked
+        done!


### PR DESCRIPTION
This adds primarily:

- An `.idle` property for Application, returning the time in seconds Howl has been idle
- A new signal `idle`, fired when Howl has been idle for a configurable amount of time (currently defaults to 60s)
- A new signal `every-second`, fired once every second

This in itself is not particularly super exciting perhaps, but it enables the addition of other features that runs upon idle. Things I'm not sure about: 

- Do we want the `every-second` signal? I see that it could be useful for easily running periodical tasks, but that might be forward engineering. It does not cost much though since we have it anyway for the idle timer.
- A good default for the idle timeout. Currently 60s, but that could be considered too short 