### PR TITLE
Buffer inspections

### DIFF
--- a/bundles/moonscript/init.moon
+++ b/bundles/moonscript/init.moon
@@ -5,8 +5,15 @@ mode_reg =
   create: -> bundle_load('moonscript_mode')!
 
 howl.mode.register mode_reg
+howl.inspection.register {
+  name: 'moonscript',
+  factory: ->
+    bundle_load('moonscript_inspector')
+}
 
-unload = -> howl.mode.unregister 'moonscript'
+unload = ->
+  howl.mode.unregister 'moonscript'
+  howl.inspection.unregister 'moonscript'
 
 return {
   info:

--- a/bundles/moonscript/moonscript_inspector.moon
+++ b/bundles/moonscript/moonscript_inspector.moon
@@ -1,0 +1,72 @@
+-- Copyright 2016 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+{:Project, :app} = howl
+{:sandbox} = howl.aux
+append = table.insert
+
+project_lint_config = (root) ->
+  for p in *{'lint_config.moon', 'lint_config.lua'}
+    config = root\join(p)
+    return config if config.exists
+
+load_lint_whitelist = (root, config, for_file, lint) ->
+  cfg, err = loadfile config
+  unless cfg
+    log.error "Failed to load lint config from '#{config}': #{err}"
+    return lint.default_whitelist
+
+  s_box = sandbox no_globals: true
+  wl = s_box -> cfg!.whitelist_globals
+  return lint.default_whitelist unless wl
+
+  whitelist = setmetatable {}, __index: lint.default_whitelist
+  rel_path = for_file\relative_to_parent root
+  for pattern, list in pairs wl
+    if rel_path\match(pattern)
+      for symbol in *list
+        whitelist[symbol] = true
+
+  whitelist
+
+load_project_lint_whitelist = (root, for_file, lint) ->
+  lint_config = project_lint_config root
+  return lint.default_whitelist unless lint_config
+  load_lint_whitelist root, lint_config, for_file, lint
+
+(buffer) ->
+  lint = require "moonscript.cmd.lint"
+  lint_whitelist = lint.default_whitelist
+
+  if buffer.file
+    project = Project.for_file buffer.file
+    if project
+      lint_whitelist = load_project_lint_whitelist project.root, buffer.file, lint
+    elseif buffer.file\is_below(app.settings.dir)
+      howl_lint_config = app.root_dir\join('lint_config.moon')
+      lint_whitelist = load_lint_whitelist app.settings.dir, howl_lint_config, buffer.file, lint
+
+  res, err = lint.lint_code buffer.text, buffer.title, lint_whitelist
+  unless res
+    if err and err\match '%[%d+%]'
+      return {{
+        line: tonumber(err\match('%[(%d+)%]'))
+        message: "Syntax error: Failed to parse"
+        type: 'error'
+      }}
+    return nil
+
+  inspections = {}
+  for nr, message in res\gmatch 'line (%d+): ([^\n\r]+)'
+    inspection = {
+      line: tonumber(nr)
+      type: 'warning'
+      :message
+    }
+    symbols = [s for s in message\gmatch "`([^`]+)`"]
+    if #symbols == 1
+      inspection.search = symbols[1]
+
+    append inspections, inspection
+
+  inspections

--- a/bundles/moonscript/moonscript_mode.moon
+++ b/bundles/moonscript/moonscript_mode.moon
@@ -1,10 +1,42 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 append = table.insert
+{:Project, :app} = howl
+{:sandbox} = howl.aux
+
+project_lint_config = (root) ->
+  for p in *{'lint_config.moon', 'lint_config.lua'}
+    config = root\join(p)
+    return config if config.exists
+
+load_lint_whitelist = (root, config, for_file, lint) ->
+  cfg, err = loadfile config
+  unless cfg
+    log.error "Failed to load lint config from '#{config}': #{err}"
+    return lint.default_whitelist
+
+  s_box = sandbox no_globals: true
+  wl = s_box -> cfg!.whitelist_globals
+  return lint.default_whitelist unless wl
+
+  whitelist = setmetatable {}, __index: lint.default_whitelist
+  rel_path = for_file\relative_to_parent root
+  for pattern, list in pairs wl
+    if rel_path\match(pattern)
+      for symbol in *list
+        whitelist[symbol] = true
+
+  whitelist
+
+load_project_lint_whitelist = (root, for_file, lint) ->
+  lint_config = project_lint_config root
+  return lint.default_whitelist unless lint_config
+  load_lint_whitelist root, lint_config, for_file, lint
 
 class MoonscriptMode
   new: =>
     @lexer = bundle_load('moonscript_lexer')
+    @inspectors = { self\inspect }
     with howl.mode.by_name('lua')
       @api = .api
       @completers = .completers
@@ -80,4 +112,39 @@ class MoonscriptMode
 
     #lines > 0 and lines or self.parent.structure @, editor
 
-return MoonscriptMode
+  inspect: (buffer) =>
+    lint = require "moonscript.cmd.lint"
+    lint_whitelist = lint.default_whitelist
+
+    if buffer.file
+      project = Project.for_file buffer.file
+      if project
+        lint_whitelist = load_project_lint_whitelist project.root, buffer.file, lint
+      elseif buffer.file\is_below(app.settings.dir)
+        howl_lint_config = app.root_dir\join('lint_config.moon')
+        lint_whitelist = load_lint_whitelist app.settings.dir, howl_lint_config, buffer.file, lint
+
+    res, err = lint.lint_code buffer.text, buffer.title, lint_whitelist
+    unless res
+      if err and err\match '%[%d+%]'
+        return {{
+          line: tonumber(err\match('%[(%d+)%]'))
+          message: "Syntax error: Failed to parse"
+          type: 'error'
+        }}
+      return nil
+
+    inspections = {}
+    for nr, message in res\gmatch 'line (%d+): ([^\n\r]+)'
+      inspection = {
+        line: tonumber(nr)
+        type: 'warning'
+        :message
+      }
+      symbols = [s for s in message\gmatch "`([^`]+)`"]
+      if #symbols == 1
+        inspection.search = symbols[1]
+
+      append inspections, inspection
+
+    inspections

--- a/bundles/moonscript/moonscript_mode.moon
+++ b/bundles/moonscript/moonscript_mode.moon
@@ -1,45 +1,18 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
 append = table.insert
-{:Project, :app} = howl
-{:sandbox} = howl.aux
-
-project_lint_config = (root) ->
-  for p in *{'lint_config.moon', 'lint_config.lua'}
-    config = root\join(p)
-    return config if config.exists
-
-load_lint_whitelist = (root, config, for_file, lint) ->
-  cfg, err = loadfile config
-  unless cfg
-    log.error "Failed to load lint config from '#{config}': #{err}"
-    return lint.default_whitelist
-
-  s_box = sandbox no_globals: true
-  wl = s_box -> cfg!.whitelist_globals
-  return lint.default_whitelist unless wl
-
-  whitelist = setmetatable {}, __index: lint.default_whitelist
-  rel_path = for_file\relative_to_parent root
-  for pattern, list in pairs wl
-    if rel_path\match(pattern)
-      for symbol in *list
-        whitelist[symbol] = true
-
-  whitelist
-
-load_project_lint_whitelist = (root, for_file, lint) ->
-  lint_config = project_lint_config root
-  return lint.default_whitelist unless lint_config
-  load_lint_whitelist root, lint_config, for_file, lint
 
 class MoonscriptMode
   new: =>
     @lexer = bundle_load('moonscript_lexer')
-    @inspectors = { self\inspect }
+
     with howl.mode.by_name('lua')
       @api = .api
       @completers = .completers
+
+  default_config:
+    inspectors: { 'moonscript' }
 
   comment_syntax: '--'
 
@@ -111,40 +84,3 @@ class MoonscriptMode
           break
 
     #lines > 0 and lines or self.parent.structure @, editor
-
-  inspect: (buffer) =>
-    lint = require "moonscript.cmd.lint"
-    lint_whitelist = lint.default_whitelist
-
-    if buffer.file
-      project = Project.for_file buffer.file
-      if project
-        lint_whitelist = load_project_lint_whitelist project.root, buffer.file, lint
-      elseif buffer.file\is_below(app.settings.dir)
-        howl_lint_config = app.root_dir\join('lint_config.moon')
-        lint_whitelist = load_lint_whitelist app.settings.dir, howl_lint_config, buffer.file, lint
-
-    res, err = lint.lint_code buffer.text, buffer.title, lint_whitelist
-    unless res
-      if err and err\match '%[%d+%]'
-        return {{
-          line: tonumber(err\match('%[(%d+)%]'))
-          message: "Syntax error: Failed to parse"
-          type: 'error'
-        }}
-      return nil
-
-    inspections = {}
-    for nr, message in res\gmatch 'line (%d+): ([^\n\r]+)'
-      inspection = {
-        line: tonumber(nr)
-        type: 'warning'
-        :message
-      }
-      symbols = [s for s in message\gmatch "`([^`]+)`"]
-      if #symbols == 1
-        inspection.search = symbols[1]
-
-      append inspections, inspection
-
-    inspections

--- a/lib/aullar/display_lines.moon
+++ b/lib/aullar/display_lines.moon
@@ -250,7 +250,9 @@ DisplayLine = define_class {
     @y_offset = floor config.view_line_padding
     @text_height = height
     @height = height + @y_offset * 2
-    @width = width + view.cursor.width
+    @width = width
+    if config.view_show_cursor
+      @width += view.cursor.width
     @is_wrapped = @layout.is_wrapped
     @line_count = @layout.line_count
 

--- a/lib/aullar/flair.moon
+++ b/lib/aullar/flair.moon
@@ -91,6 +91,27 @@ draw_ops = {
     cr\rel_line_to width, 0
     cr\stroke!
 
+  wavy_underline: (flair, x, y, width, height, cr) ->
+    wave_height = flair.wave_height or 2
+    line_run = (flair.wave_width or 8) / 2
+
+    runs = math.floor (width / line_run)
+    cr\move_to x, y + height - 0.5
+
+    set_source_from_color cr, 'foreground', flair
+    set_line_type_from_flair cr, flair
+
+    direction = -1
+    for i = 1, runs
+      cr\rel_line_to line_run, direction * wave_height
+      direction *= -1
+
+    partial_run = width - (runs * line_run)
+    if partial_run > 0
+      cr\rel_line_to partial_run, (direction * wave_height * partial_run / line_run)
+
+    cr\stroke!
+
   pipe: (flair, x, y, width, height, cr) ->
     if flair.foreground
       set_source_from_color cr, 'foreground', flair
@@ -145,6 +166,7 @@ need_text_object = (flair) ->
   ROUNDED_RECTANGLE: 'rounded_rectangle'
   SANDWICH: 'sandwich'
   UNDERLINE: 'underline'
+  WAVY_UNDERLINE: 'wavy_underline'
   PIPE: 'pipe'
 
   :build

--- a/lib/aullar/markers.moon
+++ b/lib/aullar/markers.moon
@@ -5,6 +5,8 @@
 {:insert, :remove} = table
 
 selector_matches = (selector, marker) ->
+  return true unless selector
+
   for k, v in pairs selector
     return false unless marker[k] == v
 
@@ -62,6 +64,9 @@ define_class {
 
   for_range: (start_offset, end_offset, selector) =>
     (@_scan start_offset, end_offset, selector)
+
+  find: (selector) =>
+    [m for m in *@markers when selector_matches(selector, m)]
 
   expand: (offset, count) =>
     for i = 1, #@markers

--- a/lib/aullar/spec/markers_spec.moon
+++ b/lib/aullar/spec/markers_spec.moon
@@ -59,6 +59,19 @@ describe 'markers', ->
         markers\add { {name: 'test2', start_offset: 4, end_offset: 6, frob: 'nic'} }
         assert.same {}, markers\for_range(1, 6, foo: 'other')
 
+  describe 'find(selector)', ->
+    it 'finds all markers matching the selector', ->
+      markers\add { {name: 'test1', start_offset: 1, end_offset: 2} }
+      markers\add { {name: 'test2', start_offset: 1, end_offset: 2} }
+      assert.same {
+        {name: 'test1', start_offset: 1, end_offset: 2}
+      }, markers\find name: 'test1'
+
+      assert.same {
+        {name: 'test2', start_offset: 1, end_offset: 2}
+      }, markers\find name: 'test2'
+      assert.same {}, markers\find foo: 'bar'
+
   it 'markers can overlap', ->
     markers\add { {name: 'test1', start_offset: 2, end_offset: 4} }
     markers\add { {name: 'test2', start_offset: 3, end_offset: 4} }

--- a/lib/ext/moonscript/moonscript/cmd/lint.lua
+++ b/lib/ext/moonscript/moonscript/cmd/lint.lua
@@ -58,7 +58,7 @@ do
     lint_mark_used = function(self, name)
       if self.lint_unused_names and self.lint_unused_names[name] then
         self.lint_unused_names[name] = false
-        return 
+        return
       end
       if self.parent then
         return self.parent:lint_mark_used(name)
@@ -66,7 +66,7 @@ do
     end,
     lint_check_unused = function(self)
       if not (self.lint_unused_names and next(self.lint_unused_names)) then
-        return 
+        return
       end
       local names_by_position = { }
       for name, pos in pairs(self.lint_unused_names) do
@@ -230,7 +230,7 @@ end
 local format_lint
 format_lint = function(errors, code, header)
   if not (next(errors)) then
-    return 
+    return
   end
   local pos_to_line, get_line
   do
@@ -319,5 +319,6 @@ lint_file = function(fname)
 end
 return {
   lint_code = lint_code,
-  lint_file = lint_file
+  lint_file = lint_file,
+  default_whitelist = default_whitelist
 }

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -12,16 +12,16 @@ callbacks = require 'ljglibs.callbacks'
 append = table.insert
 coro_create, coro_status = coroutine.create, coroutine.status
 
-idle_dispatches = {
-  '^signal draw$',
-  '^cursor%-blink$',
-  'timer'
+non_idle_dispatches = {
+  '^signal motion%-',
+  '^signal key%-press%-event',
+  '^signal button%-',
 }
 
 is_idle_dispatch = (desc) ->
-  for p in *idle_dispatches
-    return true if desc\find(p) != nil
-  false
+  for p in *non_idle_dispatches
+    return false if desc\find(p) != nil
+  true
 
 last_activity = get_monotonic_time!
 

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -464,6 +464,7 @@ class Application extends PropertyObject
     require 'howl.editing'
     require 'howl.ui.icons.font_awesome'
     require 'howl.janitor'
+    require 'howl.inspect'
 
   _load_application_icon: =>
     dir = @root_dir

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -30,6 +30,7 @@ class Buffer extends PropertyObject
     @viewers = 0
     @_modified = false
     @sync_revision_id = @_buffer\get_revision_id true
+    @last_changed = sys.time!
 
     @_buffer\add_listener
       on_inserted: self\_on_text_inserted
@@ -299,6 +300,7 @@ class Buffer extends PropertyObject
 
   _on_buffer_modification: (what, args) =>
     @_modified = true
+    @last_changed = sys.time!
     args = {
       buffer: self,
       at_pos: @char_offset(args.offset),

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -22,6 +22,7 @@ class Buffer extends PropertyObject
     @config = config.local_proxy!
     @markers = BufferMarkers @_buffer
     @completers = {}
+    @inspectors = {}
     @mode = mode
     @properties = {}
     @data = {}

--- a/lib/howl/buffer_markers.moon
+++ b/lib/howl/buffer_markers.moon
@@ -56,3 +56,7 @@ class BufferMarkers extends PropertyObject
     end_offset = @a_buffer\byte_offset end_offset
 
     @markers\remove_for_range start_offset, end_offset, selector
+
+  find: (selector) =>
+    ms = @markers\find selector
+    [translate(m, @a_buffer) for m in *ms]

--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -296,7 +296,7 @@ do_howl_eval = (load_f, mode_name, transform_f) ->
     else
       buf = Buffer mode.by_name mode_name
       buf.text = "-- Howl eval (#{mode_name}) =>#{out}"
-      editor\show_popup BufferPopup buf
+      editor\show_popup BufferPopup buf, scrollable: true
     howl.clipboard.push out
    else
     log.error "(ERROR) => #{ret[2]}"
@@ -358,7 +358,7 @@ command.register
       editor.buffer = buf
     else
       buf\insert "-- #{title}\n", 1
-      editor\show_popup BufferPopup buf
+      editor\show_popup BufferPopup buf, scrollable: true
 
 -----------------------------------------------------------------------
 -- Launch commands

--- a/lib/howl/commands/edit_commands.moon
+++ b/lib/howl/commands/edit_commands.moon
@@ -119,7 +119,7 @@ command.register
       if node and node.description
         buf = Buffer mode.by_name('markdown')
         buf.text = node.description
-        app.editor\show_popup BufferPopup buf
+        app.editor\show_popup BufferPopup buf, scrollable: true
         return
 
     log.info "No documentation found for '#{ctx.word}'"

--- a/lib/howl/config.moon
+++ b/lib/howl/config.moon
@@ -95,7 +95,8 @@ define = (var = {}) ->
     var = moon.copy var
     predef = predefined_types[var.type_of]
     error('Unknown type"' .. var.type_of .. '"', 2) if not predef
-    var[k] = v for k,v in pairs predef
+    for k,v in pairs predef
+      var[k] = v unless var[k] != nil
 
   defs[var.name] = var
   broadcast var.name, var.default, false

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -208,6 +208,16 @@ highlight.define_default 'warning',
   line_type: 'solid'
 
 command.register
+  name: 'buffer-inspect'
+  description: 'Inspects the current buffer for abberations'
+  handler: ->
+    buffer = app.editor.buffer
+    criticize buffer
+    editor or= app\editor_for_buffer buffer
+    if editor
+      update_inspections_display editor
+
+command.register
   name: 'cursor-goto-inspection'
   description: 'Goes to a specific inspection in the current buffer'
   input: ->

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -219,7 +219,9 @@ command.register
           unless i == #inspections
             pbuf\append "\n"
 
-      popup.view.cursor.line = 1
+      with popup.view
+        .cursor.line = 1
+        .base_x = 0
 
       spans = selection.spans
       highlight.remove_all 'search', buffer

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -1,7 +1,7 @@
 -- Copyright 2016 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-{:app, :bindings, :config, :command, :interact, :log, :signal, :config, :timer} = howl
+{:app, :bindings, :command, :inspection, :interact, :log, :signal, :timer} = howl
 {:highlight} = howl.ui
 {:pcall} = _G
 {:concat, :sort} = table
@@ -20,13 +20,12 @@ update_inspections_display = (editor) ->
 load_inspectors = (buffer) ->
   inspectors = {}
 
-  if buffer.inspectors
-    for i in *buffer.inspectors
-      append inspectors, i
-
-  if buffer.mode.inspectors
-    for i in *buffer.mode.inspectors
-      append inspectors, i
+  for inspector in *buffer.config.inspectors
+    conf = inspection[inspector]
+    if conf
+      append inspectors, conf.factory!
+    else
+      log.warn "Invalid inspector '#{inspector}' specified for '#{buffer.title}'"
 
   inspectors
 
@@ -142,17 +141,6 @@ signal.connect 'after-buffer-switch', (args) ->
 
 signal.connect 'app-ready', (args) ->
   timer.on_idle 0.5, on_idle
-
-config.define {
-  name: 'auto_inspect'
-  description: 'When to automatically inspect code for abberrations-'
-  default: 'idle'
-  options: {
-    { 'manual', 'Only inspect when explicitly asked' }
-    { 'idle', 'Inspect on idle' }
-    { 'save', 'Inspect when saving a buffer' }
-  }
-}
 
 highlight.define_default 'error',
   type: highlight.WAVY_UNDERLINE

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -1,0 +1,147 @@
+-- Copyright 2016 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+{:app, :config, :log, :signal, :config} = howl
+{:highlight} = howl.ui
+{:pcall} = _G
+{:concat, :sort} = table
+append = table.insert
+
+update_inspections_display = (editor) ->
+  text = ''
+  inspections = editor.buffer.data.inspections
+  count = inspections and inspections.count
+  if inspections and count > 0
+    text = "(#{count} inspection#{inspections.count > 1 and 's' or ''})"
+
+  editor.indicator.inspections.text = text
+
+load_inspectors = (buffer) ->
+  inspectors = {}
+
+  if buffer.inspectors
+    for i in *buffer.inspectors
+      append inspectors, i
+
+  if buffer.mode.inspectors
+    for i in *buffer.mode.inspectors
+      append inspectors, i
+
+  inspectors
+
+merge = (found, criticisms) ->
+  for c in *found
+    l_nr = c.line
+    criticisms[l_nr] or= {}
+    append criticisms[l_nr], {
+      message: c.message,
+      type: c.type,
+      search: c.search
+    }
+
+get_line_segment = (line, criticism) ->
+  start_pos = line.start_pos
+  end_pos = line.end_pos
+  adjusted = false
+
+  if criticism.search
+    p = r"\\b#{r.escape(criticism.search)}\\b"
+    s, e = line\ufind p, 1
+    if s
+      unless line\ufind p, s + 1
+        end_pos = start_pos + e
+        start_pos += s - 1
+        adjusted = true
+
+  if not adjusted and not line.is_empty
+    start_pos += line.indentation
+
+  start_pos, end_pos
+
+mark_criticisms = (buffer, criticisms) ->
+  {:lines, :markers} = buffer
+  ms = {}
+  line_nrs = [nr for nr in pairs criticisms]
+  sort line_nrs
+
+  for nr in *line_nrs
+    line = lines[nr]
+    list = criticisms[nr]
+    continue unless line and #list > 0
+    for c in *list
+      start_pos, end_pos = get_line_segment line, c
+
+      ms[#ms + 1] = {
+        name: 'inspection',
+        flair: c.type or 'error',
+        start_offset: start_pos,
+        end_offset: end_pos
+        message: c.message
+      }
+
+  criticisms.count = #ms
+  buffer.data.inspections = criticisms
+
+  if #ms > 0
+    markers\add ms
+
+  return #ms
+
+inspect = (buffer) ->
+  criticisms = {}
+
+  for i in *load_inspectors(buffer)
+    status, ret = pcall i, buffer
+    if status
+      if ret
+        merge ret, criticisms
+    else
+      log.error "inspector '#{i}' failed: #{ret}"
+
+  criticisms
+
+criticize = (buffer, criticisms) ->
+  criticisms or= inspect buffer
+  buffer.markers\remove name: 'inspection'
+  mark_criticisms buffer, criticisms
+
+update_buffer = (buffer, editor) ->
+  return unless buffer.config.auto_inspect
+  return unless buffer.size < 1024 * 1020 -- 1MB
+
+  criticize buffer
+  editor or= app\editor_for_buffer buffer
+  if editor
+    update_inspections_display editor
+
+signal.connect 'buffer-modified', (args) ->
+  with args.buffer
+    .markers\remove name: 'inspection'
+    .data.inspections = nil
+
+  editor = app\editor_for_buffer args.buffer
+  if editor
+    editor.indicator.inspections.text = ''
+
+signal.connect 'buffer-saved', (args) ->
+  update_buffer args.buffer
+
+signal.connect 'after-buffer-switch', (args) ->
+  update_buffer args.current_buffer, args.editor
+
+highlight.define_default 'error',
+  type: highlight.UNDERLINE
+  foreground: 'red'
+  line_width: 1
+  line_type: 'dashed'
+
+highlight.define_default 'warning',
+  type: highlight.ROUNDED_RECTANGLE
+  background: 'orange'
+  background_alpha: 0.3
+  foreground: 'white'
+  text_color: 'lightgray'
+  line_width: 0.5
+  line_type: 'dotted'
+
+:inspect, :criticize

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -107,6 +107,7 @@ criticize = (buffer, criticisms) ->
   mark_criticisms buffer, criticisms
 
 update_buffer = (buffer, editor) ->
+  return if buffer.read_only
   data = buffer.data
   if data.last_inspect and data.last_inspect >= buffer.last_changed
     return

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -150,7 +150,7 @@ display_inspections = ->
   -- if we've already displayed the message at this position, punt
   return if pos == last_display_position
 
-  a_markers = editor.buffer.markers
+  a_markers = editor.buffer.markers.markers
   markers = a_markers\at pos
   if #markers == 0 and pos > 1
     markers = a_markers\at pos - 1

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -156,13 +156,13 @@ config.define {
 }
 
 highlight.define_default 'error',
-  type: highlight.UNDERLINE
+  type: highlight.WAVY_UNDERLINE
   foreground: 'red'
   line_width: 1
   line_type: 'dashed'
 
 highlight.define_default 'warning',
-  type: highlight.UNDERLINE
+  type: highlight.WAVY_UNDERLINE
   foreground: 'orange'
   line_width: 1
   line_type: 'dashed'

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -160,12 +160,12 @@ highlight.define_default 'error',
   type: highlight.WAVY_UNDERLINE
   foreground: 'red'
   line_width: 1
-  line_type: 'dashed'
+  line_type: 'solid'
 
 highlight.define_default 'warning',
   type: highlight.WAVY_UNDERLINE
   foreground: 'orange'
   line_width: 1
-  line_type: 'dashed'
+  line_type: 'solid'
 
 :inspect, :criticize

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -152,6 +152,9 @@ display_inspections = (editor) ->
 on_idle = ->
   timer.on_idle 0.5, on_idle
   editor = app.editor
+  -- if there's a popup open already of any sorts, don't interfere
+  return if editor.popup
+
   b = editor.buffer
   if b.config.auto_inspect == 'idle'
     if b.size < 1024 * 1024 * 5 -- 5 MB

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -6,7 +6,8 @@
 {:pcall} = _G
 {:concat, :sort} = table
 append = table.insert
-local popup
+
+local popup, last_display_position
 
 update_inspections_display = (editor) ->
   text = ''
@@ -140,6 +141,10 @@ show_popup = (editor, inspections, pos) ->
 
 display_inspections = (editor) ->
   pos = editor.view.cursor.pos
+
+  -- if we've already displayed the message at this position, punt
+  return if pos == last_display_position
+
   a_markers = editor.buffer.markers
   markers = a_markers\at pos
   if #markers == 0 and pos > 1
@@ -147,6 +152,7 @@ display_inspections = (editor) ->
 
   markers = [{message: m.message, type: m.flair} for m in *markers when m.message]
   if #markers > 0
+    last_display_position = pos
     show_popup editor, markers, editor.cursor.pos
 
 on_idle = ->
@@ -179,6 +185,9 @@ signal.connect 'buffer-saved', (args) ->
 
 signal.connect 'after-buffer-switch', (args) ->
   update_buffer args.current_buffer, args.editor
+
+signal.connect 'cursor-changed', (args) ->
+  last_display_position = nil
 
 signal.connect 'app-ready', (args) ->
   timer.on_idle 0.5, on_idle

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -191,6 +191,9 @@ signal.connect 'after-buffer-switch', (args) ->
 signal.connect 'cursor-changed', (args) ->
   last_display_position = nil
 
+signal.connect 'editor-defocused', (args) ->
+  last_display_position = nil
+
 signal.connect 'app-ready', (args) ->
   timer.on_idle 0.5, on_idle
   timer.on_idle (config.display_inspections_delay / 1000), display_inspections

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -1,7 +1,7 @@
 -- Copyright 2016 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-{:app, :bindings, :command, :inspection, :interact, :log, :signal, :timer} = howl
+{:app, :bindings, :command, :config, :inspection, :interact, :log, :signal, :timer} = howl
 {:ActionBuffer, :BufferPopup, :highlight} = howl.ui
 {:pcall} = _G
 {:concat, :sort} = table
@@ -139,7 +139,12 @@ show_popup = (editor, inspections, pos) ->
     keep_alive: true,
   }
 
-display_inspections = (editor) ->
+display_inspections = ->
+  timer.on_idle (config.display_inspections_delay / 1000), display_inspections
+
+  editor = app.editor
+  return unless editor.has_focus
+
   pos = editor.view.cursor.pos
 
   -- if we've already displayed the message at this position, punt
@@ -166,9 +171,6 @@ on_idle = ->
     if b.size < 1024 * 1024 * 5 -- 5 MB
       update_buffer b, editor
 
-  if editor.has_focus
-    display_inspections editor
-
 signal.connect 'buffer-modified', (args) ->
   with args.buffer
     .markers\remove name: 'inspection'
@@ -191,6 +193,7 @@ signal.connect 'cursor-changed', (args) ->
 
 signal.connect 'app-ready', (args) ->
   timer.on_idle 0.5, on_idle
+  timer.on_idle (config.display_inspections_delay / 1000), display_inspections
 
 highlight.define_default 'error',
   type: highlight.WAVY_UNDERLINE

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -9,10 +9,9 @@ append = table.insert
 
 update_inspections_display = (editor) ->
   text = ''
-  inspections = editor.buffer.data.inspections
-  count = inspections and inspections.count
-  if inspections and count > 0
-    text = "(#{count} inspection#{inspections.count > 1 and 's' or ''})"
+  count = #editor.buffer.markers\find(name: 'inspection')
+  if count > 0
+    text = "(#{count} inspection#{count > 1 and 's' or ''})"
 
   editor.indicator.inspections.text = text
 
@@ -79,8 +78,6 @@ mark_criticisms = (buffer, criticisms) ->
         message: c.message
       }
 
-  criticisms.count = #ms
-  buffer.data.inspections = criticisms
   buffer.data.last_inspect = buffer.last_changed
 
   if #ms > 0
@@ -127,7 +124,6 @@ on_idle = ->
 signal.connect 'buffer-modified', (args) ->
   with args.buffer
     .markers\remove name: 'inspection'
-    .data.inspections = nil
 
   editor = app\editor_for_buffer args.buffer
   if editor

--- a/lib/howl/inspection.moon
+++ b/lib/howl/inspection.moon
@@ -1,0 +1,25 @@
+-- Copyright 2012-2015 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+import PropertyTable from howl.aux
+
+inspections = {}
+
+register = (options = {}) ->
+  error 'Missing parameter `name` for inspection', 2 if not options.name
+  error 'Missing parameter `factory` for inspection', 2 if not options.factory
+
+  inspections[options.name] = options
+
+unregister = (name) ->
+  inspections[name] = nil
+
+mod = setmetatable {
+  :register,
+  :unregister
+  list: get: -> [c for _, c in pairs inspections]
+}, {
+  __index: (key) => inspections[key]
+}
+
+return PropertyTable mod

--- a/lib/howl/interactions/location_selection.moon
+++ b/lib/howl/interactions/location_selection.moon
@@ -12,7 +12,6 @@ interact.register
   handler: (opts) ->
     opts = moon.copy opts
     editor = opts.editor or app.editor
-    buffer = editor.buffer
 
     if howl.config.preview_files or opts.force_preview
       on_change = opts.on_change

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -37,6 +37,7 @@
     ctrl_b:           'switch-buffer'
     ctrl_c:           'editor-copy'
     ctrl_d:           'editor-duplicate-current'
+    ctrl_shift_e:     'cursor-goto-inspection'
     ctrl_f:           'buffer-search-forward'
     ctrl_r:           'buffer-search-backward'
     ctrl_comma:       'buffer-search-word-backward'

--- a/lib/howl/timer.moon
+++ b/lib/howl/timer.moon
@@ -14,12 +14,15 @@ jit.off true, true
 
 idle_handlers = {}
 idle_fired = 0
+last_idle = 0
 
 check_for_idle = ->
   idle = howl.app.idle
-  unless idle >= 1
+  if (last_idle + 0.4) > idle
     idle_fired = 0
-    return
+
+  last_idle = idle
+  return unless idle >= 0.5
 
   fired = {}
   for i = 1, #idle_handlers
@@ -33,7 +36,7 @@ check_for_idle = ->
       fired[#fired + 1] = i
 
   for i = #fired, 1, -1
-    table.remove idle_handlers, i
+    table.remove idle_handlers, fired[i]
 
   idle_fired = idle
 
@@ -92,7 +95,7 @@ on_idle = (seconds, f, ...) ->
 second_handle = {}
 second_handle.cb = callbacks.register every_second, "timer-every-second"
 second_handle.tag = C.g_timeout_add_full C.G_PRIORITY_LOW,
-  1000,
+  500,
   timer_callback,
   cast_arg(second_handle.cb.id),
   nil

--- a/lib/howl/ui/buffer_popup.moon
+++ b/lib/howl/ui/buffer_popup.moon
@@ -16,6 +16,7 @@ class BufferPopup extends Popup
     with @view.config
       .view_show_line_numbers = false
       .view_show_cursor = false
+      .view_show_h_scrollbar = false
 
     @bin = @view\to_gobject!
 
@@ -28,10 +29,7 @@ class BufferPopup extends Popup
   keymap: {
     down: => @view.cursor\down!
     up: => @view.cursor\up!
-    -- right: => @sci\line_scroll 1, 0
-    -- left: => @sci\line_scroll -1, 0
     space: => @view.cursor\page_down!
-    -- backspace: => @sci\page_up!
     page_down: => @view.cursor\page_down!
     page_up: => @view.cursor\page_up!
   }

--- a/lib/howl/ui/buffer_popup.moon
+++ b/lib/howl/ui/buffer_popup.moon
@@ -6,9 +6,32 @@ import View from aullar
 import Popup, style from howl.ui
 {:ceil, :max} = math
 
+keymap = {
+  down: =>
+    @view.first_visible_line += 1
+    @view.cursor.line = @view.first_visible_line
+  up: =>
+    @view.first_visible_line -= 1
+    @view.cursor.line = @view.first_visible_line
+  right: => @view.base_x += @view.width_of_space
+  left: => @view.base_x -= @view.width_of_space
+  home: => @view.base_x = 0
+  end: =>
+    width = @view\block_dimensions @view.first_visible_line, @view.last_visible_line
+    @view.base_x = width - @view.width
+  space: => @view.cursor\page_down!
+  backspace: => @view.cursor\page_up!
+  page_down: => @view.cursor\page_down!
+  page_up: => @view.cursor\page_up!
+  escape: => @close!
+
+  on_unhandled: ->
+    -> true
+}
+
 class BufferPopup extends Popup
 
-  new: (buffer) =>
+  new: (buffer, opts = {}) =>
     error('Missing argument #1: buffer', 3) if not buffer
     @buffer = buffer
     @default_style = style.popup and style.popup.background and 'popup' or 'default'
@@ -17,22 +40,17 @@ class BufferPopup extends Popup
       .view_show_line_numbers = false
       .view_show_cursor = false
       .view_show_h_scrollbar = false
+      .view_show_v_scrollbar = false
 
     @bin = @view\to_gobject!
+    if opts.scrollable
+      @keymap = keymap
 
     super @bin, @_get_dimensions!
 
   resize: =>
     dimensions = @_get_dimensions!
     super dimensions.width, dimensions.height
-
-  keymap: {
-    down: => @view.cursor\down!
-    up: => @view.cursor\up!
-    space: => @view.cursor\page_down!
-    page_down: => @view.cursor\page_down!
-    page_up: => @view.cursor\page_up!
-  }
 
   _get_dimensions: =>
     nr_lines = #@buffer.lines

--- a/lib/howl/ui/command_line.moon
+++ b/lib/howl/ui/command_line.moon
@@ -342,6 +342,10 @@ class CommandLine extends PropertyObject
       @write text
 
   notify: (text, style='info') =>
+    if #text == 0
+      @clear_notification!
+      return
+
     if @notification_widget
       @notification_widget\notify style, text
       @notification_widget\show!

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -694,6 +694,13 @@ class Editor extends PropertyObject
     @_brace_highlight!
     signal.emit 'cursor-changed', editor: self, cursor: @cursor
 
+    inspections = @buffer.data.inspections
+    current = inspections and inspections[@cursor.line]
+    if current
+      markers = @buffer.markers.markers\at @view.cursor.pos
+      markers = [m.message for m in *markers when m.message]
+      log.warning table.concat(markers, '; ')
+
   _get_matching_brace: (byte_pos, start_pos, end_pos) =>
     buffer = @view.buffer
     return if byte_pos < 1 or byte_pos > buffer.size
@@ -806,6 +813,7 @@ with Editor
   .register_indicator 'title', 'top_left'
   .register_indicator 'position', 'bottom_right'
   .register_indicator 'activity', 'top_right', -> Gtk.Spinner!
+  .register_indicator 'inspections', 'bottom_left'
 
 -- Config variables
 

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -694,11 +694,9 @@ class Editor extends PropertyObject
     @_brace_highlight!
     signal.emit 'cursor-changed', editor: self, cursor: @cursor
 
-    inspections = @buffer.data.inspections
-    current = inspections and inspections[@cursor.line]
-    if current
-      markers = @buffer.markers.markers\at @view.cursor.pos
-      markers = [m.message for m in *markers when m.message]
+    markers = @buffer.markers.markers\at @view.cursor.pos
+    markers = [m.message for m in *markers when m.message]
+    if #markers > 0
       log.warning table.concat(markers, '; ')
 
   _get_matching_brace: (byte_pos, start_pos, end_pos) =>

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -504,6 +504,10 @@ class Editor extends PropertyObject
     @remove_popup!
     pos = @buffer\byte_offset options.position or @cursor.pos
     coordinates = @view\coordinates_from_position pos
+    unless coordinates
+      pos = @buffer.lines[@line_at_top].start_pos
+      coordinates = @view\coordinates_from_position pos
+
     x = coordinates.x
     y = coordinates.y2 + 2
 

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -698,12 +698,6 @@ class Editor extends PropertyObject
     @_brace_highlight!
     signal.emit 'cursor-changed', editor: self, cursor: @cursor
 
-    if @has_focus
-      markers = @buffer.markers.markers\at @view.cursor.pos
-      markers = [m.message for m in *markers when m.message]
-      if #markers > 0
-        log.warning table.concat(markers, '; ')
-
   _get_matching_brace: (byte_pos, start_pos, end_pos) =>
     buffer = @view.buffer
     return if byte_pos < 1 or byte_pos > buffer.size

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -698,10 +698,11 @@ class Editor extends PropertyObject
     @_brace_highlight!
     signal.emit 'cursor-changed', editor: self, cursor: @cursor
 
-    markers = @buffer.markers.markers\at @view.cursor.pos
-    markers = [m.message for m in *markers when m.message]
-    if #markers > 0
-      log.warning table.concat(markers, '; ')
+    if @has_focus
+      markers = @buffer.markers.markers\at @view.cursor.pos
+      markers = [m.message for m in *markers when m.message]
+      if #markers > 0
+        log.warning table.concat(markers, '; ')
 
   _get_matching_brace: (byte_pos, start_pos, end_pos) =>
     buffer = @view.buffer

--- a/lib/howl/ui/highlight.moon
+++ b/lib/howl/ui/highlight.moon
@@ -6,12 +6,14 @@ flair = require 'aullar.flair'
 -- Highlight styles
 export SANDWICH = flair.SANDWICH
 export UNDERLINE = flair.UNDERLINE
+export WAVY_UNDERLINE = flair.WAVY_UNDERLINE
 export RECTANGLE = flair.RECTANGLE
 export ROUNDED_RECTANGLE = flair.ROUNDED_RECTANGLE
 
 setmetatable {
   SANDWICH: flair.SANDWICH
   UNDERLINE: flair.UNDERLINE
+  WAVY_UNDERLINE: flair.WAVY_UNDERLINE
   RECTANGLE: flair.RECTANGLE
   ROUNDED_RECTANGLE: flair.ROUNDED_RECTANGLE
 

--- a/lib/howl/variables/core_variables.moon
+++ b/lib/howl/variables/core_variables.moon
@@ -27,12 +27,6 @@ config.define
   type_of: 'boolean'
 
 config.define
-  name: 'auto_inspect'
-  description: 'Whether to automatically inspect code for abberrations'
-  default: true
-  type_of: 'boolean'
-
-config.define
   name: 'preview_files'
   description: 'Whether to automatically preview the selected file or buffer'
   default: true

--- a/lib/howl/variables/core_variables.moon
+++ b/lib/howl/variables/core_variables.moon
@@ -27,6 +27,12 @@ config.define
   type_of: 'boolean'
 
 config.define
+  name: 'auto_inspect'
+  description: 'Whether to automatically inspect code for abberrations'
+  default: true
+  type_of: 'boolean'
+
+config.define
   name: 'preview_files'
   description: 'Whether to automatically preview the selected file or buffer'
   default: true

--- a/lib/howl/variables/core_variables.moon
+++ b/lib/howl/variables/core_variables.moon
@@ -50,3 +50,15 @@ config.define {
     { 'save', 'Inspect when saving a buffer' }
   }
 }
+
+config.define {
+  name: 'display_inspections_delay'
+  description: 'The delay before inspections are displayed at the current pos (ms, minimum 500ms)'
+  type_of: 'number'
+  default: 500
+  scope: 'global'
+  validate: (v) ->
+    return false unless type(v) == 'number'
+    v >= 500
+
+}

--- a/lib/howl/variables/core_variables.moon
+++ b/lib/howl/variables/core_variables.moon
@@ -32,3 +32,21 @@ config.define
   default: true
   type_of: 'boolean'
   scope: 'global'
+
+config.define {
+  name: 'inspectors'
+  description: 'List of inspectors to run for a buffer'
+  type_of: 'string_list'
+  default: {}
+}
+
+config.define {
+  name: 'auto_inspect'
+  description: 'When to automatically inspect code for abberrations'
+  default: 'idle'
+  options: {
+    { 'manual', 'Only inspect when explicitly asked' }
+    { 'idle', 'Inspect on idle' }
+    { 'save', 'Inspect when saving a buffer' }
+  }
+}

--- a/site/source/doc/api/buffer.md
+++ b/site/source/doc/api/buffer.md
@@ -78,10 +78,17 @@ contents. If the file does not exist, the buffer's current contents will be
 emptied. The buffer's [title](#title) is automatically updated from the file's
 name as part of the assignment.
 
+### last_changed
+
+A timestamp value, as obtained from [howl.sys.time](sys.html#time), specifying
+when the buffer was last changed due to any modification operation, such as a
+insert or delete. Note that this is not related to any potential [file](#file)
+association, but only reflects the buffer's in-memory status.
+
 ### last_shown
 
-A timestamp value, as obtained from Lua's `os.time`, specifying when the buffer
-was last [showing](#showing).
+A timestamp value, as obtained from [howl.sys.time](sys.html#time), specifying
+when the buffer was last [showing](#showing).
 
 ### length
 

--- a/spec/buffer_markers_spec.moon
+++ b/spec/buffer_markers_spec.moon
@@ -62,6 +62,20 @@ describe 'BufferMarkers', ->
       assert.same {'test2'}, names(markers\for_range(5, 10))
       assert.same {'test1', 'test2'}, names(markers\for_range(1, 6))
 
+  describe 'find(selector)', ->
+    it 'finds all markers matching the selector', ->
+      buffer.text = 'åäö€ᛖ'
+      markers\add { {name: 'test1', start_offset: 1, end_offset: 2} }
+      markers\add { {name: 'test2', start_offset: 3, end_offset: 5} }
+      assert.same {
+        {name: 'test1', start_offset: 1, end_offset: 2}
+      }, markers\find name: 'test1'
+
+      assert.same {
+        {name: 'test2', start_offset: 3, end_offset: 5}
+      }, markers\find name: 'test2'
+      assert.same {}, markers\find foo: 'bar'
+
   describe 'remove(selector)', ->
     it 'removes all markers matching the selector', ->
       buffer.text = 'åäö€ᛖ'

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -32,6 +32,26 @@ describe 'Buffer', ->
     assert.is_true b.modified
     assert.equal b.text, 'hello' -- toggling should not have changed text
 
+  describe '.last_changed', ->
+    sys = howl.sys
+
+    it 'is set to the current time for a new buffer', ->
+      b = buffer 'time'
+      now = math.floor sys.time!
+      assert.is_true math.floor(b.last_changed) > now - 1
+      assert.is_true math.floor(b.last_changed) <= now
+
+    it 'is updated whenever the buffer is changed in some way', ->
+      b = buffer 'time'
+      cur = b.last_changed
+
+      b\insert 'foo', 1
+      assert.is_true b.last_changed > cur
+
+      cur = b.last_changed
+      b\delete 1, 3
+      assert.is_true b.last_changed > cur
+
   it '.read_only can be set to mark the buffer as read-only', ->
     b = buffer 'kept'
     b.read_only = true

--- a/spec/inspect_spec.moon
+++ b/spec/inspect_spec.moon
@@ -1,0 +1,137 @@
+-- Copyright 2016 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+import inspect, Buffer, completion from howl
+import Editor from howl.ui
+append = table.insert
+
+describe 'inspector', ->
+  local buffer, mode
+  before_each ->
+    mode = inspectors: {}
+    buffer = Buffer mode
+
+  describe 'inspect(buffer)', ->
+    it 'runs inspectors specified for the buffer', ->
+      inspector = spy.new -> nil
+      append buffer.inspectors, inspector
+      inspect.inspect(buffer)
+      assert.spy(inspector).was_called_with(buffer)
+
+    it 'runs inspectors specified for the mode', ->
+      inspector = spy.new -> nil
+      append mode.inspectors, inspector
+      inspect.inspect(buffer)
+      assert.spy(inspector).was_called_with(buffer)
+
+    it 'runs all inspectors specified for either buffer or mode', ->
+      b_inspector = spy.new -> nil
+      m_inspector = spy.new -> nil
+      append buffer.inspectors, b_inspector
+      append mode.inspectors, m_inspector
+      inspect.inspect(buffer)
+      assert.spy(b_inspector).was_called_with(buffer)
+      assert.spy(m_inspector).was_called_with(buffer)
+
+    it 'merges inspection results into one scathing result', ->
+      b_inspector = -> { { line: 1, type: 'error', message: 'foo' } }
+      m_inspector = -> {
+        { line: 1, type: 'error', message: 'foo_mode' }
+        { line: 3, type: 'warning', message: 'bar' }
+      }
+      append buffer.inspectors, b_inspector
+      append mode.inspectors, m_inspector
+      res = inspect.inspect(buffer)
+      assert.same {
+        [1]: {
+          { type: 'error', message: 'foo' },
+          { type: 'error', message: 'foo_mode' }
+        }
+        [3]: {
+          { type: 'warning', message: 'bar' }
+        }
+       }, res
+
+  describe 'criticize(buffer, criticism)', ->
+    before_each ->
+      buffer.text = 'linƏ 1\nline 2\nline 3'
+
+    it 'applies inspect markers to the buffer corresponding to criticisms', ->
+      inspect.criticize buffer, {
+        [1]: {
+          {type: 'error', message: 'bar'}
+        },
+        [2]: {
+          {type: 'error', message: 'zed'}
+        }
+       }
+      assert.same {
+        {
+          start_offset: 1,
+          end_offset: 7,
+          name: 'inspection',
+          flair: 'error',
+          message: 'bar'
+        },
+        {
+          start_offset: 8,
+          end_offset: 14,
+          name: 'inspection',
+          flair: 'error',
+          message: 'zed'
+        }
+      }, buffer.markers.all
+
+    it 'starts the visual marker at the start of text for line inspections', ->
+      buffer.text = '  34567\n'
+      inspect.criticize buffer, {
+        [1]: {
+          {type: 'error', message: 'zed'}
+        }
+      }
+      assert.equal 3, buffer.markers.all[1].start_offset
+
+    describe 'when a .search field is present', ->
+      it 'is used for selecting a part of the line to highlight', ->
+        buffer.text = '1 345 7\n'
+        inspect.criticize buffer, {
+          [1]: {
+            {type: 'error', message: 'zed', search: '345'}
+          }
+        }
+        marker = buffer.markers.all[1]
+        assert.equal 3, marker.start_offset
+        assert.equal 6, marker.end_offset
+
+      it 'marks the whole line if the search fails', ->
+        buffer.text = '1234567\n'
+        inspect.criticize buffer, {
+          [1]: {
+            {type: 'error', message: 'zed', search: 'XX'}
+          }
+        }
+        marker = buffer.markers.all[1]
+        assert.equal 1, marker.start_offset
+        assert.equal 8, marker.end_offset
+
+      it 'marks the whole line if the search has multiple matches ', ->
+        buffer.text = 'foo foo\n'
+        inspect.criticize buffer, {
+          [1]: {
+            {type: 'error', message: 'zed', search: 'oo'}
+          }
+        }
+        marker = buffer.markers.all[1]
+        assert.equal 1, marker.start_offset
+        assert.equal 8, marker.end_offset
+
+      it 'is not confused by other substring matches', ->
+        buffer.text = ' res = refresh!\n'
+        inspect.criticize buffer, {
+          [1]: {
+            {type: 'error', message: 'zed', search: 'res'}
+          }
+        }
+        marker = buffer.markers.all[1]
+        assert.equal 2, marker.start_offset
+        assert.equal 5, marker.end_offset


### PR DESCRIPTION
This adds a first version of inspection support for Aullar. Inspectors are registered wit the `inspection` module, and the `inspect` module deals with running these according to configuration settings and displaying the results.

<hr/>
[previously] 

This is a work-in-progress branch for getting a generic inspections framework in place for Howl. It allows inspectors to be present for both buffers and their modes. All inspectors are run, with the results being coalesced and displayed visually for the buffer. As a first proof-of-concept a Moonscript inspector has been implemented (not coincidentally since that works for Howl code).

Current things to consider:

- Currently the inspections are run on save, but work is in progress to add inspections-on-idle as well.
- The inspectors are currently assumed to be Lua functions, but we want to support just specifying an external command to run as well with automatic parsing of the output
- Should we look at generalizing this further to allow arbitrary code to jack into the same structure?
- Inspections are currently cleared upon modification, but that makes it jarring, so that should be changed