### PR TITLE
Add icons to switch-buffer list

### DIFF
--- a/lib/howl/interactions/buffer_selection.moon
+++ b/lib/howl/interactions/buffer_selection.moon
@@ -1,12 +1,19 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-import app, interact, Project from howl
+import app, config, interact, Project from howl
 import File from howl.io
 import icon, markup from howl.ui
 import Matcher from howl.util
 
 append = table.insert
+
+config.define
+  name: 'buffer_icons'
+  description: 'Whether buffer icons are displayed'
+  scope: 'global'
+  type_of: 'boolean'
+  default: true
 
 icon.define_default 'buffer', 'font-awesome-square'
 icon.define_default 'buffer-modified', 'font-awesome-pencil-square-o'
@@ -15,13 +22,17 @@ icon.define_default 'process-success', 'font-awesome-check-circle'
 icon.define_default 'process-running', 'font-awesome-play-circle'
 icon.define_default 'process-failure', 'font-awesome-exclamation-circle'
 
-
 buffer_dir = (buffer) ->
   if buffer.file
     return buffer.file.parent.short_path
   elseif buffer.directory
     return buffer.directory.short_path
   return '(none)'
+
+buffer_status_text = (buffer) ->
+  stat = if buffer.modified then '*' else ''
+  stat ..= '[modified on disk]' if buffer.modified_on_disk
+  stat
 
 buffer_status_icon = (buffer) ->
   local name
@@ -87,7 +98,11 @@ get_buffer_list = ->
     for i=1,#buffers
       enhanced_titles[buffers[i]] = titles[i]
 
-  return [{buffer_status_icon(buffer), enhanced_titles[buffer] or buffer.title, buffer_dir(buffer), :buffer} for buffer in *app.buffers]
+  title = (buffer) -> enhanced_titles[buffer] or buffer.title
+  if config.buffer_icons
+    return [{buffer_status_icon(buffer), title(buffer), buffer_dir(buffer), :buffer} for buffer in *app.buffers]
+  else
+    return [{title(buffer), buffer_status_text(buffer), buffer_dir(buffer), :buffer} for buffer in *app.buffers]
 
 buffer_matcher = (text) ->
   matcher = Matcher get_buffer_list!
@@ -98,14 +113,23 @@ interact.register
   description: 'Selection list for buffers'
   handler: (opts={}) ->
     opts = moon.copy opts
-    with opts
-      .title or= 'Buffers'
-      .matcher = buffer_matcher
-      .columns = {
+    local columns
+    if config.buffer_icons
+      columns = {
         {},
         {style: 'string'}
         {style: 'comment'}
       }
+    else
+      columns = {
+        {style: 'string'}
+        {style: 'operator'}
+        {style: 'comment'}
+      }
+    with opts
+      .title or= 'Buffers'
+      .matcher = buffer_matcher
+      .columns = columns
       .keymap = {
         binding_for:
           ['close']: (current) ->

--- a/spec/interactions/buffer_selection_spec.moon
+++ b/spec/interactions/buffer_selection_spec.moon
@@ -36,14 +36,14 @@ describe 'buffer_selection', ->
     it 'displays a list of active buffers', ->
       local buflist
       within_activity (-> interact.select_buffer :editor), ->
-        buflist = get_ui_list_widget_column!
+        buflist = get_ui_list_widget_column 2
       assert.same {'a1-buffer', 'a2-buffer', 'b-buffer', 'c-buffer'}, buflist
 
     it 'filters the buffer list based on entered text', ->
       local buflist
       within_activity (-> interact.select_buffer :editor), ->
         command_line\write 'a-b'
-        buflist = get_ui_list_widget_column!
+        buflist = get_ui_list_widget_column 2
       assert.same {'a1-buffer', 'a2-buffer'}, buflist
 
     it 'previews currently selected buffer in the editor', ->
@@ -85,7 +85,7 @@ describe 'buffer_selection', ->
         within_activity (-> interact.select_buffer :editor), ->
           command_line\handle_keypress close_event
           command_line\handle_keypress close_event
-          buflist = get_ui_list_widget_column!
+          buflist = get_ui_list_widget_column 2
         assert.same {'b-buffer', 'c-buffer'}, buflist
 
       it 'preserves filter', ->
@@ -93,7 +93,7 @@ describe 'buffer_selection', ->
         within_activity (-> interact.select_buffer :editor), ->
           command_line\write 'a-b'
           command_line\handle_keypress close_event
-          buflist = get_ui_list_widget_column!
+          buflist = get_ui_list_widget_column 2
         assert.same {'a2-buffer'}, buflist
 
     context 'duplicate filenames', ->
@@ -112,5 +112,5 @@ describe 'buffer_selection', ->
       it 'uniquifies title by using project name and parent directory prefix', ->
         local buflist
         within_activity (-> interact.select_buffer :editor), ->
-          buflist = get_ui_list_widget_column!
+          buflist = get_ui_list_widget_column 2
         assert.same {'file1 [project1]', 'file1 [project2]', 'path1/file2 [project2]', 'path2/file2 [project2]'}, buflist


### PR DESCRIPTION
This adds icons in the first column of the buffer list for `switch-buffer`. It also removes the status column which showed '*' for modified buffers since the icon indicates modification state. Custom icons also show status of process buffers - running, successful or error.

Some screenshots below (the icons should be self-explanatory, I hope):

![buffer-icons](https://cloud.githubusercontent.com/assets/7066873/13522120/4e9a4c32-e1a2-11e5-9e01-0ec2334b9e4f.png)
![buffer-icons2](https://cloud.githubusercontent.com/assets/7066873/13522121/4f26cf04-e1a2-11e5-9464-6ffe67136e05.png)
