### PR TITLE
Fix compilation under FreeBSD

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,6 +22,9 @@ LPEG_URL = http://nordman.org/mirror/lpeg/$(LPEG_VER).tar.gz
 CFLAGS = -Wall -O2 -g $(LUAJIT_CFLAGS) $(GTK_CFLAGS) -DHOWL_PREFIX=$(PREFIX)
 ARCHIVES = $(LUAJIT_ARCHIVE)
 LIBS = -lm -ldl ${GTK_LIBS} -lstdc++
+ifeq ($(UNAME_S),FreeBSD)
+    LIBS = -lm ${GTK_LIBS} -lstdc++
+endif
 ifeq ($(UNAME_S),Darwin)
 	LD_FLAGS = -Wl,-export_dynamic -pagezero_size 10000 -image_base 100000000
 else

--- a/src/tools/download
+++ b/src/tools/download
@@ -4,7 +4,7 @@
 # License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 os=`uname -s`
-[ "$os" = "Darwin" ] && md5="md5 -r" || md5=md5sum
+([ "$os" = "Darwin" ] || [ "$os" = "FreeBSD" ]) && md5="md5 -r" || md5=md5sum
 
 file=$1; shift
 checksum=$1; shift


### PR DESCRIPTION
Tested under FreeBSD 10.2, of course, you should gmake instead make.

===
WoW, this is the first native modern editor for FreeBSD