### PR TITLE
Add some more extensions and filenames for ruby mode.

### DIFF
--- a/bundles/ruby/init.moon
+++ b/bundles/ruby/init.moon
@@ -9,9 +9,16 @@ mode_reg =
     'rb',
     'rbw',
     'gemspec',
-    'builder'
+    'builder',
+    'thor',
+    'jbuilder',
+    'podspec',
+    'rabl'
   }
-  patterns: { 'Rakefile$', 'Gemfile$', 'Guardfile$', 'Capfile$'  }
+  patterns: {
+    'Rakefile$', 'Gemfile$', 'Guardfile$', 'Capfile$',
+    'Cheffile$', 'Thorfile$', 'Podfile$', 'config.ru$', 'Vagrantfile$'
+  }
   shebangs: '[/ ]ruby.*$'
   create: -> bundle_load('ruby_mode')
 


### PR DESCRIPTION
Small change. Was looking for .jbuilder files to use ruby mode. Thought I'd add a few other common ones at the same time (inspired by the list in sublime).