### PR TITLE
Command line persistent keymap

### DIFF
--- a/lib/howl/interactions/buffer_selection.moon
+++ b/lib/howl/interactions/buffer_selection.moon
@@ -142,7 +142,7 @@ interact.register
         current_selection = selection
 
     command_line = howl.app.window.command_line
-    command_line.keymap = {
+    command_line.persistent_keymap = {
       binding_for:
         ['buffer-close']: =>
           if current_selection and current_selection.buffer

--- a/lib/howl/interactions/buffer_selection.moon
+++ b/lib/howl/interactions/buffer_selection.moon
@@ -133,16 +133,22 @@ interact.register
         {style: 'operator'}
         {style: 'comment'}
       }
+    current_selection = nil
     with opts
       .title or= 'Buffers'
       .matcher = buffer_matcher
       .columns = columns
-      .keymap = {
-        binding_for:
-          ['close']: (current) ->
-            if current.selection
-              app\close_buffer current.selection.buffer
-      }
+      .on_change = (selection, text, items) ->
+        current_selection = selection
+
+    command_line = howl.app.window.command_line
+    command_line.keymap = {
+      binding_for:
+        ['buffer-close']: =>
+          if current_selection and current_selection.buffer
+            app\close_buffer current_selection.buffer
+            command_line\refresh!
+    }
 
     result = interact.select_location opts
     if result

--- a/lib/howl/interactions/selection_list.moon
+++ b/lib/howl/interactions/selection_list.moon
@@ -43,6 +43,8 @@ class SelectionList
       else
         @on_update spillover
 
+  refresh: => @list_widget\update @command_line.text, true
+
   show_list: =>
     @command_line\add_widget 'completion_list', @list_widget
     @showing_list = true
@@ -81,17 +83,6 @@ class SelectionList
         @show_list!
       else
         @submit!
-
-    on_unhandled: (event, source, translations, self) ->
-      return false if not @opts.keymap
-      return ->
-        if bindings.dispatch event, source, { @opts.keymap }, {
-            selection: @list_widget.selection
-            text: @command_line.text
-          }
-          @list_widget\update @command_line.text, true
-          @_handle_change!
-        return false
 
 interact.register
   name: 'select'

--- a/lib/howl/ui/command_line.moon
+++ b/lib/howl/ui/command_line.moon
@@ -37,6 +37,8 @@ class CommandLine extends PropertyObject
         error "activity '#{activity_frame.name}' factory returned nil"
 
       activity_frame.activity = activity
+      if activity.keymap
+        activity_frame.command_line_keymap = activity.keymap
 
       parked_handle = dispatch.park 'activity'
       activity_frame.parked_handle = parked_handle
@@ -341,6 +343,13 @@ class CommandLine extends PropertyObject
       @clear!
       @write text
 
+  @property keymap:
+    get: => @current and @current.command_line_keymap
+    set: (keymap) =>
+      unless @current
+        error 'Cannot set keymap - no running activity', 2
+      @current.command_line_keymap = keymap
+
   notify: (text, style='info') =>
     if @notification_widget
       @notification_widget\notify style, text
@@ -408,31 +417,33 @@ class CommandLine extends PropertyObject
   handle_keypress: (event) =>
     -- keymaps checked in order:
     --   @preemptive_keymap - keys that cannot be remapped by activities
-    --   @_activity.keymap
     --   widget.keymap for widget in @_widgets
-    --   @keymap
+    --   registered keymaps for every running activity, newest to oldest
+    --   @default_keymap
     @clear_notification!
     @window.status\clear!
 
     return true if bindings.dispatch event, 'commandline', { @preemptive_keymap}, self
-
-    activity = @_activity
-    if activity and activity.keymap
-      return true if bindings.dispatch event, 'commandline', { activity.keymap }, activity
 
     if @_widgets
       for _, widget in pairs @_widgets
         if widget.keymap
           return true if bindings.dispatch event, 'commandline', { widget.keymap }, widget
 
-    return true if bindings.dispatch event, 'commandline', { @keymap }, self
+    for i = @stack_depth, 1, -1
+      frame = @running[i]
+      keymap = frame.command_line_keymap
+      continue unless keymap
+      return true if bindings.dispatch event, 'commandline', { keymap }, frame.activity
+
+    return true if bindings.dispatch event, 'commandline', { @default_keymap }, self
 
     return false
 
   preemptive_keymap:
     ctrl_shift_backspace: => @abort_all!
 
-  keymap:
+  default_keymap:
     binding_for:
       ["cursor-home"]: => @command_widget.cursor.pos = @_prompt_end
 
@@ -498,6 +509,10 @@ class CommandLine extends PropertyObject
       @window.status\show!
       @last_focused\grab_focus! if @last_focused
       @last_focused = nil
+
+  refresh: =>
+    for frame in *@running
+      frame.activity\refresh! if frame.activity.refresh
 
 style.define_default 'prompt', 'keyword'
 

--- a/site/source/doc/api/ui/command_line.md
+++ b/site/source/doc/api/ui/command_line.md
@@ -69,6 +69,14 @@ the text for the active interaction. Read/write.
 The title of the CommandLine view. This property only gets or sets the title for
 the active interaction. Read/write.
 
+### persistent_keymap
+
+A [keymap](../bindings.html) associated with the currently active interaction.
+This keymap is active while associated interaction, or any nested interaction,
+is active. By contract, keymaps specified in the interaction
+[factory](../interact.md#register) are only active when the associated
+interaction is active and not active when a nested interaction is running.
+
 ## Methods
 
 ### add_widget (name, widget)

--- a/spec/interactions/buffer_selection_spec.moon
+++ b/spec/interactions/buffer_selection_spec.moon
@@ -64,8 +64,8 @@ describe 'buffer_selection', ->
         table.insert previews, editor.buffer.title
       assert.same {'a1-buffer', 'a2-buffer'}, previews
 
-    context 'sending binding_for("close")', ->
-      keymap = ctrl_w: 'close'
+    context 'sending binding_for("buffer-close")', ->
+      keymap = ctrl_w: 'buffer-close'
       before_each -> bindings.push keymap
       after_each -> bindings.remove keymap
 


### PR DESCRIPTION
The purpose of this PR is to remove the special case handling of keymaps by `interact.select` and introduce a more generic way for interactions to install keymaps that are active even when nested interactions are running.

This adds `command_line.persistent_keymap` - a keymap that is active for the interaction that sets this property, and also while any nested interactions are running. This also adds `command_line\refresh!` which invokes `refresh`, if present on all running interactions. These two are used to implement buffer closing in the `interact.select_buffer` list and the old implementation that passed a keymap to `interact.select` has been replaced.