### PR TITLE
Reset buffer 'modified' status after undo when applicable

### DIFF
--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -447,6 +447,10 @@ Buffer = {
 
   clear_revisions: => @revisions\clear!
 
+  snapshot: => @revisions\snapshot!
+
+  is_snapshot: (snapshot_id)=> @revisions\is_snapshot(snapshot_id)
+
   notify: (event, parameters) =>
     for listener in *@listeners
       callback = listener["on_#{event}"]

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -447,9 +447,10 @@ Buffer = {
 
   clear_revisions: => @revisions\clear!
 
-  snapshot: => @revisions\snapshot!
-
-  is_snapshot: (snapshot_id)=> @revisions\is_snapshot(snapshot_id)
+  get_revision_id: (snapshot=false) =>
+    if snapshot and @revisions.last
+      @revisions.last.dont_merge = true
+    return @revisions.revision_id
 
   notify: (event, parameters) =>
     for listener in *@listeners

--- a/lib/aullar/spec/revisions_spec.moon
+++ b/lib/aullar/spec/revisions_spec.moon
@@ -20,7 +20,8 @@ describe 'Revisions', ->
         type: 'inserted',
         offset: 3,
         text: 'foo',
-        meta: {}
+        meta: {},
+        revision_id: 1
       }, revisions.entries[1]
 
       revisions\push 'deleted', 3, 'f', nil, foo: 1
@@ -28,7 +29,8 @@ describe 'Revisions', ->
         type: 'deleted',
         offset: 3,
         text: 'f',
-        meta: { foo: 1 }
+        meta: { foo: 1 },
+        revision_id: 2
       }, revisions.entries[2]
 
       revisions\push 'changed', 3, 'f', 'x'
@@ -37,7 +39,8 @@ describe 'Revisions', ->
         offset: 3,
         text: 'f',
         prev_text: 'x',
-        meta: {}
+        meta: {},
+        revision_id: 3
       }, revisions.entries[3]
 
     it 'returns the added revision', ->
@@ -46,7 +49,8 @@ describe 'Revisions', ->
         type: 'inserted',
         offset: 3,
         text: 'foo',
-        meta: {}
+        meta: {},
+        revision_id: 1
       }, rev
 
     it 'keeps at most config.undo_limit revisions', ->
@@ -65,7 +69,8 @@ describe 'Revisions', ->
           type: 'inserted',
           offset: 2,
           text: 'fooba',
-          meta: {}
+          meta: {},
+          revision_id: 1
         }, revisions.last
 
       it 'merges preceeding deletes', ->
@@ -78,7 +83,8 @@ describe 'Revisions', ->
           type: 'deleted',
           offset: 2,
           text: '234',
-          meta: {}
+          meta: {},
+          revision_id: 1
         }, revisions.last
 
       it 'merges deletes at the same offset', ->
@@ -91,7 +97,33 @@ describe 'Revisions', ->
           type: 'deleted',
           offset: 4,
           text: '456',
-          meta: {}
+          meta: {},
+          revision_id: 1
+        }, revisions.last
+
+      it 'does not merge if dont_merge is set on a revision', ->
+        buffer.text = 'a'
+        revisions\push 'inserted', 2, 'foo'
+        revisions.last.dont_merge = true
+        revisions\push 'inserted', 5, 'ba'
+        assert.equal 2, #revisions
+        buffer.text = 'afooba'
+
+        assert.same {
+          type: 'inserted',
+          offset: 5,
+          text: 'ba',
+          meta: {},
+          revision_id: 2
+        }, revisions\pop(buffer)
+
+        assert.same {
+          type: 'inserted',
+          offset: 2,
+          text: 'foo',
+          meta: {},
+          revision_id: 1
+          dont_merge: true
         }, revisions.last
 
     it 'raises an error if the type is unknown', ->
@@ -121,7 +153,8 @@ describe 'Revisions', ->
         type: 'deleted',
         offset: 9,
         text: '9',
-        meta: {}
+        meta: {},
+        revision_id: 1
       }, revisions\pop(buffer)
 
   describe 'forward(buffer)', ->
@@ -179,7 +212,8 @@ describe 'Revisions', ->
         offset: 4,
         text: 'x',
         group: 1,
-        meta: {}
+        meta: {},
+        revision_id: 2
       }, revisions\pop(buffer)
 
       assert.equal '12345678', buffer.text -- and both should be undone
@@ -191,7 +225,8 @@ describe 'Revisions', ->
         offset: 2,
         text: 'y',
         group: 1,
-        meta: {}
+        meta: {},
+        revision_id: 3
       }, revisions\forward(buffer)
 
       assert.equal '1y23x45678', buffer.text -- and both should be reapplied

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -29,7 +29,7 @@ class Buffer extends PropertyObject
     @_eol = '\n'
     @viewers = 0
     @_modified = false
-    @sync_snapshot_id = @_buffer\snapshot!
+    @sync_revision_id = @_buffer\get_revision_id true
 
     @_buffer\add_listener
       on_inserted: self\_on_text_inserted
@@ -49,7 +49,7 @@ class Buffer extends PropertyObject
         @sync_etag = nil
 
       @_modified = false
-      @sync_snapshot_id = @_buffer\snapshot!
+      @sync_revision_id = @_buffer\get_revision_id true
       @can_undo = false
 
   @property mode:
@@ -192,7 +192,7 @@ class Buffer extends PropertyObject
       @file.contents = @text
       @_modified = false
       @sync_etag = @file.etag
-      @sync_snapshot_id = @_buffer\snapshot!
+      @sync_revision_id = @_buffer\get_revision_id true
       signal.emit 'buffer-saved', buffer: self
 
   save_as: (file) =>
@@ -203,13 +203,11 @@ class Buffer extends PropertyObject
 
   undo: =>
     @_buffer\undo!
-    if @_buffer\is_snapshot(@sync_snapshot_id)
-      @_modified = false
+    @_modified = @_buffer\get_revision_id! != @sync_revision_id
 
   redo: =>
     @_buffer\redo!
-    if @_buffer\is_snapshot(@sync_snapshot_id)
-      @_modified = false
+    @_modified = @_buffer\get_revision_id! != @sync_revision_id
 
   char_offset: (byte_offset) =>
     @_buffer\char_offset byte_offset

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -226,11 +226,44 @@ describe 'Buffer', ->
 
       assert.equals 'zed', ret
 
-  it 'undo undoes the last operation', ->
-    b = buffer 'hello'
-    b\delete 1, 1
-    b\undo!
-    assert.equal 'hello', b.text
+  describe 'undo', ->
+    it 'undoes the last operation', ->
+      b = buffer 'hello'
+      b\delete 1, 1
+      b\undo!
+      assert.equal 'hello', b.text
+
+    it 'resets the .modified flag when at synced file revision', ->
+      with_tmpfile (file) ->
+        b = buffer ''
+        b.file = file
+        b.text = 'hello'
+        b\delete 1, 1
+        b\save!
+        b\delete 1, 1
+        assert.equal true, b.modified
+        b\undo!
+        assert.equal false, b.modified
+        b\undo!
+        assert.equal true, b.modified
+
+  describe 'redo', ->
+    it 'redoes the last undo operation', ->
+      b = buffer 'hello'
+      b\delete 1, 1
+      b\undo!
+      b\redo!
+      assert.equal 'ello', b.text
+
+    it 'resets the .modified flag when at synced file revision', ->
+      with_tmpfile (file) ->
+        b = buffer ''
+        b.file = file
+        b.text = 'hello'
+        b\delete 1, 1
+        b\save!
+        b\undo!
+        b\redo!
 
   it '.can_undo returns true if undo is possible, and false otherwise', ->
     b = Buffer {}

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -262,8 +262,14 @@ describe 'Buffer', ->
         b.text = 'hello'
         b\delete 1, 1
         b\save!
+        b\delete 1, 1
         b\undo!
+        b\undo!
+        assert.equal true, b.modified
         b\redo!
+        assert.equal false, b.modified
+        b\redo!
+        assert.equal true, b.modified
 
   it '.can_undo returns true if undo is possible, and false otherwise', ->
     b = Buffer {}


### PR DESCRIPTION
The `buffer.modified` flag is now automatically reset to false if you undo all the way back to the originally synced revision. This avoids unnecessary 'Buffer is modified' warnings on close/exit and also the misleading '*' marker in the buffer list.

(I'm not quite sure if this is the best way to do this, but it works :smile: ).