### PR TITLE
Add editor-move-text-left|right commands

### DIFF
--- a/lib/howl/commands/edit_commands.moon
+++ b/lib/howl/commands/edit_commands.moon
@@ -207,3 +207,42 @@ command.register
       editor\with_selection_preserved ->
         buffer.lines\delete nr, nr
         buffer.lines\insert first, text
+
+command.register
+  name: 'editor-move-text-right'
+  description: 'Move selected text or current character right by one character'
+  handler: ->
+    editor = howl.app.editor
+    buffer = editor.buffer
+    start_pos, end_pos = editor.selection\range!
+    unless start_pos
+      start_pos = editor.cursor.pos
+      end_pos = start_pos + 1
+
+    return unless end_pos < #buffer
+
+    buffer\as_one_undo ->
+      editor\with_selection_preserved ->
+        text = buffer\chunk(end_pos, end_pos).text
+        buffer\delete end_pos, end_pos
+        buffer\insert text, start_pos
+
+command.register
+  name: 'editor-move-text-left'
+  description: 'Move selected text or current character left by one character'
+  handler: ->
+    editor = howl.app.editor
+    buffer = editor.buffer
+    start_pos, end_pos = editor.selection\range!
+    unless start_pos
+      start_pos = editor.cursor.pos
+      end_pos = start_pos + 1
+
+    return unless start_pos > 1
+
+    buffer\as_one_undo ->
+      editor\with_selection_preserved ->
+        text = buffer\chunk(start_pos - 1, start_pos - 1).text
+        buffer\insert text, end_pos
+        buffer\delete start_pos - 1, start_pos - 1
+

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -14,6 +14,8 @@
     shift_down:       'cursor-down-extend'
     alt_up:           'editor-move-lines-up'
     alt_down:         'editor-move-lines-down'
+    alt_left:         'editor-move-text-left'
+    alt_right:        'editor-move-text-right'
 
     tab:              'editor-smart-tab'
     shift_tab:        'editor-smart-back-tab'


### PR DESCRIPTION
Adds commands to move the selection (or current character) left and right by one character. Bound to `alt_right` and `alt_left`