### PR TITLE
Change early-exit behaviour in signal emission to be explicit

### DIFF
--- a/lib/howl/bindings.moon
+++ b/lib/howl/bindings.moon
@@ -186,7 +186,8 @@ export process = (event, source, extra_keymaps = {},  ...) ->
   event = substitute_keyname event
   translations = translate_key event
   return true if process_capture event, source, translations, ...
-  return true if signal.emit 'key-press', :event, :source, :translations, parameters: {...}
+  signal_says = signal.emit 'key-press', :event, :source, :translations, parameters: {...}
+  return true if signal_says == 'abort'
 
   maps = {}
   append maps, map for map in *extra_keymaps

--- a/lib/howl/bindings.moon
+++ b/lib/howl/bindings.moon
@@ -186,8 +186,8 @@ export process = (event, source, extra_keymaps = {},  ...) ->
   event = substitute_keyname event
   translations = translate_key event
   return true if process_capture event, source, translations, ...
-  signal_says = signal.emit 'key-press', :event, :source, :translations, parameters: {...}
-  return true if signal_says == 'abort'
+  emit_result = signal.emit 'key-press', :event, :source, :translations, parameters: {...}
+  return true if emit_result == signal.abort
 
   maps = {}
   append maps, map for map in *extra_keymaps

--- a/lib/howl/signal.moon
+++ b/lib/howl/signal.moon
@@ -4,6 +4,7 @@
 handlers = {}
 all = {}
 append = table.insert
+abort = {}
 
 register = (name, options = {}) ->
   error "Missing field 'description'", 2 unless options.description
@@ -27,8 +28,8 @@ emit = (name, params, illegal) ->
     status, ret = coroutine.resume co, params
 
     if status
-      if ret == 'abort' and coroutine.status(co) == 'dead'
-        return 'abort'
+      if ret == abort and coroutine.status(co) == 'dead'
+        return abort
     else
       _G.log.error 'Error invoking handler for "' .. name .. '": ' .. ret
 
@@ -45,4 +46,4 @@ connect = (name, handler, index) ->
 disconnect = (name, handler) ->
   handlers[name] = [h for h in *handlers_for name when h != handler]
 
-return :register, :unregister, :emit, :connect, :disconnect, :all
+return :abort, :register, :unregister, :emit, :connect, :disconnect, :all

--- a/lib/howl/signal.moon
+++ b/lib/howl/signal.moon
@@ -27,7 +27,8 @@ emit = (name, params, illegal) ->
     status, ret = coroutine.resume co, params
 
     if status
-      return true if ret == true and coroutine.status(co) == 'dead'
+      if ret == 'abort' and coroutine.status(co) == 'dead'
+        return 'abort'
     else
       _G.log.error 'Error invoking handler for "' .. name .. '": ' .. ret
 

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -742,7 +742,7 @@ class Editor extends PropertyObject
   _on_insert_at_cursor: (_, args) =>
     params = moon.copy args
     params.editor = self
-    return if signal.emit('insert-at-cursor', params) == 'abort'
+    return if signal.emit('insert-at-cursor', params) == signal.abort
     return if @buffer.mode.on_insert_at_cursor and @buffer.mode\on_insert_at_cursor(params, self)
 
     if @popup

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -742,7 +742,7 @@ class Editor extends PropertyObject
   _on_insert_at_cursor: (_, args) =>
     params = moon.copy args
     params.editor = self
-    return if signal.emit 'insert-at-cursor', params
+    return if signal.emit('insert-at-cursor', params) == 'abort'
     return if @buffer.mode.on_insert_at_cursor and @buffer.mode\on_insert_at_cursor(params, self)
 
     if @popup

--- a/site/source/doc/api/signal.md
+++ b/site/source/doc/api/signal.md
@@ -9,12 +9,12 @@ title: howl.signal
 Signals provide a way of sending and receiving notifications about various
 events that happens within Howl. For example, there are signals emitted whenever
 text is added or deleted in a buffer, or a key is pressed in Howl, etc. By
-"connecting" a handler for signal, you can easily hook into the ordinary workings
-to add your own additional functionality. Signals are defined by their name, and
-each signal can provide additional information about the event as parameters.
-Each signal can have multiple handlers connected at a given time, which will all
-be invoked, provided a handler does not explicitly halt the processing (see
-[emit](#emit) for more information).
+"connecting" a handler for signal, you can easily hook into the ordinary
+workings to add your own additional functionality. Signals are defined by their
+name, and each signal can provide additional information about the event as
+parameters. Each signal can have multiple handlers connected at a given time,
+which will all be invoked, provided a handler does not explicitly halt the
+processing (see [emit](#emit) for more information).
 
 To view the list of currently registered signals within Howl as well as
 information about the parameters you can use the `describe-signal` command.
@@ -24,6 +24,11 @@ _See also_:
 - The [spec](../spec/signal_spec.html) for signal
 
 ## Properties
+
+### .abort
+
+A sentinel value used for causing an early exit during signal dispatch (see
+[emit](#emit) for more information).
 
 ### .all
 
@@ -56,9 +61,10 @@ keys matching those of the parameters specified for [register](#register). An
 error is raised when trying to emit a signal that has not been registered.
 
 When a signal is emitted each connected handler is invoked in turn, with
-`parameters` as the sole argument. Should any handler return `'abort'`, the
-processing is halted and `emit` returns `'abort'`. Otherwise, `false` is returned.
-Any error triggered in a signal handler is logged, and processing continues.
+`parameters` as the sole argument. Should any handler return `signal.abort`, the
+processing is halted and `emit` in turn returns `signal.abort`. Otherwise,
+`false` is returned. Any error triggered in a signal handler is logged, and
+processing continues.
 
 ### register (name, options)
 

--- a/site/source/doc/api/signal.md
+++ b/site/source/doc/api/signal.md
@@ -39,7 +39,7 @@ Connects `handler` to the signal specified by `name`. The optional `index`
 argument specifies where in the handler list the handler should be placed. All
 handlers for a specific signal are stored in a list, and the index specifies the
 order in which they are invoked whenever a signal is emitted, where the handler
-with index 1 is invoked first, followed by the handlers with greater indices.
+with index 1 is invoked first, followed by handlers with greater indices.
 
 An error is raised when trying to connect a handler for a signal that has not
 been registered.
@@ -56,8 +56,8 @@ keys matching those of the parameters specified for [register](#register). An
 error is raised when trying to emit a signal that has not been registered.
 
 When a signal is emitted each connected handler is invoked in turn, with
-`parameters` as the sole argument. Should any handler return `true`, the
-processing is halted and `emit` returns `true`. Otherwise, `false` is returned.
+`parameters` as the sole argument. Should any handler return `'abort'`, the
+processing is halted and `emit` returns `'abort'`. Otherwise, `false` is returned.
 Any error triggered in a signal handler is logged, and processing continues.
 
 ### register (name, options)

--- a/spec/bindings_spec.moon
+++ b/spec/bindings_spec.moon
@@ -121,9 +121,9 @@ describe 'bindings', ->
             parameters: { 'yowser' }
           }
 
-      it 'returns early with true if the handler does', ->
+      it 'returns early with true if some handler says to abort', ->
         keymap = A: spy.new -> true
-        with_signal_handler 'key-press', true, (handler) ->
+        with_signal_handler 'key-press', 'abort', (handler) ->
           status, ret = pcall bindings.process, { character: 'A', key_name: 'A', key_code: 65 }, 'editor', { keymap }
           assert.spy(handler).was.called!
           assert.spy(keymap.A).was.not_called!

--- a/spec/bindings_spec.moon
+++ b/spec/bindings_spec.moon
@@ -123,13 +123,13 @@ describe 'bindings', ->
 
       it 'returns early with true if some handler says to abort', ->
         keymap = A: spy.new -> true
-        with_signal_handler 'key-press', 'abort', (handler) ->
+        with_signal_handler 'key-press', signal.abort, (handler) ->
           status, ret = pcall bindings.process, { character: 'A', key_name: 'A', key_code: 65 }, 'editor', { keymap }
           assert.spy(handler).was.called!
           assert.spy(keymap.A).was.not_called!
           assert.is_true ret
 
-      it 'continues processing keymaps if the handler returns false', ->
+      it 'continues processing keymaps unless aborted', ->
         keymap = A: spy.new -> true
         with_signal_handler 'key-press', false, (handler) ->
           status, ret = pcall bindings.process, { character: 'A', key_name: 'A', key_code: 65 }, 'editor', { keymap }

--- a/spec/signal_spec.moon
+++ b/spec/signal_spec.moon
@@ -56,17 +56,17 @@ describe 'signal', ->
       it 'raises an error when the second parameter is not a table', ->
         assert.raises 'table', -> signal.emit 'foo', 2
 
-      context 'when a handler returns true', ->
+      context 'when a handler returns "abort"', ->
         it 'skips invoking subsequent handlers', ->
           handler2 = spy.new -> true
-          signal.connect 'foo', -> true
+          signal.connect 'foo', -> 'abort'
           signal.connect 'foo', handler2
           signal.emit 'foo'
           assert.spy(handler2).was.not_called!
 
-        it 'returns true', ->
-          signal.connect 'foo', -> true
-          assert.is_true signal.emit 'foo'
+        it 'returns "abort"', ->
+          signal.connect 'foo', -> 'abort'
+          assert.equals 'abort', signal.emit 'foo'
 
       context 'when a handler raises an error', ->
         it 'logs an error message', ->

--- a/spec/signal_spec.moon
+++ b/spec/signal_spec.moon
@@ -56,17 +56,17 @@ describe 'signal', ->
       it 'raises an error when the second parameter is not a table', ->
         assert.raises 'table', -> signal.emit 'foo', 2
 
-      context 'when a handler returns "abort"', ->
+      context 'when a handler returns .abort', ->
         it 'skips invoking subsequent handlers', ->
           handler2 = spy.new -> true
-          signal.connect 'foo', -> 'abort'
+          signal.connect 'foo', -> signal.abort
           signal.connect 'foo', handler2
           signal.emit 'foo'
           assert.spy(handler2).was.not_called!
 
-        it 'returns "abort"', ->
-          signal.connect 'foo', -> 'abort'
-          assert.equals 'abort', signal.emit 'foo'
+        it 'returns .abort', ->
+          signal.connect 'foo', -> signal.abort
+          assert.equals signal.abort, signal.emit 'foo'
 
       context 'when a handler raises an error', ->
         it 'logs an error message', ->

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -675,6 +675,6 @@ describe 'Editor', ->
     it 'memory usage is stable', ->
       pinned = Editor Buffer!
 
-      assert_memory_stays_within '40Kb', 20, ->
+      assert_memory_stays_within '40Kb', 30, ->
         e = Editor Buffer!
         e\to_gobject!\destroy!


### PR DESCRIPTION
The `signal` module is one of the earliest modules written, and it was written from day one with an early-exit mechanism based on boolean values from signal handlers. This might have worked out fine if Lua had been used, but since we're using moonscript with its implicit returns it ended up a giant mistake, which makes it all to easy for signals to lost due to some implicit return somewhere.

The early-exit option is retained, but is now rather explicit due to the use of a required string return value instead.