### PR TITLE
Add shell-like tab action on file selection.

### DIFF
--- a/lib/howl/interactions/file_selection.moon
+++ b/lib/howl/interactions/file_selection.moon
@@ -139,15 +139,13 @@ class FileSelector
         if @list_widget.selection and not @list_widget.selection.is_new
           @_open!
       else
-        -- if we're not on the new entry, go forward once
-        @list_widget\select_next! unless @list_widget.selection.is_new
-        -- if we land on the new entry (or were on it originally), skip it by going forward again
+        @list_widget\select_next!
+        -- if we land on the new entry, skip it by going forward again
         @list_widget\select_next! if @list_widget.selection.is_new
 
     shift_tab: =>
-      -- if we're not on the new entry, go backward once
-      @list_widget\select_prev! unless @list_widget.selection.is_new
-      -- if we land on the new entry (or were on it originally), skip it by going backward again
+      @list_widget\select_prev!
+      -- if we land on the new entry, skip it by going backward again
       @list_widget\select_prev! if @list_widget.selection.is_new
 
     backspace: =>

--- a/lib/howl/interactions/file_selection.moon
+++ b/lib/howl/interactions/file_selection.moon
@@ -116,14 +116,12 @@ class FileSelector
     file = @list_widget.selection and @list_widget.selection.file
     name = @list_widget.selection and @list_widget.selection.name
     if not @opts.allow_new and (not file or not file.exists)
-      log.error 'Invalid path: '..tostring(file)
+      log.error "Invalid path: #{file}"
       return
 
     if name == ".#{separator}"
       @_submit @directory
-      return
-
-    if file.exists and file.is_directory
+    elseif file.exists and file.is_directory
       @_chdir file
     else
       @_submit file
@@ -141,9 +139,16 @@ class FileSelector
         if @list_widget.selection and not @list_widget.selection.is_new
           @_open!
       else
-        -- cycle non-new entries
+        -- if we're not on the new entry, go forward once
         @list_widget\select_next! unless @list_widget.selection.is_new
+        -- if we land on the new entry (or were on it originally), skip it by going forward again
         @list_widget\select_next! if @list_widget.selection.is_new
+
+    shift_tab: =>
+      -- if we're not on the new entry, go backward once
+      @list_widget\select_prev! unless @list_widget.selection.is_new
+      -- if we land on the new entry (or were on it originally), skip it by going backward again
+      @list_widget\select_prev! if @list_widget.selection.is_new
 
     backspace: =>
       return false unless @command_line.text.is_empty


### PR DESCRIPTION
From tab completion in the shell, muscle memory always has me expecting tab in file selection to do something.

The idea I've implemented is to make it perform like bash/fish shell - if there is a unique entry, open that entry, otherwise cycle the selection through matched (non-new) entries. Feels pretty natural. Thoughts?
