### PR TITLE
Add {forward,back}_till_char keybinds to vi mode

### DIFF
--- a/bundles/vi/base_map.moon
+++ b/bundles/vi/base_map.moon
@@ -26,6 +26,22 @@ back_to_char = (event, source, translations, editor) ->
   else
     return false
 
+forward_till_char = (event, source, translations, editor) ->
+  if event.character
+    apply editor, (editor) ->
+      editor\forward_to_match event.character
+      editor.cursor\left!
+  else
+    return false
+
+back_till_char = (event, source, translations, editor) ->
+  if event.character
+    apply editor, (editor) ->
+      editor\backward_to_match event.character
+      editor.cursor\right!
+  else
+    return false
+
 end_of_word = (cursor) ->
   with cursor
     current_pos = .pos
@@ -100,6 +116,8 @@ map = {
 
     f: (editor) -> bindings.capture forward_to_char
     F: (editor) -> bindings.capture back_to_char
+    t: (editor) -> bindings.capture forward_till_char
+    T: (editor) -> bindings.capture back_till_char
     '/': 'buffer-search-forward'
     '?': 'buffer-search-backward'
     n: 'buffer-repeat-search'

--- a/bundles/vi/spec/vi_spec.moon
+++ b/bundles/vi/spec/vi_spec.moon
@@ -102,6 +102,15 @@ describe 'VI', ->
     press 'F', 'i'
     assert.equal 2, cursor.column
 
+  it '<t><character> searches forward in the current line to one character before <character>', ->
+    press 't', 'n'
+    assert.equal 2, cursor.column
+
+  it '<T><character> searches backwards in the current line to one character before <character>', ->
+    cursor.column = 5
+    press 'T', 'i'
+    assert.equal 3, cursor.column
+
   it '<c><w> deletes to the end of word and enters insert', ->
     press 'c', 'w'
     assert.equal ' two', editor.current_line.text


### PR DESCRIPTION
Same as `back_to_char` and `forward_to_char` except they stop one char before the match, like in vi.

Liking Howl so far, expect more vi mode pull requests from me. :)