### PR TITLE
Rework buffer titles in `switch-buffer` list

### DIFF
--- a/lib/howl/interactions/buffer_selection.moon
+++ b/lib/howl/interactions/buffer_selection.moon
@@ -1,8 +1,11 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-import app, interact from howl
+import app, interact, Project from howl
+import File from howl.io
 import Matcher from howl.util
+
+append = table.insert
 
 buffer_dir = (buffer) ->
   buffer.file and tostring(buffer.file.parent.short_path) or '(none)'
@@ -12,9 +15,59 @@ buffer_status = (buffer) ->
   stat ..= '[modified on disk]' if buffer.modified_on_disk
   stat
 
-get_buffers = (txt) ->
-  m = Matcher [{buffer.title, buffer_status(buffer), buffer_dir(buffer), :buffer} for buffer in *app.buffers]
-  return m(txt)
+
+make_title = (buffer, opts={}) ->
+  file = buffer.file
+  title = file.basename
+  if opts.parents
+    parent = file.parent
+    for i=1,opts.parents
+      if parent
+        title = "#{parent.basename}#{File.separator}#{title}"
+        parent = parent.parent
+      else
+        break
+
+  if opts.project
+    project = Project.for_file file
+    if project
+      title = "#{title} [#{project.root.basename}]"
+
+  return title
+
+has_duplicates = (list) ->
+  set = {}
+  for item in *list
+    return true if set[item]
+    set[item] = true
+  return false
+
+get_buffer_list = ->
+  basenames = {}
+  enhanced_titles = {}
+
+  for buf in *app.buffers
+    continue unless buf.file and buf.file.basename == buf.title
+    basenames[buf.file.basename] or= {}
+    append basenames[buf.file.basename], buf
+
+  for basename, buffers in pairs(basenames)
+    continue if #buffers == 1
+
+    titles = [make_title(buffer, project:true) for buffer in *buffers]
+    if has_duplicates(titles)
+      titles = [make_title(buffer, project:true, parents:1) for buffer in *buffers]
+      if has_duplicates(titles)
+        titles = [make_title(buffer, project:true, parents:2) for buffer in *buffers]
+
+    for i=1,#buffers
+      enhanced_titles[buffers[i]] = titles[i]
+
+  return [{enhanced_titles[buffer] or buffer.title, buffer_status(buffer), buffer_dir(buffer), :buffer} for buffer in *app.buffers]
+
+buffer_matcher = (text) ->
+  matcher = Matcher get_buffer_list!
+  return matcher(text)
 
 interact.register
   name: 'select_buffer'
@@ -23,7 +76,7 @@ interact.register
     opts = moon.copy opts
     with opts
       .title or= 'Buffers'
-      .matcher = get_buffers
+      .matcher = buffer_matcher
       .columns = {
         {style: 'string'}
         {style: 'operator'}

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -551,47 +551,17 @@ describe 'Buffer', ->
       b\remove_view_ref!
       assert.equal 0, b.viewers
 
-  describe 'ensuring that buffer titles are globally unique', ->
-    context 'when setting a file for a buffer', ->
-      it 'prepends to the title as many parent directories as needed for uniqueness', ->
-        b1 = Buffer {}
-        b2 = Buffer {}
-        b3 = Buffer {}
-        with_tmpdir (dir) ->
-          sub1 = dir\join('sub1')
-          sub1\mkdir!
-          sub2 = dir\join('sub2')
-          sub2\mkdir!
-          f1 = sub1\join('file.foo')
-          f2 = sub2\join('file.foo')
-          f1\touch!
-          f2\touch!
-          b1.file = f1
-          b2.file = f2
-          assert.equal b2.title, 'sub2' .. File.separator .. 'file.foo'
+  describe 'titles', ->
+    it 'uses file basename as the default title', ->
+      b = Buffer {}
+      b.file = File('/path/to/file.ext')
+      assert.equal b.title, 'file.ext'
 
-          sub_sub = sub1\join('sub2')
-          sub_sub\mkdir!
-          f3 = sub_sub\join('file.foo')
-          f3\touch!
-          b3.file = f3
-          assert.equal b3.title, 'sub1' .. File.separator .. b2.title
-
-      it 'does not unneccesarily transform the title when setting the same file for a buffer', ->
-        b = Buffer!
-        with_tmpfile (file) ->
-          b.file = file
-          title = b.title
-          b.file = file
-          assert.equal title, b.title
-
-    context 'when setting the title explicitly', ->
-      it 'appends a counter number in the format <number> to the title', ->
-        b1 = Buffer {}
-        b2 = Buffer {}
-        b1.title = 'Title'
-        b2.title = 'Title'
-        assert.equal b2.title, 'Title<2>'
+    it 'setting title explicitly overrides default title', ->
+      b = Buffer {}
+      b.file = File('/path/to/file.ext')
+      b.title = 'be something else'
+      assert.equal b.title, 'be something else'
 
   describe 'signals', ->
     it 'buffer-saved is fired whenever a buffer is saved', ->

--- a/spec/interactions/buffer_selection_spec.moon
+++ b/spec/interactions/buffer_selection_spec.moon
@@ -103,7 +103,8 @@ describe 'buffer_selection', ->
 
         paths = {'/project1/some/file1', '/project2/some/file1', '/project2/path1/file2', '/project2/path2/file2'}
         for path in *paths
-          app\open_file File path
+          b = app\new_buffer!
+          b.file = File path
 
         Project.add_root File '/project1'
         Project.add_root File '/project2'

--- a/spec/project_spec.moon
+++ b/spec/project_spec.moon
@@ -2,6 +2,9 @@ import Project, VC from howl
 import File from howl.io
 
 describe 'Project', ->
+  before_each ->
+    Project.roots = {}
+
   after_each ->
     Project.roots = {}
     Project.open = {}


### PR DESCRIPTION
- Removed title counters
- Default title is always basename
- Title unique-ification moved to switch-buffer command
- Unique-ification uses project name and parent directory name up to two levels

This also removes any counters and directory prefixes from the header bar of the editor - only the basename is displayed when viewing a file.