### PR TITLE
Keymap changes for #112

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -55,6 +55,10 @@ code-named `aullar`.
 - The `howl-moon-eval` command was improved by automatically adjusting the
 indentation levels to work as a stand-alone code chunk.
 
+### Keymap changes
+
+- Changed `ctrl_w` to run `buffer-close` instead of `view-close`. Added `ctrl_shift_w` for `view-close`.
+
 ### Bugs fixed
 
 - Issues as seen on [Github](https://github.com/howl-editor/howl/issues?utf8=%E2%9C%93&q=created%3A%3E2015-09-02+state%3Aclosed++type%3Aissue)

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -27,6 +27,10 @@
     shift_end:        'cursor-line-end-extend'
     home:             'cursor-home'
     shift_home:       'cursor-home-extend'
+    ctrl_home:        'cursor-start'
+    ctrl_shift_home:  'cursor-start-extend'
+    ctrl_end:         'cursor-eof'
+    ctrl_shift_end:   'cursor-eof-extend'
 
     ctrl_b:           'switch-buffer'
     ctrl_c:           'editor-copy'

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -166,7 +166,7 @@
       meta_shift_r:     'project-exec'
       meta_shift_b:     'project-build'
 
-      meta_shift_w:           'view-close'
+      meta_shift_w:     'view-close'
       'meta_-':         'zoom-out'
       'meta_+':         'zoom-in'
 

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -40,6 +40,7 @@
     ctrl_k:           'editor-delete-to-end-of-line'
     ctrl_shift_k:     'editor-delete-line'
     ctrl_n:           'new-buffer'
+    ctrl_w:           'buffer-close'
     ctrl_shift_i:     'editor-indent-all'
     ctrl_h:           'buffer-replace'
     ctrl_s:           'save'
@@ -87,7 +88,7 @@
   ctrl_alt_r:       'project-exec'
   ctrl_shift_b:     'project-build'
 
-  ctrl_w:           'view-close'
+  ctrl_shift_w:     'view-close'
   'ctrl_-':         'zoom-out'
   'ctrl_+':         'zoom-in'
 
@@ -122,6 +123,7 @@
         meta_shift_i:     'editor-indent-all'
         meta_h:           'buffer-replace'
         meta_n:           'new-buffer'
+        meta_w:           'buffer-close'
         meta_s:           'save'
         meta_shift_s:     'save-as'
         meta_v:           'editor-paste'
@@ -160,7 +162,7 @@
       meta_shift_r:     'project-exec'
       meta_shift_b:     'project-build'
 
-      meta_w:           'view-close'
+      meta_shift_w:           'view-close'
       'meta_-':         'zoom-out'
       'meta_+':         'zoom-in'
 


### PR DESCRIPTION
- Changed `ctrl_w` to run `buffer-close` not `view-close`. Added `ctrl_shift_w` for `view-close`.
- Added `ctrl_[shift_](home|end)` bindings for moving cursor to start or end of buffer, optionally extending selection.

This fixes #112.