### PR TITLE
Change cursor behavior when unindenting line

### DIFF
--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -384,9 +384,10 @@ class Editor extends PropertyObject
 
     conf = @buffer.config
     if conf.tab_indents and @current_context.prefix.is_blank
+      cursor_col = @cursor.column
       cur_line = @current_line
       cur_line\unindent!
-      @cursor.column = cur_line.indentation + 1
+      @cursor.column = math.min(cursor_col, cur_line.indentation + 1)
     else
       return if @cursor.column == 1
       tab_stops = math.floor (@cursor.column - 1) / conf.tab_width
@@ -395,11 +396,12 @@ class Editor extends PropertyObject
       @cursor.column = col
 
   delete_back: =>
-    if @selection.empty and @current_context.prefix\match '^%s+$'
+    if @selection.empty and @current_context.prefix.is_blank
       if @buffer.config.backspace_unindents
         cur_line = @current_line
+        gap = cur_line.indentation - @cursor.column
         cur_line\unindent!
-        @cursor.column = cur_line.indentation + 1
+        @cursor.column = math.max(1, cur_line.indentation - gap)
         return
 
     @view\delete_back!

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -387,7 +387,7 @@ class Editor extends PropertyObject
       cursor_col = @cursor.column
       cur_line = @current_line
       cur_line\unindent!
-      @cursor.column = math.min(cursor_col, cur_line.indentation + 1)
+      @cursor.column = min(cursor_col, cur_line.indentation + 1)
     else
       return if @cursor.column == 1
       tab_stops = math.floor (@cursor.column - 1) / conf.tab_width
@@ -401,7 +401,7 @@ class Editor extends PropertyObject
         cur_line = @current_line
         gap = cur_line.indentation - @cursor.column
         cur_line\unindent!
-        @cursor.column = math.max(1, cur_line.indentation - gap)
+        @cursor.column = max(1, cur_line.indentation - gap)
         return
 
     @view\delete_back!
@@ -556,9 +556,9 @@ class Editor extends PropertyObject
 
     line = @buffer.lines\at_pos(pos).nr
     if @line_at_top > line
-      @line_at_top = math.max 1,  line - 2
+      @line_at_top = max 1,  line - 2
     else
-      @line_at_bottom = math.min #@buffer.lines, line + 2
+      @line_at_bottom = min #@buffer.lines, line + 2
 
   -- private
   _show_buffer: (buffer, opts={}) =>


### PR DESCRIPTION
This PR adjusts the behavior as per #150.

Using `backspace` to unindent now never moves the cursor to the right and always moves the cursor left. The conceptual idea is that the spaces to the left of the cursor are being deleted. Successive backspacing looks something like this:

```
    |    abc
  |    abc
|    abc
```

Using `shift_tab` to unindent now never moves the cursor to the right. It may move the cursor to the left to the first non blank character. The conceptual idea is that the rightmost spaces are being deleted. Successive shift-tabbing now looks something like this:

```
    |    abc
    |  abc
    |abc
  |abc
|abc
```