### PR TITLE
Added howl.sys.time for high resolution time

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased (in master)
 
+- Added a new function `sys.time()` which returns the POSIX time for the system
+  with microsecond resolution.
+
 - Added a new module, 'janitor', which automatically closes old buffers and
 tries to release memory back to the OS. The buffer closing is controlled by two
 new configuration variables, `cleanup_min_buffers_open` and

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -1,7 +1,7 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-import BufferContext, BufferLines, BufferMarkers, Chunk, config, signal from howl
+import BufferContext, BufferLines, BufferMarkers, Chunk, config, signal, sys from howl
 import File from howl.io
 import style from howl.ui
 import PropertyObject from howl.aux.moon
@@ -129,7 +129,7 @@ class Buffer extends PropertyObject
   @property showing: get: => @viewers > 0
 
   @property last_shown:
-    get: => @viewers > 0 and os.time! or @_last_shown
+    get: => @viewers > 0 and sys.time! or @_last_shown
     set: (timestamp) => @_last_shown = timestamp
 
   @property multibyte: get: =>

--- a/lib/howl/janitor.moon
+++ b/lib/howl/janitor.moon
@@ -40,7 +40,7 @@ clean_up_buffers = ->
   bufs = app.buffers
   to_remove = #bufs - config.cleanup_min_buffers_open
   return if to_remove <= 0
-  now = os.time!
+  now = sys.time!
   closeable = {}
 
   for b in *bufs

--- a/lib/howl/sys.moon
+++ b/lib/howl/sys.moon
@@ -24,9 +24,13 @@ find_executable = (name) ->
     if exe.exists and not exe.is_directory
       return exe.path
 
+
+time = -> glib.get_real_time! / 1000000
+
 {
   :env,
   :find_executable
+  :time,
   info: {
     os: jit.os\lower!
   }

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -5,7 +5,7 @@ Gdk = require 'ljglibs.gdk'
 Gtk = require 'ljglibs.gtk'
 aullar = require 'aullar'
 gobject_signal = require 'ljglibs.gobject.signal'
-import Completer, signal, bindings, config, command, clipboard from howl
+import Completer, signal, bindings, config, command, clipboard, sys from howl
 import View from aullar
 aullar_config = aullar.config
 import PropertyObject from howl.aux.moon
@@ -556,7 +556,7 @@ class Editor extends PropertyObject
       @_buf.properties.line_at_top = @line_at_top
       @_buf\remove_view_ref @view
       unless @_is_previewing
-        @_buf.last_shown = os.time!
+        @_buf.last_shown = sys.time!
 
     @_is_previewing = opts.preview
     prev_buffer = @_buf
@@ -635,7 +635,7 @@ class Editor extends PropertyObject
     @buffer\remove_view_ref!
     @completion_popup\destroy!
     @view\destroy!
-    @buffer.last_shown = os.time! unless @_is_previewing
+    @buffer.last_shown = sys.time! unless @_is_previewing
     signal.emit 'editor-destroyed', editor: self
 
   _on_key_press: (view, event) =>

--- a/lib/ljglibs/cdefs/glib.moon
+++ b/lib/ljglibs/cdefs/glib.moon
@@ -282,4 +282,6 @@ ffi.cdef [[
 
   gint64 g_get_monotonic_time (void);
 
+  gint64 g_get_real_time (void);
+
 ]]

--- a/lib/ljglibs/glib/init.moon
+++ b/lib/ljglibs/glib/init.moon
@@ -111,4 +111,6 @@ core.auto_loading 'glib', {
 
   get_monotonic_time: -> tonumber C.g_get_monotonic_time!
 
+  get_real_time: -> tonumber C.g_get_real_time!
+
 }

--- a/site/source/doc/api/sys.md
+++ b/site/source/doc/api/sys.md
@@ -33,3 +33,11 @@ for k,v in pairs(env) do
   print(k .. '=' .. v)
 end
 ```
+
+## Functions
+
+### time
+
+Returns the current system time as seconds since the [POSIX
+epoch](https://en.wikipedia.org/wiki/Unix_time). The returned float value has
+microsecond resolution.

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -1,7 +1,7 @@
 Gtk = require 'ljglibs.gtk'
 append = table.insert
 
-{:Buffer, :config, :signal, :clipboard} = howl
+{:Buffer, :config, :signal, :clipboard, :sys} = howl
 {:Editor} = howl.ui
 
 describe 'Editor', ->
@@ -293,12 +293,12 @@ describe 'Editor', ->
       assert.equal 15, cursor.pos
 
     it 'updates .last_shown for buffer switched out', ->
-      time = os.time
+      time =  sys.time
       now = time!
-      os.time = -> now
+      sys.time = -> now
       pcall ->
         editor.buffer = Buffer {}
-      os.time = time
+      sys.time = time
       assert.same now, buffer.last_shown
 
   context 'previewing', ->
@@ -310,12 +310,12 @@ describe 'Editor', ->
       assert.same 2, new_buffer.last_shown
 
     it 'updates .last_shown for original buffer switched out', ->
-      time = os.time
+      time = sys.time
       now = time!
-      os.time = -> now
+      sys.time = -> now
       pcall ->
         editor\preview Buffer {}
-      os.time = time
+      sys.time= time
       assert.same now, buffer.last_shown
 
   context 'indentation, tabs, spaces and backspace', ->


### PR DESCRIPTION
- uses g_get_real_time for microsecond resolution
- returns time as seconds (float) so comparable with os.time

Replaced use of os.time with sys.time