### PR TITLE
Moved directory from process buffer title to directory column

### DIFF
--- a/lib/howl/interactions/buffer_selection.moon
+++ b/lib/howl/interactions/buffer_selection.moon
@@ -8,7 +8,11 @@ import Matcher from howl.util
 append = table.insert
 
 buffer_dir = (buffer) ->
-  buffer.file and tostring(buffer.file.parent.short_path) or '(none)'
+  if buffer.file
+    return buffer.file.parent.short_path
+  elseif buffer.directory
+    return buffer.directory.short_path
+  return '(none)'
 
 buffer_status = (buffer) ->
   stat = if buffer.modified then '*' else ''

--- a/lib/howl/ui/process_buffer.moon
+++ b/lib/howl/ui/process_buffer.moon
@@ -76,7 +76,7 @@ class ProcessBuffer extends ActionBuffer
     @read_only = true
     @activity = command_activity @process
     @directory = @process.working_directory
-    @title = "[#{@directory.short_path}]$ #{@process.command_line} (running)"
+    @title = "$ #{@process.command_line} (running)"
     @mode = mode.by_name 'process'
 
     @append '[', 'operator'
@@ -115,7 +115,7 @@ class ProcessBuffer extends ActionBuffer
       @append(read, 'error') if read and not @destroyed
 
     @process\pump on_stdout, on_stderr
-    @title = "[#{@directory.short_path}]$ #{@process.command_line} (done)"
+    @title = "$ #{@process.command_line} (done)"
 
     unless @destroyed
       @append '\n' unless @lines[#@lines].is_blank


### PR DESCRIPTION
Process buffer titles in the `switch-buffer` command can really blow up the width of the first column if the directory is deep. This moves the directory from the first 'title' column to the second column, also making it consistent with where the file buffer directories are shown.