### PR TITLE
Generalize the sub_lex_by_inline lexer helper

### DIFF
--- a/bundles/mail-mode/mail_lexer.moon
+++ b/bundles/mail-mode/mail_lexer.moon
@@ -40,7 +40,7 @@ howl.aux.lpeg_lexer ->
   -- quoted correspondence
   quote_pattern = (start, level) ->
     s = "mail_level_#{level}"
-    c(s, start) * sub_lex_by_inline(s, eol, mail_markup)
+    c(s, start) * sub_lex_by_inline(s, scan_until(eol), mail_markup)
 
   quoted = line_start * any {
     quote_pattern('>>>>', 4),

--- a/lib/howl/aux/lpeg_lexer.moon
+++ b/lib/howl/aux/lpeg_lexer.moon
@@ -284,10 +284,15 @@ sub_lex_by_pattern_match_time = (mode_p, mode_style, match_time_p) ->
 sub_lex_by_lexer = (base_style, stop_p, lexer) ->
   Cmt(Cc(base_style) * Cc(lexer) * C(scan_until(stop_p)), lexer_sub_lex_capture)
 
-sub_lex_by_inline = (base_style, stop_p, pattern) ->
+sub_lex_by_inline = (base_style, match_p, pattern) ->
   p = Ct lenient_pattern(pattern)^0
   f = (text) -> p\match text
-  Cmt(Cc(base_style) * Cc(f) * C(scan_until(stop_p)), function_sub_lex_capture)
+  Cmt(Cc(base_style) * Cc(f) * C(match_p), function_sub_lex_capture)
+
+sub_lex_by_inline_match_time = (base_style, match_time_p, pattern) ->
+  p = Ct lenient_pattern(pattern)^0
+  f = (text) -> p\match text
+  Cmt(Cc(base_style) * Cc(f) * C(match_time_p), function_sub_lex_capture)
 
 compose = (mode_name, definition_p) ->
   m = mode.by_name mode_name

--- a/spec/aux/lpeg_lexer_spec.moon
+++ b/spec/aux/lpeg_lexer_spec.moon
@@ -382,13 +382,13 @@ describe 'lpeg_lexer', ->
 
       }, lexer('x2')
 
-  describe 'sub_lex_by_inline(name, base_style, pattern)', ->
-    it 'sub lexes using the provided pattern', ->
+  describe 'sub_lex_by_inline(base_style, match_p, pattern)', ->
+    it 'sub lexes the matched text using the provided pattern', ->
       lexer = l ->
         sub_lexer = capture('number', digit^1)
         sequence {
           capture('keyword', 'x'),
-          sub_lex_by_inline('string', l.eol, sub_lexer)
+          sub_lex_by_inline('string', l.scan_until(l.eol), sub_lexer)
         }
       assert.same {
         1, 'keyword', 2
@@ -399,7 +399,7 @@ describe 'lpeg_lexer', ->
     it 'adds a zero width styling instruction at the end if needed', ->
       lexer = l ->
         sub_lexer = capture('number', digit^1)
-        alpha * sub_lex_by_inline('string', l.eol, sub_lexer)
+        alpha * sub_lex_by_inline('string', l.scan_until(l.eol), sub_lexer)
 
       assert.same {
         2, {


### PR DESCRIPTION
Where it previously internally used scan_until this is now left for the
user. This makes it possible to use arbitrary patterns for matching the
text to be sub lexed, e.g. `scan_through_indented`.