### PR TITLE
Command history persistence

### DIFF
--- a/lib/howl/ui/command_line.moon
+++ b/lib/howl/ui/command_line.moon
@@ -260,10 +260,14 @@ class CommandLine extends PropertyObject
     table.sort merged_history, (a, b) -> a.timestamp > b.timestamp
     deduped_history = {}
     commands = {}
+    limit = config.command_history_limit
+    count = 0
     for item in *merged_history
       continue if commands[item.cmd.text]
       append deduped_history, item
       commands[item.cmd.text] = true
+      count += 1
+      break if count >= limit
 
     howl.app.settings\save_system 'command_line_history', deduped_history
     @_command_history = deduped_history
@@ -645,6 +649,13 @@ class CommandLine extends PropertyObject
 
 style.define_default 'prompt', 'keyword'
 style.define_default 'keystroke', 'special'
+
+config.define
+  name: 'command_history_limit'
+  description: 'The number of commands persisted in command line history'
+  scope: 'global'
+  type_of: 'number'
+  default: 100
 
 return CommandLine
 

--- a/lib/howl/ui/styled_text.moon
+++ b/lib/howl/ui/styled_text.moon
@@ -12,6 +12,11 @@ style.define_default 'list_header', color: '#5E5E5E', underline: true
 styled_text_mt = {
   __tostring: => @text,
 
+  __serialize: => {
+    text: @text
+    styles: @styles
+  }
+
   __concat: (op1, op2) ->
     text = tostring(op1) .. tostring(op2)
     return text unless typeof(op1) == "StyledText" and typeof(op2) == "StyledText"

--- a/spec/ui/styled_text_spec.moon
+++ b/spec/ui/styled_text_spec.moon
@@ -41,7 +41,7 @@ describe 'StyledText', ->
 
   it 'serializable by serpent into a table', ->
     st = StyledText 'text', {1, 'string', 2}
-    ok, copy = serpent.load serpent.dump(st)
+    _, copy = serpent.load serpent.dump(st)
     assert.equal 'text', copy.text
     assert.same {1, 'string', 2}, copy.styles
 

--- a/spec/ui/styled_text_spec.moon
+++ b/spec/ui/styled_text_spec.moon
@@ -4,6 +4,8 @@
 import StyledText from howl.ui
 import Buffer from howl
 
+serpent = require 'serpent'
+
 describe 'StyledText', ->
 
   it 'has a type of StyledText', ->
@@ -36,6 +38,12 @@ describe 'StyledText', ->
     assert.equal StyledText('foo', {1, 'number', 3}), StyledText('foo', {1, 'number', 3})
     assert.not_equal StyledText('fo1', {1, 'number', 3}), StyledText('foo', {1, 'number', 3})
     assert.not_equal StyledText('foo', {1, 'number', 2}), StyledText('foo', {1, 'number', 3})
+
+  it 'serializable by serpent into a table', ->
+    st = StyledText 'text', {1, 'string', 2}
+    ok, copy = serpent.load serpent.dump(st)
+    assert.equal 'text', copy.text
+    assert.same {1, 'string', 2}, copy.styles
 
   context 'for_table', ->
     it 'returns a table containing rows padded and newline terminated', ->


### PR DESCRIPTION
Implements command line history persistence.

This saves the command line history and reloads it when Howl is started so pressing `up` after `alt_x` will show entries from the previous run. History is synced every time any command is run, so a crash or kill of the Howl process will leave the history saved as well. The saving mechanism attempts to merge new history with saved history so multiple running instances of Howl should not clobber each other's history, but instead produce a merged history.

This also implements full deduplication of history. Rerunning any historical command removes the old record and creates a new one.