### PR TITLE
Makes toggle-comment comment if any line not commented

### DIFF
--- a/lib/howl/modes/default_mode.moon
+++ b/lib/howl/modes/default_mode.moon
@@ -94,7 +94,13 @@ class DefaultMode
     return unless prefix
     pattern = r"^\\s*#{r.escape prefix}.*"
 
-    if editor.active_lines[1]\umatch pattern
+    all_active_lines_commented = true
+    for line in *editor.active_lines
+      unless line\umatch pattern
+        all_active_lines_commented = false
+        break
+
+    if all_active_lines_commented
       @uncomment editor
     else
       @comment editor

--- a/lib/howl/modes/default_mode.moon
+++ b/lib/howl/modes/default_mode.moon
@@ -96,7 +96,7 @@ class DefaultMode
 
     all_active_lines_commented = true
     for line in *editor.active_lines
-      unless line\umatch pattern
+      if not line\umatch(pattern) and not line.is_blank
         all_active_lines_commented = false
         break
 

--- a/spec/modes/default_mode_spec.moon
+++ b/spec/modes/default_mode_spec.moon
@@ -327,11 +327,11 @@ describe 'DefaultMode', ->
     context 'when mode provides .comment_syntax', ->
       before_each -> buffer.mode.comment_syntax = '--'
 
-      it 'it uncomments if all selected lines start with the comment prefix', ->
-        buffer.text = '  -- foo\n  -- foo2'
+      it 'uncomments if all non-empty selected lines start with the comment prefix', ->
+        buffer.text = '  -- foo\n\n  -- foo2'
         selection\select_all!
         mode\toggle_comment editor
-        assert.equal '  foo\n  foo2', buffer.text
+        assert.equal '  foo\n\n  foo2', buffer.text
 
       it 'comments if first selected line does not start with the comment prefix', ->
         buffer.text = 'foo\n-- foo2'

--- a/spec/modes/default_mode_spec.moon
+++ b/spec/modes/default_mode_spec.moon
@@ -327,15 +327,29 @@ describe 'DefaultMode', ->
     context 'when mode provides .comment_syntax', ->
       before_each -> buffer.mode.comment_syntax = '--'
 
-      it 'it uncomments if the first line starts with the comment prefix', ->
-        buffer.text = '  -- foo'
+      it 'it uncomments if all selected lines start with the comment prefix', ->
+        buffer.text = '  -- foo\n  -- foo2'
+        selection\select_all!
         mode\toggle_comment editor
-        assert.equal '  foo', buffer.text
+        assert.equal '  foo\n  foo2', buffer.text
 
-      it 'comments if the first line do no start with the comment prefix', ->
-        buffer.text = 'foo'
+      it 'comments if first selected line does not start with the comment prefix', ->
+        buffer.text = 'foo\n-- foo2'
+        selection\select_all!
         mode\toggle_comment editor
-        assert.equal '-- foo', buffer.text
+        assert.equal '-- foo\n-- -- foo2', buffer.text
+
+      it 'comments if any one selected line does not start with the comment prefix', ->
+        buffer.text = '-- foo\nfoo2'
+        selection\select_all!
+        mode\toggle_comment editor
+        assert.equal '-- -- foo\n-- foo2', buffer.text
+
+      it 'comments if no selected line starts with the comment prefix', ->
+        buffer.text = 'foo\nfoo2'
+        selection\select_all!
+        mode\toggle_comment editor
+        assert.equal '-- foo\n-- foo2', buffer.text
 
   describe 'auto-formatting after newline', ->
     it 'indents the new line automatically given the indent patterns', ->


### PR DESCRIPTION
Toggle comment with multiple selected lines only considered the first line
when deciding whether to comment or uncomment.  If the first line was
commented then it attempted to uncomment all lines - leaving already
uncommented lines unchanged.