### PR TITLE
Even *more* C/C++ lexer fixes

### DIFF
--- a/bundles/c/c_lexer.moon
+++ b/bundles/c/c_lexer.moon
@@ -32,19 +32,19 @@ howl.aux.lpeg_lexer ->
 
   classdef = any {
     sequence {
-      c 'keyword', word { 'enum', 'union' }
+      c('keyword', word { 'enum', 'union' })
       ws^1
-      c 'type_def', ident
+      c('type_def', ident)
       ws^0
       c('operator', '{')
     }
     sequence {
-      c 'keyword', word { 'class', 'struct' }
+      c('keyword', word { 'class', 'struct' })
       ws^1
-      c 'type_def', ident
+      c('type_def', ident)
       ws^0
       (((V'all' + P 1) - S':{}=;') + ws)^0
-      c 'operator', S':{'
+      c('operator', S':{')
     }
   }
 

--- a/bundles/c/c_lexer.moon
+++ b/bundles/c/c_lexer.moon
@@ -4,7 +4,7 @@
 howl.aux.lpeg_lexer ->
   c = capture
   ident = (alpha + '_')^1 * (alpha + digit + '_')^0
-  ws = c 'whitespace', blank
+  ws = c 'whitespace', space
 
   identifer = c 'identifer', ident
 
@@ -13,7 +13,7 @@ howl.aux.lpeg_lexer ->
     'alignas', 'alignof', 'and_eq', 'and', 'asm', 'bitand', 'bitor',
     'catch', 'class', 'compl', 'constexpr',
     'const_cast', 'decltype', 'delete', 'dynamic_cast', 'explicit', 'export',
-    'friend', 'mutable', 'namespace', 'new', 'noexcept', 'not_eq',
+    'friend', 'final', 'mutable', 'namespace', 'new', 'noexcept', 'not_eq',
     'not', 'nullptr', 'operator', 'or_eq', 'or', 'private', 'protected',
     'public', 'reinterpret_cast', 'static_assert', 'static_cast', 'template',
     'this', 'thread_local', 'throw', 'try', 'typeid', 'typename',
@@ -30,6 +30,13 @@ howl.aux.lpeg_lexer ->
     'long', 'short', 'unsigned', 'void', 'wchar_t'
   }
 
+  attribute_spec = sequence {
+    c 'operator', '[['
+    c 'special', scan_until ']]'
+    c 'operator', ']]'
+    ws^0
+  }
+
   classdef = any {
     sequence {
       c('keyword', word { 'enum', 'union' })
@@ -41,7 +48,8 @@ howl.aux.lpeg_lexer ->
     sequence {
       c('keyword', word { 'class', 'struct' })
       ws^1
-      c('type_def', ident)
+      attribute_spec^0
+      c('type_def', ident) * (c('operator', P'::') + c('type_def', ident))^0
       ws^0
       (((V'all' + P 1) - S':{}=;') + ws)^0
       c('operator', S':{')

--- a/bundles/c/c_lexer.moon
+++ b/bundles/c/c_lexer.moon
@@ -32,22 +32,23 @@ howl.aux.lpeg_lexer ->
 
   classdef = any {
     sequence {
-      c('keyword', word { 'enum', 'union' })
+      c 'keyword', word { 'enum', 'union' }
       ws^1
-      c('type_def', ident)
+      c 'type_def', ident
       ws^0
       c('operator', '{')
     }
     sequence {
-      c('keyword', word { 'class', 'struct' })
+      c 'keyword', word { 'class', 'struct' }
       ws^1
-      c('type_def', ident)
+      c 'type_def', ident
       ws^0
-      c('operator', S':{')
+      (((V'all' + P 1) - S':{}=;') + ws)^0
+      c 'operator', S':{'
     }
   }
 
-  operator = c 'operator', S('+-*/%=<>~&^|!(){}[];.')
+  operator = c 'operator', S'+-*/%=<>~&^|!(){}[];.,?:'
 
   comment = c 'comment', any {
     P'//' * scan_until eol,
@@ -85,17 +86,21 @@ howl.aux.lpeg_lexer ->
 
   constant = c 'constant', word any('_', upper)^1 * any('_', upper, digit)^0
 
-  any {
-    include_stmt,
-    preproc,
-    comment,
-    string,
-    classdef,
-    type,
-    keyword,
-    special,
-    operator,
-    number,
-    constant,
-    identifer,
+  P {
+    'all'
+
+    all: any {
+      include_stmt,
+      preproc,
+      comment,
+      string,
+      classdef,
+      type,
+      keyword,
+      special,
+      operator,
+      number,
+      constant,
+      identifer,
+    }
   }

--- a/bundles/c/misc/example.c
+++ b/bundles/c/misc/example.c
@@ -103,6 +103,8 @@ struct Abc<1, 2> {};
 class [[a,b,c]] X::Y::Z {};
 class X::Y::Z<A, B> virtual final : B {};
 class [[a,b,c]] [[def]] X::Y::Z virtual : B {};
+class X
+{};
 struct X<A, B> y;
 
 int a = 1, 2 == 2 ? 1 : 0;

--- a/bundles/c/misc/example.c
+++ b/bundles/c/misc/example.c
@@ -100,5 +100,9 @@ static void printcapkind (int kind) {
 
 // C++ template specializations!
 struct Abc<1, 2> {};
+class [[a,b,c]] X::Y::Z {};
+class X::Y::Z<A, B> virtual final : B {};
+class [[a,b,c]] [[def]] X::Y::Z virtual : B {};
+struct X<A, B> y;
 
 int a = 1, 2 == 2 ? 1 : 0;

--- a/bundles/c/misc/example.c
+++ b/bundles/c/misc/example.c
@@ -97,3 +97,8 @@ static void printcapkind (int kind) {
     "runtime", "group"};
   printf("%s", modes[kind]);
 }
+
+// C++ template specializations!
+struct Abc<1, 2> {};
+
+int a = 1, 2 == 2 ? 1 : 0;


### PR DESCRIPTION
This should allow pretty much all C++ types to be properly highlighted.