### PR TITLE
Add editor-{copy,cut}-current to copy/cut the selection or otherwise current line

### DIFF
--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -1002,8 +1002,8 @@ for cmd_spec in *{
   { 'scroll-up', 'Scrolls one line up', 'scroll_up' }
   { 'scroll-down', 'Scrolls one line down', 'scroll_down' }
   { 'duplicate-current', 'Duplicates the selection or current line', 'duplicate_current' }
-  { 'cut', 'Cut the selection or current line to the clipboard', 'cut' }
-  { 'copy', 'Copy the selection or current line to the clipboard', 'copy' }
+  { 'cut', 'Cuts the selection or current line to the clipboard', 'cut' }
+  { 'copy', 'Copies the selection or current line to the clipboard', 'copy' }
   { 'cycle-case', 'Changes case for current word or selection', 'cycle_case' }
 }
   args = { select 4, table.unpack cmd_spec }

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -470,6 +470,19 @@ class Editor extends PropertyObject
       @buffer\insert @selection.text, max(anchor, cursor)
       @selection\set anchor, cursor
 
+  cut: =>
+    if @selection.empty
+      clipboard.push text: @current_line.text, whole_lines: true
+      @buffer.lines[@cursor.line] = nil
+    else
+      @selection\cut!
+
+  copy: =>
+    if @selection.empty
+      clipboard.push text: @current_line.text, whole_lines: true
+    else
+      @selection\copy!
+
   cycle_case: =>
     _capitalize = (word) ->
       word\usub(1, 1).uupper .. word\usub(2).ulower
@@ -989,6 +1002,8 @@ for cmd_spec in *{
   { 'scroll-up', 'Scrolls one line up', 'scroll_up' }
   { 'scroll-down', 'Scrolls one line down', 'scroll_down' }
   { 'duplicate-current', 'Duplicates the selection or current line', 'duplicate_current' }
+  { 'cut', 'Cut the selection or current line to the clipboard', 'cut' }
+  { 'copy', 'Copy the selection or current line to the clipboard', 'copy' }
   { 'cycle-case', 'Changes case for current word or selection', 'cycle_case' }
 }
   args = { select 4, table.unpack cmd_spec }
@@ -998,8 +1013,6 @@ for cmd_spec in *{
     handler: -> howl.app.editor[cmd_spec[3]] howl.app.editor, table.unpack args
 
 for sel_cmd_spec in *{
-  { 'copy', 'Copies the current selection to the clipboard' }
-  { 'cut', 'Cuts the current selection to the clipboard' }
   { 'select-all', 'Selects all text' }
 }
   command.register

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -676,6 +676,58 @@ describe 'Editor', ->
         editor\duplicate_current!
         assert.equals 'hello\nhello\nwörld', buffer.text
 
+  describe 'cut', ->
+    context 'with an active selection', ->
+      it 'cuts the selection', ->
+        buffer.text = 'hello\nwörld'
+        cursor.pos = 2
+        selection\set 2, 5 -- 'ell'
+        editor\cut!
+        assert.equals 'ho\nwörld', buffer.text
+        cursor.pos = 1
+        editor\paste!
+        assert.equal 'ellho\nwörld', buffer.text
+
+    context 'with no active selection', ->
+      it 'cuts the current line', ->
+        buffer.text = 'hello\nwörld'
+        cursor.pos = 3
+        editor\cut!
+        assert.equals 'wörld', buffer.text
+        cursor.pos = 1
+        editor\paste!
+        assert.equal 'hello\nwörld', buffer.text
+
+      it 'cuts the empty line', ->
+        buffer.text = '\nwörld'
+        cursor.pos = 1
+        editor\cut!
+        assert.equals 'wörld', buffer.text
+        editor\paste!
+        assert.equal '\nwörld', buffer.text
+
+  describe 'copy', ->
+    context 'with an active selection', ->
+      it 'copies the selection', ->
+        buffer.text = 'hello\nwörld'
+        cursor.pos = 2
+        selection\set 2, 5 -- 'ell'
+        editor\copy!
+
+        cursor.pos = 1
+        editor\paste!
+        assert.equals 'ellhello\nwörld', buffer.text
+
+    context 'with no active selection', ->
+      it 'copies the current line', ->
+        buffer.text = 'hello\nwörld'
+        cursor.pos = 3
+        editor\copy!
+
+        cursor.pos = 1
+        editor\paste!
+        assert.equals 'hello\nhello\nwörld', buffer.text
+
   context 'resource management', ->
     it 'editors are collected as they should', ->
       e = Editor Buffer {}


### PR DESCRIPTION
Similar to editor-duplicate-current and models the behaviour of a few other text editors - if you haven't a selection Ctrl+C/X will copy/cut the current line, instead of doing nothing. I find this very handy for moving a single line of code around.