### PR TITLE
Fix yielding completers

### DIFF
--- a/lib/howl/ui/completion_popup.moon
+++ b/lib/howl/ui/completion_popup.moon
@@ -18,12 +18,15 @@ class CompletionPopup extends MenuPopup
   @property empty: get: => #@items == 0
 
   complete: =>
+    return if @active
+    @active = true
     @_init_completer!
     @_load_completions!
 
   close: =>
     @completer = nil
     super!
+    @active = nil
 
   on_insert_at_cursor: (editor, args) =>
     return unless @completer

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -505,7 +505,7 @@ class Editor extends PropertyObject
       @popup = nil
 
   complete: =>
-    return if @completion_popup.showing
+    return if @completion_popup.active
     @completion_popup\complete!
     if not @completion_popup.empty
       @show_popup @completion_popup, {


### PR DESCRIPTION
Fixes #248 

Protects double invocation via an explicit `active` flag, rather than `showing`, which may not be immediately set on invocation.