### PR TITLE
ListWidget and StyledText enhancements

### DIFF
--- a/lib/howl/command.moon
+++ b/lib/howl/command.moon
@@ -238,12 +238,18 @@ interact.register
   evade_history: true
   handler: (opts={}) ->
     opts = moon.copy opts
+    command_items = get_command_items!
+    name_width = 0
+    shortcut_width = 0
+    for item in *command_items
+      name_width = math.max(name_width, item[1].ulen)
+      shortcut_width = math.max(shortcut_width, item[2].ulen)
     with opts
-      .items = get_command_items!
+      .items = command_items
       .headers = { 'Command', 'Key binding', 'Description' }
       .columns = {
-        { style: 'string', min_width: 30 }
-        { style: 'keyword', min_width: 15 }
+        { style: 'string', min_width: name_width }
+        { style: 'keyword', min_width: shortcut_width }
         { style: 'comment' }
       }
     result = interact.select opts

--- a/lib/howl/command.moon
+++ b/lib/howl/command.moon
@@ -242,8 +242,8 @@ interact.register
       .items = get_command_items!
       .headers = { 'Command', 'Key binding', 'Description' }
       .columns = {
-        { style: 'string' }
-        { style: 'keyword' }
+        { style: 'string', min_width: 30 }
+        { style: 'keyword', min_width: 15 }
         { style: 'comment' }
       }
     result = interact.select opts

--- a/lib/howl/interactions/line_selection.moon
+++ b/lib/howl/interactions/line_selection.moon
@@ -97,6 +97,10 @@ interact.register
     opts.matcher = matcher
     opts.on_change = line_match_highlighter(editor, matcher.explain)
     opts.force_preview = true
+    opts.columns = {
+        {align: 'right', style: 'comment', min_width: 3},
+        {}
+      }
 
     result = interact.select_location opts
 

--- a/lib/howl/interactions/line_selection.moon
+++ b/lib/howl/interactions/line_selection.moon
@@ -5,6 +5,8 @@ import interact from howl
 import highlight from howl.ui
 import Matcher from howl.util
 
+append = table.insert
+
 line_match_highlighter = (editor, explain) ->
   local buffer
   (selection, text, items) ->
@@ -79,7 +81,11 @@ interact.register
       error '"matcher", "items" or "on_change" not allowed', 2
 
     editor = opts.editor or howl.app.editor
-    line_items = [{tostring(line.nr), line.chunk, buffer: line.buffer, line_nr: line.nr, :line} for line in *lines]
+    line_items = {}
+    largest_nr = 0
+    for line in *lines
+      append line_items, {tostring(line.nr), line.chunk, buffer: line.buffer, line_nr: line.nr, :line}
+      largest_nr = math.max(largest_nr, line.nr)
 
     selected_line = opts.selected_line
     if selected_line
@@ -94,11 +100,12 @@ interact.register
       matcher = create_matcher(line_items, opts.find)
     else
       matcher = Matcher line_items, preserve_order: true
+
     opts.matcher = matcher
     opts.on_change = line_match_highlighter(editor, matcher.explain)
     opts.force_preview = true
     opts.columns = {
-        {align: 'right', style: 'comment', min_width: 3},
+        {align: 'right', style: 'comment', min_width: tostring(largest_nr).ulen},
         {}
       }
 

--- a/lib/howl/ui/list_widget.moon
+++ b/lib/howl/ui/list_widget.moon
@@ -183,7 +183,7 @@ class ListWidget extends PropertyObject
     length = #lines[offset]
     highlight.apply 'list_selection', @text_widget.buffer, pos, length
 
-  _jump_to_page_at: (idx, select_idx=nil) =>
+  _jump_to_page_at: (idx) =>
     start_of_last_page = #@_items - @page_size + 1
     if idx < 1
       idx = 1
@@ -199,6 +199,7 @@ class ListWidget extends PropertyObject
       idx = #@items
     else
       idx = max 1, @selected_idx - @page_size
+    @_jump_to_page_at @page_start_idx + @page_size
     @_select idx
 
   next_page: =>
@@ -207,6 +208,7 @@ class ListWidget extends PropertyObject
       idx = 1
     else
       idx = min #@items, @selected_idx + @page_size
+    @_jump_to_page_at @page_start_idx + @page_size
     @_select idx
 
   select_prev: =>

--- a/lib/howl/ui/list_widget.moon
+++ b/lib/howl/ui/list_widget.moon
@@ -163,11 +163,10 @@ class ListWidget extends PropertyObject
     if @page_start_idx <= idx and @page_start_idx + @page_size > idx
       return
 
-    edge_gap = min 1, @page_size - 1
     if idx < @page_start_idx
-      @_jump_to_page_at idx - @page_size + 1 + edge_gap
+      @_jump_to_page_at idx
     elseif @page_start_idx + @page_size - 1 < idx
-      @_jump_to_page_at idx - edge_gap
+      @_jump_to_page_at idx - @page_size + 1
 
   _highlight: (idx) =>
     highlight.remove_all 'list_selection', @text_widget.buffer
@@ -292,6 +291,7 @@ class ListWidget extends PropertyObject
     if preserve_position and current_idx
       idx = min(current_idx, #@_items)
 
+    @page_start_idx = 1
     if @text_widget.showing
       @_adjust_height!
       @_write_page!

--- a/lib/howl/ui/styled_text.moon
+++ b/lib/howl/ui/styled_text.moon
@@ -124,10 +124,21 @@ for_table = (items, columns=nil) ->
     for i = 1, column_widths.num
       cell = display_str item[i]
       cell_style = columns and columns[i] and columns[i].style
+      right_align = columns and columns[i] and columns[i].align == 'right'
+
+      left_pad_width = 0
+      right_pad_width = 0
       pad_width = column_widths[i] - tostring(cell).ulen
-      pad_width += 1 if i < column_widths.num
+      if right_align
+        left_pad_width = pad_width
+      else
+        right_pad_width = pad_width
+
+      right_pad_width += 1 if i < column_widths.num
+
+      write padding(left_pad_width), cell_style
       write cell, cell_style
-      write padding(pad_width), cell_style
+      write padding(right_pad_width), cell_style
 
     write '\n'
 

--- a/lib/howl/ui/styled_text.moon
+++ b/lib/howl/ui/styled_text.moon
@@ -60,7 +60,7 @@ compute_column_widths = (columns, items) ->
   if columns
     for i = 1, #columns
       header = columns[i].header or ''
-      widths[i] = math.max widths[i] or 1, header and tostring(header).ulen or 0
+      widths[i] = math.max widths[i] or 1, header and tostring(header).ulen or 0, columns[i].min_width or 0
       widths.num = math.max widths.num, i
 
   for item in *items

--- a/spec/ui/styled_text_spec.moon
+++ b/spec/ui/styled_text_spec.moon
@@ -85,6 +85,15 @@ describe 'StyledText', ->
         }
         assert.same tbl.styles, {1, 'comment', 4, 4, 'comment', 6, 7, 'string', 10, 10, 'comment', 12, 13, 'comment', 18}
 
+    context 'when column min_width is provided', ->
+      it 'pads small cells to respect min_width', ->
+        tbl = StyledText.for_table { 'one', 'two' }, { {min_width: 10} }
+        assert.same tbl.text, 'one       \ntwo       \n'
+
+      it 'expands column width beyond min_width if necessary', ->
+        tbl = StyledText.for_table { 'one', 'twothreefour' }, { {min_width: 4} }
+        assert.same tbl.text, 'one         \ntwothreefour\n'
+
 
     context 'when a header is provided', ->
       it 'includes header row', ->

--- a/spec/ui/styled_text_spec.moon
+++ b/spec/ui/styled_text_spec.moon
@@ -94,6 +94,10 @@ describe 'StyledText', ->
         tbl = StyledText.for_table { 'one', 'twothreefour' }, { {min_width: 4} }
         assert.same tbl.text, 'one         \ntwothreefour\n'
 
+    context 'when column align:"right" is specified', ->
+      it 'right aligns the text in the column with one extra space to the right', ->
+        tbl = StyledText.for_table { {'o', 'x'}, {'two', 'x'} }, { {align: 'right'} }
+        assert.same tbl.text, '  o x\ntwo x\n'
 
     context 'when a header is provided', ->
       it 'includes header row', ->


### PR DESCRIPTION
The main motivation here is to make list selections more aesthetically pleasing.

1. Added following features to StyledTable, and consequently, to `interact.select` and related lists:
  - Column `min_width`: Extra padding is added to make columns at least this wide. Specified as number of characters.
  - Column `align: 'right'`: Cells are right aligned instead of left aligned.

2. Changed scrolling behavior of `ListWidget` to be row-wise instead of page-wise. This makes it look more like how buffers scroll when you hold down the `up` or `down` key. IOW, it scrolls in one line at a time, instead of jumping an entire page and re-positioning the selection at the top of that page.

3. Finally the above features have been activated in a couple of places:
  - Added min_width for the command list columns, this makes the scrolling appear more smooth
  - Added right alignment and min_width for the line number field in line selections (`buffer-grep`, etc.)

