### PR TITLE
Brace matching improvements

### DIFF
--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -303,20 +303,21 @@ Buffer = {
       end_offset += offset_delta
 
     opening = arr[i]
+    opening_style = @styling\at offset
     closing = string.byte closing
     delta = 1
     i += 1 -- start at following byte
 
     while i < end_offset
-      c = arr[i]
+      if opening_style == @styling\at i - offset_delta + 1
+        c = arr[i]
 
-      if c == opening
-        delta += 1
-      elseif c == closing
-        delta -= 1
-        if delta == 0
-          return (i - offset_delta) + 1
-
+        if c == opening
+          delta += 1
+        elseif c == closing
+          delta -= 1
+          if delta == 0
+            return (i - offset_delta) + 1
       i += 1
       if i >= tb.gap_start and offset_delta == 0
         offset_delta = tb.gap_size
@@ -340,17 +341,19 @@ Buffer = {
 
     closing = arr[i]
     opening = string.byte opening
+    opening_style = @styling\at offset
     delta = 0
 
     while i >= end_offset
-      c = arr[i]
+      if opening_style == @styling\at i - offset_delta + 1
+        c = arr[i]
 
-      if c == closing
-        delta += 1
-      elseif c == opening
-        delta -= 1
-        if delta == 0
-          return (i - offset_delta) + 1
+        if c == closing
+          delta += 1
+        elseif c == opening
+          delta -= 1
+          if delta == 0
+            return (i - offset_delta) + 1
 
       i -= 1
       if i > tb.gap_start and i < tb.gap_end

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -180,6 +180,14 @@ describe 'Buffer', ->
       assert.equals 5, b\pair_match_forward 2, ']', 5
       assert.is_nil b\pair_match_forward 2, ']', 4
 
+    it 'match braces with identical style only', ->
+      b = Buffer '1[3]5]7'
+      b.styling.at = spy.new (pos) =>
+        styles = {nil, 'operator', nil, 'string', nil, 'operator'}
+        return styles[pos]
+
+      assert.equal 6, b\pair_match_forward 2, ']'
+
   describe 'pair_match_backward(offset, opening [, end_offset])', ->
     it 'returns the offset of the closing preceeding pair character', ->
       b = Buffer '1[34]6'

--- a/lib/howl/commands/edit_commands.moon
+++ b/lib/howl/commands/edit_commands.moon
@@ -145,8 +145,8 @@ command.register
   handler: (line_no) -> app.editor.cursor\move_to line: line_no, column: 1
 
 command.register
-  name: 'cursor-match-brace'
-  description: 'Jump to matching brace'
+  name: 'cursor-goto-brace'
+  description: 'Go to the brace matching the current brace, if any'
   handler: ->
     cursor = app.editor.cursor
     pos = app.editor\get_matching_brace cursor.pos

--- a/lib/howl/commands/edit_commands.moon
+++ b/lib/howl/commands/edit_commands.moon
@@ -143,3 +143,12 @@ command.register
     return tonumber line_str
 
   handler: (line_no) -> app.editor.cursor\move_to line: line_no, column: 1
+
+command.register
+  name: 'cursor-match-brace'
+  description: 'Jump to matching brace'
+  handler: ->
+    cursor = app.editor.cursor
+    pos = app.editor\get_matching_brace cursor.pos
+    cursor\move_to(:pos, :extend) if pos
+

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -753,3 +753,35 @@ describe 'Editor', ->
       assert.is_nil editors[1]
       assert.is_nil buffers[1]
       assert.is_nil buffers[2]
+
+  context 'get_matching_brace', ->
+    it 'finds position of matching opending/closing brace', ->
+      editor.buffer.mode.auto_pairs = {'[': ']'}
+
+      editor.buffer.text = '[]'
+      assert.same 2, editor\get_matching_brace 1
+      assert.same 1, editor\get_matching_brace 2
+      assert.same nil, editor\get_matching_brace 3
+
+      editor.buffer.text = '[Ü]'
+      assert.same 3, editor\get_matching_brace 1
+      assert.same 1, editor\get_matching_brace 3
+      assert.same nil, editor\get_matching_brace 2
+
+      editor.buffer.text = '1ÜÜ4[6ÜÜ9]---'
+      assert.same 10, editor\get_matching_brace 5
+      assert.same 5, editor\get_matching_brace 10
+      assert.same nil, editor\get_matching_brace 1
+      assert.same nil, editor\get_matching_brace 4
+      assert.same nil, editor\get_matching_brace 6
+      assert.same nil, editor\get_matching_brace 11
+
+    it 'returns nil for unmatched/mismatched braces', ->
+      editor.buffer.mode.auto_pairs = {'[': ']'}
+      editor.buffer.text = ']['
+      assert.same nil, editor\get_matching_brace 1
+      assert.same nil, editor\get_matching_brace 2
+
+      editor.buffer.text = '([]]'
+      assert.same nil, editor\get_matching_brace 4
+


### PR DESCRIPTION
- Made brace matching style aware, so operators are not matched with string literals, etc.
- Refactored brace matching implementation 
- Added cursor-match-brace command that moves cursor to matching brace, if any