### PR TITLE
Change matching brace highlight behavior a bit

### DIFF
--- a/bundles/howl-themes/monokai/monokai.moon
+++ b/bundles/howl-themes/monokai/monokai.moon
@@ -163,6 +163,13 @@ return {
       background: '#0064b1'
       height: 'text'
 
+    brace_highlight_secondary:
+      type: flair.RECTANGLE
+      foreground: '#0064b1'
+      text_color: foreground
+      line_width: 1
+      height: 'text'
+
     list_selection:
       type: flair.RECTANGLE
       background: current

--- a/bundles/howl-themes/solarized_light/solarized_light.moon
+++ b/bundles/howl-themes/solarized_light/solarized_light.moon
@@ -178,6 +178,12 @@ return {
       background_alpha: 0.6
       height: 'text'
 
+    brace_highlight_secondary:
+      type: highlight.RECTANGLE
+      foreground: blue
+      line_width: 1
+      height: 'text'
+
     list_selection:
       type: highlight.RECTANGLE
       foreground: blue

--- a/bundles/howl-themes/steinom/steinom.moon
+++ b/bundles/howl-themes/steinom/steinom.moon
@@ -159,6 +159,13 @@ return {
       background: '#0064b1'
       height: 'text'
 
+    brace_highlight_secondary:
+      type: flair.RECTANGLE
+      foreground: '#0064b1'
+      text_color: foreground
+      line_width: 1
+      height: 'text'
+
     list_selection:
       type: flair.ROUNDED_RECTANGLE
       background: slategray

--- a/bundles/howl-themes/tomorrow_night_blue/tm_night_blue.moon
+++ b/bundles/howl-themes/tomorrow_night_blue/tm_night_blue.moon
@@ -158,6 +158,13 @@ return {
       background: '#0064b1'
       height: 'text'
 
+    brace_highlight_secondary:
+      type: flair.RECTANGLE
+      foreground: '#0064b1'
+      text_color: foreground
+      line_width: 1
+      height: 'text'
+
     list_selection:
       type: flair.RECTANGLE
       background: white

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -711,9 +711,11 @@ class Editor extends PropertyObject
           return cur_char, pos, k, false
 
     pos = cursor.pos
-    cur_char, start_pos, matching, forward = get_brace_pos buffer, pos, auto_pairs
-    if not matching and pos > 1
+    local cur_char, start_pos, matching, forward
+    if pos > 1
       cur_char, start_pos, matching, forward = get_brace_pos buffer, pos - 1, auto_pairs
+    unless matching
+      cur_char, start_pos, matching, forward = get_brace_pos buffer, pos, auto_pairs
 
     return if not matching or cur_char == matching
 
@@ -731,6 +733,12 @@ class Editor extends PropertyObject
         flair: 'brace_highlight',
         start_offset: match_pos,
         end_offset: match_pos + 1
+      }}
+      buffer.markers\add {{
+        name: 'brace_highlight',
+        flair: 'brace_highlight',
+        start_offset: start_pos,
+        end_offset: start_pos + 1
       }}
       @_brace_highlighted = true
 

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -701,7 +701,7 @@ class Editor extends PropertyObject
     auto_pairs = @buffer.mode.auto_pairs
     return unless auto_pairs
 
-    get_brace_pos = (buffer, pos, auto_pairs) ->
+    get_brace_pos = (pos) ->
       cur_char = buffer\sub pos, pos
       matching = auto_pairs[cur_char]
       return cur_char, pos, matching, true if matching
@@ -710,37 +710,58 @@ class Editor extends PropertyObject
         if v == cur_char
           return cur_char, pos, k, false
 
+    get_matching_pair = (pos) ->
+      return if pos < 1 or pos > buffer.size
+      cur_char, start_pos, matching, forward = get_brace_pos pos
+      return unless matching and matching != cur_char
+
+      if matching
+        match_pos = if forward
+          last_visible_line = buffer\get_line(@view.last_visible_line)
+          search_to = last_visible_line and last_visible_line.end_offset or buffer.size
+          buffer\pair_match_forward(start_pos, matching, search_to)
+        else
+          search_to = buffer\get_line(@view.first_visible_line).start_offset
+          buffer\pair_match_backward(start_pos, matching, search_to)
+        return unless match_pos
+        if forward
+          return start_pos, match_pos
+        else
+          return match_pos, start_pos
+
+    highlight_pair = (pos, start_pos, end_pos) ->
+      flair = if start_pos == pos or end_pos == pos
+        'brace_highlight'
+        else
+          'brace_highlight_secondary'
+
+      buffer.markers\add {
+        {
+          name: 'brace_highlight',
+          :flair,
+          start_offset: start_pos,
+          end_offset: start_pos + 1
+        },
+        {
+          name: 'brace_highlight',
+          :flair,
+          start_offset: end_pos,
+          end_offset: end_pos + 1
+        },
+      }
+
     pos = cursor.pos
-    local cur_char, start_pos, matching, forward
-    if pos > 1
-      cur_char, start_pos, matching, forward = get_brace_pos buffer, pos - 1, auto_pairs
-    unless matching
-      cur_char, start_pos, matching, forward = get_brace_pos buffer, pos, auto_pairs
 
-    return if not matching or cur_char == matching
-
-    match_pos = if forward
-      last_visible_line = buffer\get_line(@view.last_visible_line)
-      search_to = last_visible_line and last_visible_line.end_offset or buffer.size
-      buffer\pair_match_forward(start_pos, matching, search_to)
-    else
-      search_to = buffer\get_line(@view.first_visible_line).start_offset
-      buffer\pair_match_backward(start_pos, matching, search_to)
-
-    if match_pos and abs(match_pos - start_pos) > 1
-      buffer.markers\add {{
-        name: 'brace_highlight',
-        flair: 'brace_highlight',
-        start_offset: match_pos,
-        end_offset: match_pos + 1
-      }}
-      buffer.markers\add {{
-        name: 'brace_highlight',
-        flair: 'brace_highlight',
-        start_offset: start_pos,
-        end_offset: start_pos + 1
-      }}
+    start_pos, end_pos = get_matching_pair pos - 1
+    if start_pos
+      highlight_pair pos, start_pos, end_pos
       @_brace_highlighted = true
+
+    start_pos, end_pos = get_matching_pair pos
+    if start_pos
+      highlight_pair pos, start_pos, end_pos
+      @_brace_highlighted = true
+
 
   _update_position: =>
     pos = @cursor.line .. ':' .. @cursor.column


### PR DESCRIPTION
- prefer to match brace before cursor rather than after, when both
present
- highlight both braces of the matched pair

## Reasoning
(`|` represents cursor, `^` represent hightlight)

### Old behavior

When typing away, the last typed brace is matched in the common case. This is ideal because one usually wants to know which brace was just closed:
```
( ( ... ))|
^
```

However if you happen to be editing something and type a brace that happens to be just before another brace, the brace to the right of the cursor is matched:

```
( ( ... )|)
^  
```

This is confusing because it is inconsistent - one would still want to know (or expect to see) the brace that was just closed. To add to the confusion, there is no indication of which brace is being matched.

### New behavior

This PR always matching the brace *before* cursor, if present.

As a convenience, the PR also matches the brace after the cursor, if there is no brace before cursor. To let user know exactly which brace is being matched in all cases, it highlights both braces in the pair, instead of just the far-away matched brace. 

