### PR TITLE
Line motion commands and bindings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased (in master)
 
+- Added new commands `editor-move-lines-up` and `editor-move-lines-down` bound
+to `alt_up` and `alt_down` by default. These move the current or selected lines
+up (or down) by one line while preserving the selection.
+
 - Upgrade Moonscript to 0.4.0
 
 - Added new command, `editor-replace-exec`, for replacing selection or buffer

--- a/lib/aullar/markers.moon
+++ b/lib/aullar/markers.moon
@@ -84,8 +84,14 @@ define_class {
         m.end_offset -= count
       elseif m.start_offset <= offset and m.end_offset >= end_offset -- enclosing
         m.end_offset -= count
-      else -- otherwise affected, remove it
-        insert to_remove, i
+      else -- partial or full overlap
+        if m.preserve
+          m.start_offset = offset if offset < m.start_offset
+          m.end_offset -= math.min count, (m.end_offset - offset)
+          if m.start_offset == m.end_offset
+            insert to_remove, i
+        else
+          insert to_remove, i
 
     for i = #to_remove, 1, -1
       remove @markers, to_remove[i]

--- a/lib/aullar/spec/markers_spec.moon
+++ b/lib/aullar/spec/markers_spec.moon
@@ -181,12 +181,27 @@ describe 'markers', ->
       markers\shrink 5, 1
       assert.equals 5, markers\at(2)[1].end_offset
 
-    it 'removes partially affected markers', ->
-      markers\add { {name: 'test1', start_offset: 2, end_offset: 4} }
-      markers\add { {name: 'test2', start_offset: 5, end_offset: 10} }
+    context 'for partially affected markers', ->
+      it 'removes markers with marker.preserve = false', ->
+        markers\add { {name: 'test1', start_offset: 2, end_offset: 4} }
+        markers\add { {name: 'test2', start_offset: 5, end_offset: 10} }
 
-      markers\shrink 8, 3
-      assert.same {}, markers\at(5)
+        markers\shrink 8, 3
+        assert.same { {name: 'test1', start_offset: 2, end_offset: 4} }, markers\for_range 1, 100
 
-      markers\shrink 1, 3
-      assert.same {}, markers\at(2)
+        markers\shrink 1, 3
+        assert.same {}, markers\for_range 1, 100
+
+      it 'trims markers with marker.preserve = true', ->
+        markers\add { {name: 'test1', start_offset: 2, end_offset: 4, preserve: true} }
+        markers\add { {name: 'test2', start_offset: 5, end_offset: 10, preserve: true} }
+
+        -- trim end
+        markers\shrink 8, 3
+        assert.same { {name: 'test2', start_offset: 5, end_offset: 8, preserve: true} }, markers\at(5)
+
+        -- trim start
+        markers\shrink 4, 2
+        assert.same { {name: 'test2', start_offset: 4, end_offset: 6, preserve: true} }, markers\at(4)
+
+        assert.same { {name: 'test1', start_offset: 2, end_offset: 4, preserve: true} }, markers\at(2)

--- a/lib/howl/buffer_lines.moon
+++ b/lib/howl/buffer_lines.moon
@@ -9,7 +9,7 @@ get_indentation = (text, config) ->
   leading = text\match '^%s*'
   spaces = leading\count ' '
   tabs = leading\count '\t'
-  spaces + tabs * config.tab_width, #leading
+  spaces + tabs * config.tab_width, #leading, leading
 
 line_mt =
   __index: (k) =>
@@ -138,7 +138,7 @@ Line = (nr, buffer) ->
 
       indentation: (indent) =>
         config = @buffer.config
-        cur_indent, real_indent = get_indentation text!, config
+        cur_indent, real_indent, whitespace = get_indentation text!, config
         return if indent == cur_indent
 
         indent_s = if config.use_tabs
@@ -146,6 +146,10 @@ Line = (nr, buffer) ->
           string.rep('\t', nr_tabs) .. string.rep(' ', indent % config.tab_width)
         else
           string.rep ' ', indent
+
+        while real_indent > 0 and #indent_s > 0 and whitespace[real_indent] == indent_s[#indent_s]
+          real_indent -= 1
+          indent_s = indent_s\sub 1, -2
 
         @replace 1, real_indent, indent_s
 

--- a/lib/howl/commands/edit_commands.moon
+++ b/lib/howl/commands/edit_commands.moon
@@ -176,7 +176,6 @@ command.register
   handler: ->
     editor = howl.app.editor
     buffer = editor.buffer
-    selection = editor.selection
     lines = editor.active_lines
     first = lines[1].nr
     last = lines[#lines].nr
@@ -196,7 +195,6 @@ command.register
   handler: ->
     editor = howl.app.editor
     buffer = editor.buffer
-    selection = editor.selection
     lines = editor.active_lines
     first = lines[1].nr
     last = lines[#lines].nr

--- a/lib/howl/commands/edit_commands.moon
+++ b/lib/howl/commands/edit_commands.moon
@@ -150,8 +150,7 @@ command.register
     pos = app.editor\get_matching_brace cursor.pos
     cursor\move_to(:pos) if pos
 
-
-howl.command.register
+command.register
   name: 'editor-replace-exec'
   description: 'Replace selection with output of selection fed into external command'
   input: ->
@@ -170,3 +169,43 @@ howl.command.register
       log.info "Replaced with output of '#{cmd}'"
     else
       log.error "Failed to run #{cmd}"
+
+command.register
+  name: 'editor-move-lines-up'
+  description: 'Move current or selected lines up by one line'
+  handler: ->
+    editor = howl.app.editor
+    buffer = editor.buffer
+    selection = editor.selection
+    lines = editor.active_lines
+    first = lines[1].nr
+    last = lines[#lines].nr
+    return unless first > 1
+
+    nr = first - 1
+    text = buffer.lines[nr].text
+
+    buffer\as_one_undo ->
+      editor\with_selection_preserved ->
+        buffer.lines\delete nr, nr
+        buffer.lines\insert last, text
+
+command.register
+  name: 'editor-move-lines-down'
+  description: 'Move current or selected lines down by one line'
+  handler: ->
+    editor = howl.app.editor
+    buffer = editor.buffer
+    selection = editor.selection
+    lines = editor.active_lines
+    first = lines[1].nr
+    last = lines[#lines].nr
+    return unless last < #buffer.lines
+
+    nr = last + 1
+    text = buffer.lines[nr].text
+
+    buffer\as_one_undo ->
+      editor\with_selection_preserved ->
+        buffer.lines\delete nr, nr
+        buffer.lines\insert first, text

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -12,6 +12,8 @@
     shift_right:      'cursor-right-extend'
     shift_up:         'cursor-up-extend'
     shift_down:       'cursor-down-extend'
+    alt_up:           'editor-move-lines-up'
+    alt_down:         'editor-move-lines-down'
 
     tab:              'editor-smart-tab'
     shift_tab:        'editor-smart-back-tab'

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -221,64 +221,17 @@ class Editor extends PropertyObject
       @view\insert @buffer.eol
 
   shift_right: =>
-    cursor_line, cursor_col = @cursor.line, @cursor.column
-    anchor_line, anchor_col = nil, nil
-
-    unless @selection.empty
-      line = @buffer.lines\at_pos @selection.anchor
-      anchor_line = line.nr
-      anchor_col = line\virtual_column (@selection.anchor - line.start_pos) + 1
-
-    @transform_active_lines (lines) ->
-      for line in *lines
-        line\indent!
-
-    if anchor_line
-      line = @buffer.lines[anchor_line]
-      unless anchor_col == 1 and anchor_line > cursor_line
-        anchor_col += @buffer.config.indent
-
-      real_column = line\real_column anchor_col
-      @selection.anchor = line.start_pos + real_column - 1
-
-    unless cursor_col == 1 and cursor_line > anchor_line
-      cursor_col += @buffer.config.indent
-
-    @cursor\move_to {
-      line: cursor_line,
-      column: cursor_col,
-      extend: anchor_line != nil
-    }
+    @with_selection_preserved ->
+      @transform_active_lines (lines) ->
+        for line in *lines
+          line\indent!
 
   shift_left: =>
-    cursor_line, cursor_col = @cursor.line, @cursor.column
-    anchor_line, anchor_col, adjust_anchor = nil, nil, false
-    adjust_cursor = @current_line.indentation != 0
-
-    unless @selection.empty
-      line = @buffer.lines\at_pos @selection.anchor
-      anchor_line = line.nr
-      anchor_col = line\virtual_column (@selection.anchor - line.start_pos) + 1
-      adjust_anchor = line.indentation != 0
-
-    @transform_active_lines (lines) ->
-      for line in *lines
-        if line.indentation > 0
-          line\unindent!
-
-    if anchor_line
-      line = @buffer.lines[anchor_line]
-      anchor_col -= @buffer.config.indent if adjust_anchor
-      real_column = line\real_column max(1, anchor_col)
-      @selection.anchor = line.start_pos + real_column - 1
-
-    cursor_col -= @buffer.config.indent if adjust_cursor
-
-    @cursor\move_to {
-      line: cursor_line,
-      column: max(1, cursor_col),
-      extend: anchor_line
-    }
+    @with_selection_preserved ->
+      @transform_active_lines (lines) ->
+        for line in *lines
+          if line.indentation > 0
+            line\unindent!
 
   transform_active_lines: (f) =>
     lines = @active_lines
@@ -294,6 +247,36 @@ class Editor extends PropertyObject
     delta = @current_line.indentation - indentation
     @cursor.column = max 1, column + delta
     @line_at_top = top_line
+    error ret unless status
+
+  with_selection_preserved: (f) =>
+    if @selection.empty
+      return @with_position_restored f
+
+    start_offset, end_offset = @selection.anchor, @selection.cursor
+    invert = start_offset > end_offset
+    start_offset, end_offset = end_offset, start_offset if invert
+
+    @buffer.markers\add {
+      {
+        name: 'howl-selection'
+        :start_offset
+        :end_offset
+        preserve: true
+      }
+    }
+
+    status, ret = pcall f, self
+
+    markers = @buffer.markers\for_range 1, @buffer.length, name: 'howl-selection'
+    @buffer.markers\remove name: 'howl-selection'
+
+    marker = markers[1]
+    if marker
+      start_offset, end_offset = marker.start_offset, marker.end_offset
+      start_offset, end_offset = end_offset, start_offset if invert
+      @selection\set start_offset, end_offset
+
     error ret unless status
 
   preview: (buffer) =>

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -251,7 +251,7 @@ class Editor extends PropertyObject
 
   with_selection_preserved: (f) =>
     if @selection.empty
-      return @with_position_restored f
+      return f!
 
     start_offset, end_offset = @selection.anchor, @selection.cursor
     invert = start_offset > end_offset

--- a/site/source/doc/api/ui/editor.md
+++ b/site/source/doc/api/ui/editor.md
@@ -376,6 +376,13 @@ Invokes `f`, and restores the position to the original line and column after `f`
 has returned. Should the indentation level for the current line have changed,
 attempts to automatically adjust the column for the new indentation.
 
+### with_selection_preserved (f)
+
+Invokes `f`, and preserves any selection - i.e. the selected text stays
+selected. If `f` modifies text outside of the current selection, the selection
+is preserved exactly. If `f` adds or removes text within the selection, the selection
+is adjusted to contain the modified text. If `f` deletes text at the boundary of the selection, the selection is trimmed.
+
 [.active_lines]: #.active_lines
 [.buffer]: #.buffer
 [.current_line]: #.current_line

--- a/spec/buffer_lines_spec.moon
+++ b/spec/buffer_lines_spec.moon
@@ -93,6 +93,27 @@ describe 'BufferLines', ->
         lines[2].indentation = 2
         assert.equal 'first\n  ', buf.text
 
+      context 'when markers are present in the intentation', ->
+        it 'preserves and shifts markers', ->
+          buf.text = '    abc\n'
+          buf.markers\add {{
+            name: 'test'
+            start_offset: 3
+            end_offset: 5
+          }}
+
+          line = buf.lines[1]
+
+          line.indentation -= 1
+          assert.same {{name: 'test', start_offset: 2, end_offset: 4}}, buf.markers\for_range(1, #buf)
+
+          line.indentation -= 1
+          assert.same {{name: 'test', start_offset: 1, end_offset: 3}}, buf.markers\for_range(1, #buf)
+
+          line.indentation += 2
+          assert.same {{name: 'test', start_offset: 3, end_offset: 5}}, buf.markers\for_range(1, #buf)
+
+
     it '.start_pos returns the start position for line', ->
       assert.equal lines[2].start_pos, 7
       buf.text = ''

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -138,11 +138,28 @@ describe 'Editor', ->
       editor\with_selection_preserved f
       assert.spy(f).was_called_with editor
 
-    it 'restores the selection afterwards', ->
+    it 'restores the selected region', ->
       editor\with_selection_preserved ->
         selection\set 1, 2
       assert.equals 10, selection.anchor
       assert.equals 8, selection.cursor
+
+    context 'when buffer is modified outside the selection', ->
+      it 'preserves the selected text', ->
+        editor\with_selection_preserved ->
+          buffer\insert 'abc', 1
+          buffer\insert 'abc', 14
+        assert.equals 13, selection.anchor
+        assert.equals 11, selection.cursor
+
+    context 'when no selection present', ->
+      it 'preserves relative position of cursor', ->
+        selection\set 1, 0
+        editor.cursor.pos = 5
+        editor\with_selection_preserved ->
+          buffer\insert 'abc\n', 1
+          buffer\insert 'abc\n', 10
+        assert.equals 9, editor.cursor.pos
 
   it 'insert(text) inserts the text at the cursor, and moves cursor after text', ->
     buffer.text = 'hƏllo'

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -128,6 +128,22 @@ describe 'Editor', ->
 
         assert.equals 4, cursor.pos
 
+  describe 'with_selection_preserved(f)', ->
+    before_each ->
+      buffer.text = '\nhello hello hello\n'
+      selection\set 10, 8
+
+    it 'calls <f> passing itself a parameter', ->
+      f = spy.new -> nil
+      editor\with_selection_preserved f
+      assert.spy(f).was_called_with editor
+
+    it 'restores the selection afterwards', ->
+      editor\with_selection_preserved ->
+        selection\set 1, 2
+      assert.equals 10, selection.anchor
+      assert.equals 8, selection.cursor
+
   it 'insert(text) inserts the text at the cursor, and moves cursor after text', ->
     buffer.text = 'hƏllo'
     cursor.pos = 6


### PR DESCRIPTION
This adds the following commands:

* `editor-move-lines-up` - moves current or selected lines up by one line
* `editor-move-lines-down` - moves current or selected lines down by one line

See a preview here: https://www.youtube.com/watch?v=w9FPK4XtESo

This also contains the following API changes:

1. Adds a new API method `editor\with_selection_preserved` - this uses the markers to preserve the selection through buffer edits. 

2. Implements the trimming feature for markers that have `preserve: true` set - this causes markers to be trimmed rather than removed when text at either boundary is deleted.

 