### PR TITLE
Updated howl-spec to run each file standalone if desired.

### DIFF
--- a/bin/howl-spec
+++ b/bin/howl-spec
@@ -27,7 +27,18 @@ if [ -n "$busted" ]; then
 
   if [ -f $busted_script ]; then
     export BUSTED='yes'
-    exec $HOWL $busted_script --pattern=_spec.moon $*
+    if [ -z "$HOWL_SPEC_SINGLY" ]; then
+      exec $HOWL $busted_script --pattern=_spec.moon $*
+    else
+      for spec in `find $* -name '*_spec.moon'`
+      do
+        echo $spec
+        $HOWL $busted_script $spec
+        exit_code=$?;
+        if [ "$exit_code" != "0" ]; then exit $exit_code; fi
+      done
+      exit 0
+    fi
   fi
 fi
 


### PR DESCRIPTION
The way to invoke this feature would be:

$ HOWL_SPEC_SINGLY=1 ./bin/howl-spec
$ HOWL_SPEC_SINGLY=1 ./bin/run-all-specs

Execution stops at first failure and return code is propagated back.

This will be useful to ensure that each spec also passes standalone and does not depend on the state left by another spec. This may also be useful to determine which spec is hanging since it prints the file name before execution.

On my machine, running `run-all-specs` with HOWL_SPEC_SINGLY enabled takes 28s, compared to 20s when run without.