### PR TITLE
Fix matching of file extensions containing symbols

### DIFF
--- a/lib/howl/io/file.moon
+++ b/lib/howl/io/file.moon
@@ -67,7 +67,7 @@ class File extends PropertyObject
     base = @basename
     @is_directory and "#{base}#{File.separator}" or base
 
-  @property extension: get: => @basename\match('%.(%w+)$')
+  @property extension: get: => @basename\match('%.([^.]+)$')
   @property uri: get: => @gfile.uri
   @property is_directory: get: => @exists and @_file_type == GFileInfo.TYPE_DIRECTORY
   @property is_link: get: => @exists and @_file_type == GFileInfo.TYPE_SYMBOLIC_LINK

--- a/spec/io/file_spec.moon
+++ b/spec/io/file_spec.moon
@@ -77,6 +77,7 @@ describe 'File', ->
 
   it '.extension returns the extension of the path', ->
     assert.equal File('/foo/base.ext').extension, 'ext'
+    assert.equal File('/foo/base.ex+').extension, 'ex+'
 
   it '.path returns the path of the file', ->
     assert.equal '/foo/base.ext', File('/foo/base.ext').path


### PR DESCRIPTION
Currently, files like `x.c++` won't be highlighted with the C/C++ mode. When I looked into it, it turned out that the extension pattern wasn't matching `c++`, causing the correct mode to not be loaded. This fixes that by making sure that the pattern correctly matches any extension.