### PR TITLE
Added project-other-open command

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased (in master)
 
+- Added a new command `project-other-open` that allows opening a file in any
+  project.
+
 - Added command line help which is invoked by pressing `f1` while any
 interactive command is running. This displays a popup containing a description
 

--- a/lib/howl/commands/file_commands.moon
+++ b/lib/howl/commands/file_commands.moon
@@ -84,6 +84,20 @@ command.register
     app\open_file file
 
 command.register
+  name: 'project-other-open',
+  description: 'Open a file in another project'
+  input: ->
+    selected = interact.select
+      title: 'Project'
+      items: [{root.basename, root.path, :root} for root in *Project.roots]
+      columns: {{style: 'keyword'}, {style: 'comment'}}
+
+    return unless selected
+    return interact.select_file_in_project project: Project.for_file selected.selection.root
+  handler: (file) ->
+    app\open_file file
+
+command.register
   name: 'save',
   description: 'Save the current buffer to file'
   handler: ->

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -94,6 +94,7 @@
   ctrl_o:           'open'
   ctrl_shift_o:     'open-recent'
   ctrl_p:           'project-open'
+  ctrl_shift_p:     'project-other-open'
   ctrl_shift_r:     'exec'
   ctrl_alt_r:       'project-exec'
   ctrl_shift_b:     'project-build'


### PR DESCRIPTION
Lets you first select one project and then a file in the project. It doesn't matter what your current project is  (or if you have one).