### PR TITLE
More extensive change()

### DIFF
--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -541,6 +541,12 @@ Buffer = {
     start_line: start_line.nr, end_line: end_line.nr, :invalidated
 
   _on_modification: (type, offset, text, prev_text, size, invalidate_offset, extra) =>
+    lines_changed = text\find('[\n\r]') != nil
+    if not lines_changed and prev_text
+      lines_changed = prev_text\find('[\n\r]') != nil
+
+    @_nr_lines = nil if lines_changed
+
     if @_change_sink
       @_change_sink\add type, offset, size, invalidate_offset
       return
@@ -548,10 +554,6 @@ Buffer = {
     part_of_revision = @revisions.processing
     revision = if not part_of_revision and @_collect_revisions
       @revisions\push(type, offset, text, prev_text)
-
-    lines_changed = text\find('[\n\r]') != nil
-    if not lines_changed and prev_text
-      lines_changed = prev_text\find('[\n\r]') != nil
 
     args = {
       :offset,
@@ -567,8 +569,6 @@ Buffer = {
     if extra
       for k, v in pairs extra
         args[k] = v
-
-    @_nr_lines = nil if lines_changed
 
     if @lexer
       at_line = @get_line_at_offset(offset)

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -233,6 +233,7 @@ Buffer = {
       @notify 'markers_changed', start_offset: markers_start, end_offset: markers_end
 
     error ret unless status
+    ret
 
   lines: (start_line = 1, end_line) =>
     i = start_line - 1

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -43,14 +43,15 @@ LineMt = {
 }
 
 change_sink = (start_offset, count) ->
+  start_roof = start_offset + count - 1
   {
-    roof: start_offset + count - 1
+    roof: start_roof
     changes: {}
     invalidate_offset: nil
     :start_offset
 
     add: (type, offset, size, invalidate_offset) =>
-      if offset < start_offset or (offset != start_offset and offset > @roof)
+      if offset < start_offset or (offset != start_offset and offset > @roof + 1)
         error "Out-of-range modification '#{type}' at #{offset} within change (#{start_offset} -> #{@roof})"
 
       @invalidate_offset or= invalidate_offset
@@ -68,7 +69,8 @@ change_sink = (start_offset, count) ->
 
     can_reenter: (offset, _count) =>
       return false if offset < start_offset
-      return false if offset + _count > max(start_offset + count, @roof)
+      new_roof = offset + _count - 1
+      return false if new_roof > max(start_roof, @roof)
       true
    }
 

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -590,7 +590,9 @@ Buffer = {
     @notify('styled', @_get_styled_notification(start_offset, end_offset))
 
   _on_markers_changed: (_, markers) =>
-    @notify('markers_changed', markers)
+    from_offset = markers[1].start_offset
+    to_offset = markers[#markers].end_offset
+    @notify('markers_changed', :from_offset, :to_offset)
 
 }
 

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -299,6 +299,9 @@ DisplayLine = define_class {
       @_lines
    }
 
+  refresh: =>
+    @_flairs = nil
+
   draw: (x, y, cr, clip, opts = {}) =>
     base_x = @view.base_x
     block = @block

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -529,6 +529,20 @@ describe 'Buffer', ->
       b\undo!
       assert.equal '123456789', b.text
 
+    it 'provides a consistent state during the changes', ->
+      jit.off!
+      b.text = '123456789'
+      assert.equal '123456789', b\get_line(1).text
+      assert.equal 1, b.nr_lines
+
+      b\change 3, 3, (b) -> -- change '345'
+        b\delete 4, 2 -- remove 45
+        assert.equal '1236789', b\get_line(1).text
+        b\insert 4, 'xy'
+        assert.equal '123xy6789', b\get_line_at_offset(1).text
+        b\insert 4, '\n\n'
+        assert.equal 3, b.nr_lines
+
     it 'supports growing changes', ->
       b.text = '123456789'
       b\change 3, 3, (b) -> -- change '345'

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -499,7 +499,7 @@ describe 'Buffer', ->
       assert.same {true, true}, flags
 
   describe 'change(offset, count, f)', ->
-    local b, notified, notified_styled
+    local b, notified, notified_styled, notified_markers
 
     before_each ->
       b = Buffer ''
@@ -510,6 +510,9 @@ describe 'Buffer', ->
 
         on_styled: (_, args) =>
           notified_styled = args
+
+        on_markers_changed: (_, args) =>
+          notified_markers = args
       }
 
       b\add_listener l
@@ -627,6 +630,15 @@ describe 'Buffer', ->
 
       b\undo!
       assert.equal '123456789', b.text
+
+    it 'collapses marker notification into one notification', ->
+      b.text = '123456789'
+      markers = b.markers
+      b\change 1, 9, (b) ->
+        markers\add { {name: 'first', start_offset: 2, end_offset: 4} }
+        markers\add { {name: 'second', start_offset: 6, end_offset: 8} }
+
+      assert.same { start_offset: 2, end_offset: 8 }, notified_markers
 
     describe 'styling notifications', ->
       describe 'when coupled with modifications', ->

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -532,6 +532,13 @@ describe 'Buffer', ->
       b\undo!
       assert.equal '123456789', b.text
 
+    it 'returns the return value of <f> as its own return value', ->
+      b.text = '12345'
+      ret = b\change 1, 3, ->
+        'zed'
+
+      assert.equals 'zed', ret
+
     it 'provides a consistent state during the changes', ->
       jit.off!
       b.text = '123456789'

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -367,6 +367,8 @@ View = {
           -- recreate the display line since subsequent modifications has to
           -- know what the display properties was for the modified lines
           d_lines[line.nr]
+        elseif opts.update
+          d_line\refresh!
 
         min_y or= y
         max_y = y + d_line.height
@@ -696,7 +698,7 @@ View = {
     @refresh_display {
       from_offset: args.start_offset,
       to_offset: args.end_offset,
-      invalidate: true
+      update: true
     }
 
   _on_buffer_undo: (buffer, revision) =>

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -692,10 +692,12 @@ View = {
       if @_first_visible_line > 1 and @lines_showing < lines_showing
         @last_visible_line = @buffer.nr_lines
 
-  _on_buffer_markers_changed: (buffer, markers) =>
-    from_offset = markers[1].start_offset
-    to_offset = markers[#markers].end_offset
-    @refresh_display :from_offset, :to_offset, invalidate: true
+  _on_buffer_markers_changed: (buffer, args) =>
+    @refresh_display {
+      from_offset: args.from_offset,
+      to_offset: args.to_offset,
+      invalidate: true
+    }
 
   _on_buffer_undo: (buffer, revision) =>
     pos = revision.meta.cursor_before or revision.offset

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -694,8 +694,8 @@ View = {
 
   _on_buffer_markers_changed: (buffer, args) =>
     @refresh_display {
-      from_offset: args.from_offset,
-      to_offset: args.to_offset,
+      from_offset: args.start_offset,
+      to_offset: args.end_offset,
       invalidate: true
     }
 

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -43,7 +43,6 @@ class Buffer extends PropertyObject
     @properties = {}
     @data = {}
     @read_only = false
-    @_len = nil
     @_eol = '\n'
     @viewers = 0
     @_modified = false
@@ -313,7 +312,6 @@ class Buffer extends PropertyObject
     @_on_buffer_modification 'text-changed', args
 
   _on_buffer_modification: (what, args) =>
-    @_len = nil
     @_modified = true
     args = {
       buffer: self,

--- a/lib/howl/ui/action_buffer.moon
+++ b/lib/howl/ui/action_buffer.moon
@@ -15,10 +15,11 @@ class ActionBuffer extends Buffer
     if object.styles
       pos_after = @_insert_styled_object(object, pos)
     else
-      pos_after = super object, pos
+      @change pos, pos, ->
+        pos_after = super object, pos
 
-      if style_name
-        @style pos, pos_after - 1, style_name
+        if style_name
+          @style pos, pos_after - 1, style_name
 
     pos_after
 
@@ -28,10 +29,11 @@ class ActionBuffer extends Buffer
     if object.styles
       pos_after = @_insert_styled_object(object, @length + 1)
     else
-      pos_after = super object
+      @change start_pos, start_pos, ->
+        pos_after = super object
 
-      if style_name
-        @style start_pos + 1, @length, style_name
+        if style_name
+          @style start_pos + 1, @length, style_name
 
     pos_after
 
@@ -41,9 +43,10 @@ class ActionBuffer extends Buffer
     @_buffer.styling\set start_pos, end_pos - 1, style_name
 
   _insert_styled_object: (object, pos) =>
-    pos_after = super\insert object.text, pos
-    b_start = @byte_offset pos
-    @_buffer.styling\apply b_start, object.styles
-    pos_after
+    @change pos, pos, ->
+      pos_after = super\insert object.text, pos
+      b_start = @byte_offset pos
+      @_buffer.styling\apply b_start, object.styles
+      pos_after
 
 return ActionBuffer

--- a/lib/howl/ui/list_widget.moon
+++ b/lib/howl/ui/list_widget.moon
@@ -81,27 +81,29 @@ class ListWidget extends PropertyObject
     get: => #@_columns
 
   _write_page: =>
-    @text_widget.buffer.text = ''
-    @page_size = @text_widget.visible_rows - (@has_status and 1 or 0) - (@has_header and 1 or 0)
-    if @has_items and @page_size < 1
-      error 'insufficient height - cant display any items'
+    @text_widget.buffer\change 1, @text_widget.buffer.size, (buffer) ->
+      buffer.text = ''
+      @page_size = @text_widget.visible_rows - (@has_status and 1 or 0) - (@has_header and 1 or 0)
+      if @has_items and @page_size < 1
+        error 'insufficient height - cant display any items'
 
-    items = {}
-    last_idx = @page_start_idx + @page_size - 1
-    for idx = @page_start_idx, min(last_idx, #@_items)
-      append items, @_items[idx]
+      items = {}
+      last_idx = @page_start_idx + @page_size - 1
+      for idx = @page_start_idx, min(last_idx, #@_items)
+        append items, @_items[idx]
 
-    @text_widget.buffer\append StyledText.for_table items, @columns
+      buffer\append StyledText.for_table items, @columns
 
-    for i = 1, last_idx - #@_items
-      @text_widget.buffer\append @opts.filler_text..'\n', 'comment'
+      for i = 1, last_idx - #@_items
+        buffer\append @opts.filler_text..'\n', 'comment'
 
-    header_offset = @has_header and 1 or 0
-    for lno = 1, #items
-      line = @text_widget.buffer.lines[lno + header_offset]
-      @_highlight_matches line.text, line.start_pos
+      header_offset = @has_header and 1 or 0
+      for lno = 1, #items
+        line = buffer.lines[lno + header_offset]
+        @_highlight_matches line.text, line.start_pos
 
-    @_write_status!
+      @_write_status!
+
     @text_widget.view.first_visible_line = 1
     @text_widget\adjust_height!
 

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -208,7 +208,7 @@ describe 'Buffer', ->
       b = buffer 'hello\nworld\n'
       assert.equal 1, b\replace('world', 'editor')
 
-  describe 'change(start_pos, end_pos)', ->
+  describe 'change(start_pos, end_pos, f)', ->
     it 'applies all operations as one undo for the specified region', ->
       b = buffer 'ño señor'
       b\change 4, 6, -> -- 'señ'
@@ -218,6 +218,13 @@ describe 'Buffer', ->
       assert.equal 'ño minminor', b.text
       b\undo!
       assert.equal 'ño señor', b.text
+
+    it 'returns the return value of <f> as its own return value', ->
+      b = buffer '12345'
+      ret = b\change 1, 3, ->
+        'zed'
+
+      assert.equals 'zed', ret
 
   it 'undo undoes the last operation', ->
     b = buffer 'hello'

--- a/spec/ui/action_buffer_spec.moon
+++ b/spec/ui/action_buffer_spec.moon
@@ -124,7 +124,7 @@ describe 'ActionBuffer', ->
       assert.is_nil buffers[1]
 
     it 'memory usage is stable', ->
-      assert_memory_stays_within '15Kb', 30, ->
+      assert_memory_stays_within '20Kb', 50, ->
         b = ActionBuffer!
         b.text = 'collect me!'
 


### PR DESCRIPTION
This is a performance/efficiency improvement. The major theme is to extend the `change()` operation introduced a while ago. The original `change` collapsed buffer modifications notification into one single notification, with great results for larger operations such indenting large blocks of code.

This takes it further by also collecting and collapsing styling and marker changes, which makes it possible to optimize batch changes for text based interface buffers. This PR does just that for the ListWidget, where the write_page now writes everything in one change. 

Since I was primarily interested in reducing memory pressure I measured that, and the re-allocation of display lines is cut by approximately a third e.g. when interacting with `project-open`. From a performance perspective this also cuts down a lot on unnecessary display refreshes, which makes things snappier, although it was pretty snappy already.

This also optimizes marker invalidations to not re-allocate display lines but instead just refresh flairs  (which in extension means snappier refreshes of Howl highlights). 