### PR TITLE
Janitor

### DIFF
--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -926,11 +926,6 @@ describe 'Buffer', ->
       collect_memory!
       assert.is_nil buffers[1]
 
-      -- and memory should be back to normal
-      before = collectgarbage('count')
-      for i = 1, 50
+    it 'memory usage is stable', ->
+      assert_memory_stays_within '5Kb', 50, ->
         Buffer 'collect me!'
-
-      collect_memory!
-      after = collectgarbage('count')
-      assert.is_true (after - before) < 2

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -290,6 +290,8 @@ class Application extends PropertyObject
       window = @new_window!
       @_set_initial_status window
 
+      howl.janitor.start!
+
     for path in *files
       file = File path
       buffer = @new_buffer mode.for_file file
@@ -404,6 +406,7 @@ class Application extends PropertyObject
     require 'howl.commands.edit_commands'
     require 'howl.editing'
     require 'howl.ui.icons.font_awesome'
+    require 'howl.janitor'
 
   _load_application_icon: =>
     dir = @root_dir

--- a/lib/howl/janitor.moon
+++ b/lib/howl/janitor.moon
@@ -1,0 +1,76 @@
+-- Copyright 2015 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+{:config, :timer, :sys} = howl
+ffi = require 'ffi'
+
+config.define
+  name: 'cleanup_min_buffers_open'
+  description: 'The minimum number of buffers to leave when auto-closing buffers'
+  default: 40
+  type_of: 'number'
+  scope: 'global'
+
+config.define
+  name: 'cleanup_close_buffers_after'
+  description: 'The number of minutes since a buffer was last shown before it can be closed'
+  default: 60 * 4
+  type_of: 'number'
+  scope: 'global'
+
+if sys.info.os == 'linux'
+  ffi.cdef 'int malloc_trim(size_t pad);'
+
+local timer_handle
+
+clean_up_buffers = ->
+  app = howl.app
+  bufs = app.buffers
+  to_remove = #bufs - config.cleanup_min_buffers_open
+  return if to_remove <= 0
+  now = os.time!
+  closeable = {}
+
+  for b in *bufs
+    continue if b.modified or not b.last_shown
+    unseen_for = os.difftime now, b.last_shown
+    if unseen_for > config.cleanup_close_buffers_after
+      closeable[#closeable + 1] = b
+
+  to_remove = math.min(to_remove, #closeable)
+  if to_remove > 0
+    table.sort closeable, (a, b) -> a.last_shown < b.last_shown
+    for i = 1, to_remove
+      app\close_buffer closeable[i]
+
+    log.info "Closed #{to_remove} old buffers"
+
+release_memory = ->
+  collectgarbage!
+  collectgarbage!
+
+  if sys.info.os == 'linux'
+    ffi.C.malloc_trim(1024 * 128)
+
+run = ->
+  clean_up_buffers!
+  release_memory!
+
+  if timer_handle
+    timer_handle = timer.on_idle 30, run
+
+start = ->
+  return if timer_handle
+  timer_handle = timer.on_idle 30, run
+
+stop = ->
+  return unless timer_handle
+  timer.cancel timer_handle
+  timer_handle = nil
+
+{
+  :clean_up_buffers
+  :start
+  :stop
+  :run
+}

--- a/lib/howl/janitor.moon
+++ b/lib/howl/janitor.moon
@@ -53,11 +53,14 @@ release_memory = ->
     ffi.C.malloc_trim(1024 * 128)
 
 run = ->
-  clean_up_buffers!
-  release_memory!
-
   if timer_handle
     timer_handle = timer.on_idle 30, run
+
+  window = howl.app.window
+  if window and #window.command_line.running == 0
+    clean_up_buffers!
+
+  release_memory!
 
 start = ->
   return if timer_handle

--- a/lib/howl/janitor.moon
+++ b/lib/howl/janitor.moon
@@ -23,6 +23,18 @@ if sys.info.os == 'linux'
 
 local timer_handle
 
+log_closed = (closed) ->
+  msg = "Closed buffers: '#{closed[1].title}'"
+  for i = 2, #closed
+    t = closed[i].title
+    if #t + #msg > 72
+      msg ..= " (+#{#closed - i + 1} more)"
+      break
+
+    msg ..= ", '#{t}'"
+
+  log.info msg
+
 clean_up_buffers = ->
   app = howl.app
   bufs = app.buffers
@@ -39,11 +51,14 @@ clean_up_buffers = ->
 
   to_remove = math.min(to_remove, #closeable)
   if to_remove > 0
+    closed = {}
     table.sort closeable, (a, b) -> a.last_shown < b.last_shown
     for i = 1, to_remove
-      app\close_buffer closeable[i]
+      buf = closeable[i]
+      app\close_buffer buf
+      closed[#closed + 1] = buf
 
-    log.info "Closed #{to_remove} old buffers"
+    log_closed closed
 
 release_memory = ->
   collectgarbage!

--- a/lib/howl/janitor.moon
+++ b/lib/howl/janitor.moon
@@ -13,8 +13,8 @@ config.define
 
 config.define
   name: 'cleanup_close_buffers_after'
-  description: 'The number of minutes since a buffer was last shown before it can be closed'
-  default: 60 * 4
+  description: 'The number of hours since a buffer was last shown before it can be closed'
+  default: 24
   type_of: 'number'
   scope: 'global'
 
@@ -33,7 +33,7 @@ clean_up_buffers = ->
 
   for b in *bufs
     continue if b.modified or not b.last_shown
-    unseen_for = os.difftime now, b.last_shown
+    unseen_for = os.difftime(now, b.last_shown) / 60 / 60 -- hours
     if unseen_for > config.cleanup_close_buffers_after
       closeable[#closeable + 1] = b
 

--- a/site/source/doc/manual/files.md
+++ b/site/source/doc/manual/files.md
@@ -133,9 +133,9 @@ buffers open. The default is to keep at least 40 buffers open at any given time.
 
 - `cleanup_close_buffers_after`
 
-This specifies the amount of time, in minutes, that should have passed since you
+This specifies the amount of time, in hours, that should have passed since you
 last viewed a buffer before it should be considered eligible for closing. The
-default is 240 minutes (4 hours).
+default is 24 hours.
 
 *Next*: [Editing](editing.html)
 

--- a/site/source/doc/manual/files.md
+++ b/site/source/doc/manual/files.md
@@ -112,5 +112,30 @@ when you open a non-existing file, you create a new buffer with an association
 to the specified file, which does not have to exist. As you save the buffer, the
 file will be created as necessary.
 
+## Closing buffers
+
+Closing buffers is normally done with the `buffer-close` command. However, it's
+quite easy to end up with a large number of open buffers unless you pay
+attention to closing old buffers as you're done with them. Since many users
+might find other tasks more agreeable than pruning the list of buffers, Howl
+will attempt to automatically close old buffers for you. This is done by closing
+those buffers you haven't bothered to look at for a while (assuming they're not
+modified).
+
+This behaviour is controlled by two configuration variables that you might want
+to tweak to better suit your editing preferences:
+
+- `cleanup_min_buffers_open`
+
+This specifies the minimum number of buffers that you want open at all times.
+Howl will never attempt to close buffers if you have less than this number of
+buffers open. The default is to keep at least 40 buffers open at any given time.
+
+- `cleanup_close_buffers_after`
+
+This specifies the amount of time, in minutes, that should have passed since you
+last viewed a buffer before it should be considered eligible for closing. The
+default is 240 minutes (4 hours).
+
 *Next*: [Editing](editing.html)
 

--- a/spec/janitor_spec.moon
+++ b/spec/janitor_spec.moon
@@ -1,0 +1,83 @@
+-- Copyright 2015 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+{:janitor, :config, :app} = howl
+{:time} = os
+
+cleanup_min_buffers_open = config.cleanup_min_buffers_open
+cleanup_close_buffers_after = config.cleanup_close_buffers_after
+
+close_buffers = ->
+  for b in *app.buffers
+    app\close_buffer b, true
+
+describe 'janitor', ->
+  before_each -> close_buffers!
+
+  after_each ->
+    config.cleanup_min_buffers_open = cleanup_min_buffers_open
+    config.cleanup_close_buffers_after = cleanup_close_buffers_after
+    close_buffers!
+
+  describe 'clean_up_buffers', ->
+    it 'never closes modified buffers', ->
+      config.cleanup_min_buffers_open = 0
+      config.cleanup_close_buffers_after = 0
+      b = app\new_buffer!
+      b.last_shown = time! - 60
+      b.modified = true
+      janitor.clean_up_buffers!
+      assert.equals 1, #app.buffers
+
+    it 'does not leave less than <cleanup_min_buffers_open> buffers', ->
+      config.cleanup_min_buffers_open = 2
+      config.cleanup_close_buffers_after = 0
+      for i = 1, 2
+        b = app\new_buffer!
+        b.last_shown = time! - 60
+
+      janitor.clean_up_buffers!
+      assert.equals 2, #app.buffers
+
+    context 'with more buffers than we want', ->
+      local now
+
+      before_each -> now = time!
+
+      it 'closes buffers who has not been shown recently enough', ->
+        for i = 1, 2
+          b = app\new_buffer!
+          b.title = 'keep'
+          b.last_shown = now
+
+        for i = 1, 2
+          b = app\new_buffer!
+          b.last_shown = now - 80
+
+        config.cleanup_min_buffers_open = 2
+        config.cleanup_close_buffers_after = 1
+        janitor.clean_up_buffers!
+
+        assert.equals 2, #app.buffers
+
+        for b in *app.buffers
+          assert.match b.title, 'keep'
+
+      it 'closes buffers in a least-recently-shown order', ->
+        b = app\new_buffer!
+        b.title = 'hour-old'
+        b.last_shown = now - 60 * 60
+
+        b = app\new_buffer!
+        b.title = '15-min-old'
+        b.last_shown = now - 60 * 15
+
+        b = app\new_buffer!
+        b.title = '30-min-old'
+        b.last_shown = now - 60 * 30
+
+        config.cleanup_min_buffers_open = 1
+        config.cleanup_close_buffers_after = 10
+        janitor.clean_up_buffers!
+
+        assert.same {'15-min-old'}, [b.title for b in *app.buffers]


### PR DESCRIPTION
This adds a new module, `janitor`. As the name implies, it's job is to perform some cleaning, which it does automatically in the background when idle.

It currently does two things:

- Automatically closes old buffers

Controlled by two new configuration variables that control how many buffers to keep open and for how long a buffer should have gone without viewing it before closing it. What values to choose for the defaults here are, as always, interesting. 

- Releases memory

It does garbage collection, and if on Linux we force the greedy malloc to release more memory back to the OS.