### PR TITLE
Making the escape key configurable

### DIFF
--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -4,7 +4,7 @@
 ffi = require 'ffi'
 
 import Window, Editor, theme from howl.ui
-import Buffer, Settings, mode, bundle, bindings, keymap, signal, interact, timer, clipboard, config from howl
+import Buffer, Settings, mode, bundle, bindings, keymap, signal, interact, timer, clipboard, config, command from howl
 import File, Process from howl.io
 import PropertyObject from howl.aux.moon
 Gtk = require 'ljglibs.gtk'
@@ -508,5 +508,10 @@ signal.register 'file-opened',
 
 signal.register 'app-ready',
   description: 'Signaled right after the application has completed initialization'
+
+command.register
+  name: 'cancel'
+  description: 'Command used to abort from action'
+  handler: -> nil
 
 return Application

--- a/lib/howl/bindings.moon
+++ b/lib/howl/bindings.moon
@@ -61,7 +61,27 @@ substituted_names = {
   super_r: 'superR'
 }
 
+export remapped_keys = {
+--  ctrl_g: 'escape'
+}
+
 substitute_keyname = (event) ->
+  -- for key, val in pairs event
+  --   print key, val
+  -- print "_____"      
+  
+  remapped_event = remapped_keys[event]
+  if remapped_event
+    print "Inside here"
+    event = remapped_event
+
+-- if event.key_name == "g" and event.control == true
+  --   print "HERE"
+  --   event.control = false
+  --   event.key_name = "escape"
+  --   event.key_code = 65307
+  --   --copy.character = "\e" // not needed
+  --   return event
   key_name = substituted_names[event.key_name]
   return event unless key_name
   copy = {k,v for k,v in pairs event}
@@ -159,7 +179,6 @@ export dispatch = (event, source, keymaps, ...) ->
   translations = translate_key event
   handlers, halt_map, map_opts = find_handlers event, source, translations, keymaps, ...
   remove halt_map if halt_map and map_opts.pop
-
   for handler in *handlers
     status, ret = true, true
     htype = typeof handler

--- a/lib/howl/command.moon
+++ b/lib/howl/command.moon
@@ -158,7 +158,8 @@ class CommandInput
     tab: => @command_completion!
     up: => @run_historical!
     ctrl_r: => @run_historical!
-    escape: => self.finish!
+    binding_for:
+      ["cancel"]: => self.finish!
     enter: =>
       if @command_line.text
         cmd = resolve_command(@command_line.text)

--- a/lib/howl/interactions/external_command.moon
+++ b/lib/howl/interactions/external_command.moon
@@ -183,12 +183,13 @@ class ExternalCommandEntry
 
       @_select_completion!
 
-    escape: =>
-      if @list_widget and @list_widget.showing
-        @list_widget\hide!
-        @auto_show_list = false
-      else
-        self.finish!
+    binding_for:
+      ["cancel"]: =>
+        if @list_widget and @list_widget.showing
+          @list_widget\hide!
+          @auto_show_list = false
+        else
+          self.finish!
 
     tab: =>
       @auto_show_list = true

--- a/lib/howl/interactions/file_selection.moon
+++ b/lib/howl/interactions/file_selection.moon
@@ -152,9 +152,10 @@ class FileSelector
       return false unless @command_line.text.is_empty
       @_chdir @directory.parent if @directory.parent
 
-    escape: =>
-      app.editor\cancel_preview!
-      self.finish!
+    binding_for:
+      ["cancel"]: =>
+        app.editor\cancel_preview!
+        self.finish!
 
     ctrl_s: =>
       @show_subtree = not @show_subtree

--- a/lib/howl/interactions/replacement.moon
+++ b/lib/howl/interactions/replacement.moon
@@ -302,8 +302,6 @@ class Replacement
     @_restore_return!
 
   keymap:
-    escape: => @_restore_return!
-
     alt_enter: => @_toggle_current!
 
     enter: => @runner\run 'submit', ->
@@ -324,6 +322,8 @@ class Replacement
     ctrl_r: => @_switch_to 'buffer-replace-regex'
 
     binding_for:
+      ["cancel"]: => @_restore_return!
+              
       ["cursor-down"]: =>
         return unless (@num_matches > 0) and @selected_idx
         if @selected_idx == @num_matches

--- a/lib/howl/interactions/search.moon
+++ b/lib/howl/interactions/search.moon
@@ -20,7 +20,8 @@ class SearchInteraction
     up: => @searcher\previous!
     down: => @searcher\next!
     enter: => self.finish true
-    escape: => self.finish!
+    binding_for:
+      ["cancel"]: => self.finish!
 
 interact.register
   name: 'search'

--- a/lib/howl/interactions/selection_list.moon
+++ b/lib/howl/interactions/selection_list.moon
@@ -69,7 +69,8 @@ class SelectionList
 
   keymap:
     enter: => @submit!
-    escape: => self.finish!
+    binding_for:
+      ["cancel"]: => self.finish!
     tab: =>
       if not @showing_list
         @show_list!

--- a/lib/howl/interactions/text_entry.moon
+++ b/lib/howl/interactions/text_entry.moon
@@ -13,7 +13,8 @@ class ReadText
     enter: =>
       self.finish app.window.command_line.text
 
-    escape: => self.finish!
+    binding_for:
+      ["cancel"]: => self.finish!
 
 interact.register
   name: 'read_text'

--- a/lib/howl/interactions/variable_assignment.moon
+++ b/lib/howl/interactions/variable_assignment.moon
@@ -125,8 +125,8 @@ class VariableAssignment
         @command_line\clear!
         @command_line\write @list_widget.selection[1] .. '='
 
-    escape: =>
-      self.finish!
+    binding_for:
+      ["cancel"]: => self.finish!
 
 interact.register
   name: 'get_variable_assignment'

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -87,6 +87,7 @@
 
   }
 
+  escape:           'cancel'
   ctrl_o:           'open'
   ctrl_shift_o:     'open-recent'
   ctrl_p:           'project-open'


### PR DESCRIPTION
This change uses the binding_for method to allow users to customize
the key that will abort commands, close the command line, file
browser etc.