### PR TITLE
Fix location selection for all line numbers.

### DIFF
--- a/lib/howl/interactions/location_selection.moon
+++ b/lib/howl/interactions/location_selection.moon
@@ -19,7 +19,8 @@ interact.register
       preview = Preview!
       opts.on_change = (selection, text, items) ->
         if selection
-          buffer = selection.buffer or preview\get_buffer selection.file
+          buffer = selection.buffer or preview\get_buffer selection.file,
+            full: selection.line_nr and selection.line_nr > 1
           editor\preview buffer
           if selection.line_nr
             editor.line_at_center = selection.line_nr

--- a/lib/howl/interactions/util/preview.moon
+++ b/lib/howl/interactions/util/preview.moon
@@ -11,7 +11,7 @@ new_buffer = (title, text, mode = {}) ->
   buffer.read_only = true
   buffer
 
-get_preview_buffer = (file) ->
+get_preview_buffer = (file, opts={}) ->
   if file.is_directory
     return new_buffer "Directory: #{file.basename}", file.path
 
@@ -20,7 +20,11 @@ get_preview_buffer = (file) ->
 
   buffer_mode = nil
   title = file.basename
-  ok, text = pcall -> file\read(8192) or ''
+  ok, text = pcall ->
+    if opts.full
+      file.contents or ''
+    else
+      file\read(8192) or ''
 
   if ok
     size = file.size
@@ -39,7 +43,7 @@ get_preview_buffer = (file) ->
 ->
   open_buffers = { b.file.path, b for b in *app.buffers when b.file }
   {
-    get_buffer: (file) =>
+    get_buffer: (file, opts={}) =>
       open_buffer = open_buffers[file.path]
-      open_buffer or get_preview_buffer(file)
+      open_buffer or get_preview_buffer(file, opts)
   }


### PR DESCRIPTION
Preview was only loading the first 8K bytes which did not guarantee
that line numbers in select_location would be covered. This forces
loading the entire file if a line number is given.