### PR TITLE
Make scrollbars themable

### DIFF
--- a/bundles/howl-themes/blueberry_blend/blueberry_blend.moon
+++ b/bundles/howl-themes/blueberry_blend/blueberry_blend.moon
@@ -84,6 +84,10 @@ return {
   }
 
   editor: delegate_to content_box, {
+    scrollbars:
+      slider:
+        color: keyword
+        alpha: 0.8
 
     background: color: dark_blue
     indicators:

--- a/bundles/howl-themes/monokai/monokai.moon
+++ b/bundles/howl-themes/monokai/monokai.moon
@@ -84,6 +84,10 @@ return {
       color: grey
 
   editor: delegate_to content_box, {
+    scrollbars:
+      slider:
+        color: magenta
+
     indicators:
       default:
         color: grey_light

--- a/bundles/howl-themes/steinom/steinom.moon
+++ b/bundles/howl-themes/steinom/steinom.moon
@@ -78,6 +78,10 @@ return {
       color: gray
 
   editor: delegate_to content_box, {
+    scrollbars:
+      slider:
+        color: slategray
+
     indicators:
       default:
         color: slategray

--- a/bundles/howl-themes/tomorrow_night_blue/tm_night_blue.moon
+++ b/bundles/howl-themes/tomorrow_night_blue/tm_night_blue.moon
@@ -80,6 +80,10 @@ return {
       color: '#00346e'
 
   editor: delegate_to content_box, {
+    scrollbars:
+      slider:
+        color: '#00549e'
+
     indicators:
       default:
         color: blue

--- a/lib/howl/ui/theme.moon
+++ b/lib/howl/ui/theme.moon
@@ -6,6 +6,7 @@ Gtk = require 'ljglibs.gtk'
 Gdk = require 'ljglibs.gdk'
 require 'ljglibs.gtk.widget'
 flair = require 'aullar.flair'
+RGBA = Gdk.RGBA
 
 import File from howl.io
 import config, signal from howl
@@ -27,8 +28,12 @@ css_template = [[
   background: rgba(0,0,0,0);
 }
 
+.scrollbar.slider, .scrollbar.button {
+  background: ${scrollbar_slider_color};
+}
+
 .scrollbar.trough {
-    background: rgba(0,0,0,0);
+  background: ${scrollbar_background_color};
 }
 
 .header {
@@ -62,6 +67,11 @@ background_color_widgets = setmetatable {}, __mode: 'k'
 
 interpolate = (content, values) ->
   content\gsub '%${([%a_]+)}', values
+
+parse_color = (spec, alpha = 1) ->
+  c = RGBA(spec)
+  c.alpha = alpha
+  tostring(c)
 
 parse_font = (font = {}) ->
   size = config.font_size
@@ -104,6 +114,12 @@ theme_css = (theme, file) ->
   hdr = editor.header
   footer = editor.footer
   indicators = editor.indicators
+  scrollbars = editor.scrollbars or {}
+  sb_slider = scrollbars.slider or {}
+  sb_bg = scrollbars.background or {}
+  sb_slider_color = parse_color(sb_slider.color or 'gray', sb_slider.alpha or 1)
+  sb_bg_color = parse_color(sb_bg.color or 'black', sb_bg.alpha or 0)
+
   values =
     status_font: parse_font status.font
     status_color: status.color
@@ -111,6 +127,8 @@ theme_css = (theme, file) ->
     header_font: parse_font hdr.font
     footer_color: footer.color
     footer_font: parse_font footer.font
+    scrollbar_slider_color: sb_slider_color
+    scrollbar_background_color: sb_bg_color
   css = interpolate css_template, values
   css ..= indicators_css indicators
   css ..= status_css status

--- a/lib/ljglibs/cdefs/gdk.moon
+++ b/lib/ljglibs/cdefs/gdk.moon
@@ -153,6 +153,7 @@ ffi.cdef [[
   } GdkRGBA;
 
   gboolean gdk_rgba_parse (GdkRGBA *rgba, const gchar *spec);
+  gchar * gdk_rgba_to_string (const GdkRGBA *rgba);
 
   /* GdkCursor */
   typedef struct {} GdkCursor;

--- a/lib/ljglibs/gdk/rgba.moon
+++ b/lib/ljglibs/gdk/rgba.moon
@@ -4,6 +4,7 @@
 ffi = require 'ffi'
 require 'ljglibs.cdefs.gdk'
 core = require 'ljglibs.core'
+{:g_string} = require 'ljglibs.glib'
 
 C = ffi.C
 
@@ -12,6 +13,10 @@ RGBA = ffi.typeof 'GdkRGBA'
 core.define 'GdkRGBA', {
   parse: (spec) =>
     C.gdk_rgba_parse(@, spec) != 0
+
+  meta: {
+    __tostring: => g_string C.gdk_rgba_to_string(@)
+  }
 }, (t, spec) ->
   rgba = RGBA!
   rgba\parse spec if spec

--- a/lib/ljglibs/spec/gdk/rgba_spec.moon
+++ b/lib/ljglibs/spec/gdk/rgba_spec.moon
@@ -15,3 +15,9 @@ describe 'RGBA', ->
       assert.equal 0, rgb.red
       assert.equal 1, rgb.green
       assert.equal 5, math.ceil(rgb.blue * 10)
+
+  it 'tostring(rgba) returns a textual representation', ->
+    rgb = RGBA '#00ff80'
+    assert.equal 'rgb(0,255,128)', tostring(rgb)
+    rgb.alpha = 0.5
+    assert.equal 'rgba(0,255,128,0.5)', tostring(rgb)


### PR DESCRIPTION
It didn't show itself to be much of a problem earlier, but probably only since the overlay scrollbars were often a visible orange, which wasn't that pleasing but at least clearly visible across all themes. When trying out Elementary OS however (for issue #200), whose theme uses black scrollbars, it's apparent that there is a problem if the scrollbars aren't visible.

So this makes scrollbars themeable. As ever, the Gtk support for CSS styling is a work of progress - I verified that this works on Ubuntu 16.04 and Elementary OS (Freya release, Gtk 3.14). I checked Ubuntu 14.04 and 12.04, where it's a no-op. I welcome any alternative choice for the actual colours choosen for the scrollbars of course.

Examples:

![Blueberry](https://dl.dropboxusercontent.com/u/6691346/howl/blueberry-scrollbars.png)

![Monokai](https://dl.dropboxusercontent.com/u/6691346/howl/monokai-scrollbars.png)