### PR TITLE
Vendored spec deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,11 @@ sudo: false
 addons:
   apt:
     packages:
-      - luarocks
       - libgtk-3-dev
 
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - luarocks --local --from=http://rocks.moonscript.org install luassert 1.7.6
-  - luarocks --local --from=http://rocks.moonscript.org install lua_cliargs 2.5-4
-  - luarocks --local --from=http://rocks.moonscript.org install busted 1.11.1-2
 
 install:
   - (cd src && make -j 4)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -171,7 +171,6 @@ list of the embedded dependencies with license details:
 
     ===============================================================================
 
-
 ### [Font Awesome](https://fortawesome.github.io/Font-Awesome/)
 
     Font Awesome by Dave Gandy - http://fontawesome.io
@@ -267,3 +266,110 @@ list of the embedded dependencies with license details:
     DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
     FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
     OTHER DEALINGS IN THE FONT SOFTWARE.
+
+### Spec support dependencies
+
+#### ansicolors.lua (https://github.com/kikito/ansicolors.lua)
+
+    Copyright (c) 2009 Rob Hoelz <rob@hoelzro.net>
+    Copyright (c) 2011 Enrique García Cota <enrique.garcia.cota@gmail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+#### lua_cliargs (https://github.com/amireh/lua_cliargs)
+
+    Copyright (c) 2012 Ahmad Amireh
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#### say (https://github.com/Olivine-Labs/say)
+
+    Copyright (c) 2012 Olivine Labs, LLC. Permission is hereby granted, free of
+    charge, to any person obtaining a copy of this software and associated
+    documentation files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use, copy, modify,
+    merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+    to permit persons to whom the Software is furnished to do so, subject to the
+    following conditions: The above copyright notice and this permission notice
+    shall be included in all copies or substantial portions of the Software. THE
+    SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+    INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+    PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#### Penlight (https://github.com/stevedonovan/Penlight)
+
+    Copyright (C) 2009 Steve Donovan, David Manura.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#### luassert (https://github.com/Olivine-Labs/luassert)
+
+    Copyright (c) 2012 Olivine Labs, LLC.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+    of the Software, and to permit persons to whom the Software is furnished to do
+    so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+
+#### busted (http://olivinelabs.com/busted)
+
+    Copyright (c) 2012 Olivine Labs, LLC.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+    of the Software, and to permit persons to whom the Software is furnished to do
+    so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/bin/howl-spec
+++ b/bin/howl-spec
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright 2012-2015 The Howl Developers
+# Copyright 2016 The Howl Developers
 # License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 ROOT=$(cd $(dirname $0)/.. && pwd)
@@ -16,44 +16,16 @@ if [ -z "$HOWL" ]; then
   exit 1
 fi
 
-busted=$(luarocks list busted|grep installed|head -n 1)
-if [ -n "$busted" ]; then
-  version=$(echo "$busted" | awk '{ print $1 }')
-  path=$(echo "$busted" | awk '{ print $4 }')
-  busted_script="$path/busted/$version/bin/busted_bootstrap"
-  if [ ! -f $busted_script ]; then
-    busted_script="$path/busted/$version/bin/busted"
-  fi
-
-  if [ -f $busted_script ]; then
-    export BUSTED='yes'
-    if [ -z "$HOWL_SPEC_SINGLY" ]; then
-      exec $HOWL $busted_script --pattern=_spec.moon $*
-    else
-      for spec in `find $* -name '*_spec.moon'`
-      do
-        echo $spec
-        $HOWL $busted_script $spec
-        exit_code=$?;
-        if [ "$exit_code" != "0" ]; then exit $exit_code; fi
-      done
-      exit 0
-    fi
-  fi
+if [ -z "$HOWL_SPEC_SINGLY" ]; then
+  exec $HOWL --spec --pattern=_spec.moon $*
+else
+  for spec in `find $* -name '*_spec.moon'`
+  do
+    echo $spec
+    $HOWL --spec --pattern=_spec.moon $spec
+    exit_code=$?;
+    if [ "$exit_code" != "0" ]; then exit $exit_code; fi
+  done
+  exit 0
 fi
 
-cat <<ERR
-Error: 'busted' not found
----------------------------------
-
-To run $0 you need to have the busted testing framework installed via luarocks.
-With luarocks installed, execute:
-
-$ luarocks --from=http://rocks.moonscript.org install luassert 1.7.6
-$ luarocks --from=http://rocks.moonscript.org install lua_cliargs 2.5-4
-$ luarocks --from=http://rocks.moonscript.org install busted 1.11.1-2
-
-luarocks might be available from your package manager, or you can install
-it using the instructions from http://luarocks.org
-ERR
-exit 1

--- a/bundles/vi/spec/vi_spec.moon
+++ b/bundles/vi/spec/vi_spec.moon
@@ -24,9 +24,8 @@ describe 'VI', ->
   window\add editor\to_gobject!
   window\show_all!
 
-  howl.app = window: Window!
-
   before_each ->
+    howl.app.window = window: Window!
     buffer = Buffer {}
     buffer.text = text
     lines = buffer.lines
@@ -36,6 +35,7 @@ describe 'VI', ->
     state.activate editor
 
   after_each ->
+    howl.app.window = nil
     state.reset!
     state.deactivate!
     app.editor = nil

--- a/lib/ext/spec-support/ansicolors.lua
+++ b/lib/ext/spec-support/ansicolors.lua
@@ -1,0 +1,100 @@
+-- ansicolors.lua v1.0.2 (2012-08)
+
+-- Copyright (c) 2009 Rob Hoelz <rob@hoelzro.net>
+-- Copyright (c) 2011 Enrique García Cota <enrique.garcia.cota@gmail.com>
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+
+
+-- support detection
+local function isWindows()
+  return type(package) == 'table' and type(package.config) == 'string' and package.config:sub(1,1) == '\\'
+end
+
+local supported = not isWindows()
+if isWindows() then supported = os.getenv("ANSICON") end
+
+local keys = {
+  -- reset
+  reset =      0,
+
+  -- misc
+  bright     = 1,
+  dim        = 2,
+  underline  = 4,
+  blink      = 5,
+  reverse    = 7,
+  hidden     = 8,
+
+  -- foreground colors
+  black     = 30,
+  red       = 31,
+  green     = 32,
+  yellow    = 33,
+  blue      = 34,
+  magenta   = 35,
+  cyan      = 36,
+  white     = 37,
+
+  -- background colors
+  blackbg   = 40,
+  redbg     = 41,
+  greenbg   = 42,
+  yellowbg  = 43,
+  bluebg    = 44,
+  magentabg = 45,
+  cyanbg    = 46,
+  whitebg   = 47
+}
+
+local escapeString = string.char(27) .. '[%dm'
+local function escapeNumber(number)
+  return escapeString:format(number)
+end
+
+local function escapeKeys(str)
+
+  if not supported then return "" end
+
+  local buffer = {}
+  local number
+  for word in str:gmatch("%w+") do
+    number = keys[word]
+    assert(number, "Unknown key: " .. word)
+    table.insert(buffer, escapeNumber(number) )
+  end
+
+  return table.concat(buffer)
+end
+
+local function replaceCodes(str)
+  str = string.gsub(str,"(%%{(.-)})", function(_, str) return escapeKeys(str) end )
+  return str
+end
+
+-- public
+
+local function ansicolors( str )
+  str = tostring(str or '')
+
+  return replaceCodes('%{reset}' .. str .. '%{reset}')
+end
+
+
+return setmetatable({noReset = replaceCodes}, {__call = function (_, str) return ansicolors (str) end})

--- a/lib/ext/spec-support/busted/LICENSE
+++ b/lib/ext/spec-support/busted/LICENSE
@@ -1,0 +1,22 @@
+MIT License Terms
+=================
+
+Copyright (c) 2012 Olivine Labs, LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.

--- a/lib/ext/spec-support/busted/busted_bootstrap
+++ b/lib/ext/spec-support/busted/busted_bootstrap
@@ -1,0 +1,140 @@
+-- Busted command-line runner
+
+local cli = require 'cliargs'
+local utils = require 'pl.utils'
+local path = require 'pl.path'
+local tablex = require 'pl.tablex'
+local busted = require 'busted'
+
+local defaultoutput = busted.defaultoutput
+local defaultpattern = busted.defaultpattern
+local defaultlua = busted.defaultlua
+local lpathprefix = busted.lpathprefix
+local cpathprefix = busted.cpathprefix
+local ansicolors = require "ansicolors"
+
+cli:set_name("busted")
+cli:add_flag("--version", "prints the program's version and exits")
+
+cli:optarg("ROOT", "test script file/folder. Folders will be traversed for any file that matches the --pattern option.", "spec", 1)
+
+cli:add_option("-o, --output=LIBRARY", "output library to load", defaultoutput)
+cli:add_option("-l, --lua=luajit", "path to the execution environment (luajit or lua), picks first available", defaultlua)
+cli:add_option("-d, --cwd=cwd", "path to current working directory", "./")
+cli:add_option("-p, --pattern=pattern", "only run test files matching the Lua pattern", defaultpattern)
+cli:add_option("-t, --tags=tags", "only run tests with these #tags")
+cli:add_option("--exclude-tags=tags", "do not run tests with these #tags, takes precedence over --tags")
+cli:add_option("-m, --lpath=path", "optional path to be prefixed to the Lua module search path", lpathprefix)
+cli:add_option("--cpath=path", "optional path to be prefixed to the Lua C module search path", cpathprefix)
+cli:add_option("-r, --run=run", "config to run from .busted file")
+cli:add_option("--lang=LANG", "language for error messages", "en")
+cli:add_flag("-c, --coverage", "do code coverage analysis (requires 'LuaCov' to be installed)")
+
+cli:add_flag("-v, --verbose", "verbose output of errors")
+cli:add_flag("-s, --enable-sound", "executes 'say' command if available")
+cli:add_flag("--suppress-pending", "suppress 'pending' test output")
+cli:add_flag("--defer-print", "defer print to when test suite is complete")
+
+local args = cli:parse_args()
+
+if args then
+  if args.version then
+    return print(busted._VERSION)
+  end
+
+  local fpath = args.d
+
+  local tasks = nil
+  local bfile = path.normpath(path.join(fpath, ".busted"))
+  local success, err = pcall(function() tasks = loadfile(bfile)() end)
+
+  if args.run ~= "" then
+    if not success then
+      return print(err or "")
+    elseif type(tasks) ~= "table" then
+      return print("Aborting: "..bfile.." file does not return a table.")
+    end
+
+    local runConfig = tasks[args.run]
+
+    if type(runConfig) == "table" then
+      args = tablex.merge(args, runConfig, true)
+    else
+      return print("Aborting: task '"..args.run.."' not found, or not a table")
+    end
+  else
+    if success and type(tasks.default) == "table" then
+      args = tablex.merge(args, tasks.default, true)
+    end
+  end
+
+  local root_file = path.normpath(path.join(fpath, args.ROOT))
+
+  if args.coverage then
+    local result, luacov = pcall(require, "luacov.runner")
+    if not result then
+      return print("LuaCov not found on the system, try running without --coverage option, or install LuaCov first")
+    end
+    -- call it to start
+    luacov()
+    -- exclude busted files
+    table.insert(luacov.configuration.exclude, "busted_bootstrap$")
+    table.insert(luacov.configuration.exclude, "busted%.")
+    table.insert(luacov.configuration.exclude, "luassert%.")
+    table.insert(luacov.configuration.exclude, "say%.")
+    table.insert(luacov.configuration.exclude, "pl%.")
+  end
+
+  if #args.lpath > 0 then
+    lpathprefix = args.lpath
+    lpathprefix = lpathprefix:gsub("^%.[/%\\]", fpath )
+    lpathprefix = lpathprefix:gsub(";%.[/%\\]", ";" .. fpath)
+    package.path = (lpathprefix .. ";" .. package.path):gsub(";;",";")
+  end
+
+  if #args.cpath > 0 then
+    cpathprefix = args.cpath
+    cpathprefix = cpathprefix:gsub("^%.[/%\\]", fpath )
+    cpathprefix = cpathprefix:gsub(";%.[/%\\]", ";" .. fpath)
+    package.cpath = (cpathprefix .. ";" .. package.cpath):gsub(";;",";")
+  end
+
+  local options = {
+    path = fpath,
+    lang = args.lang,
+    root_file = root_file,
+    pattern = args.pattern ~= "" and args.pattern or defaultpattern,
+    verbose = args.verbose,
+    suppress_pending = args["suppress-pending"],
+    defer_print = args["defer-print"],
+    sound = args.s,
+    cwd = args.d,
+    tags = utils.split(args.t, ","),
+    excluded_tags = utils.split(args["exclude-tags"], ","),
+    output = args.output or defaultoutput,
+    success_messages = busted.success_messages or nil,
+    failure_messages = busted.failure_messages or nil,
+    filelist = nil,
+  }
+
+  -- We report an error if the same tag appears in both 'options.tags'
+  -- and 'options.excluded_tags' because it does not make sense for the
+  -- user to tell Busted to include and exclude the same tests at the
+  -- same time.
+  for _,excluded in ipairs(options.excluded_tags) do
+    for _,included in ipairs(options.tags) do
+      if excluded == included then
+        print("Cannot use --tags and --exclude-tags for the same tags")
+        os.exit(1)
+      end
+    end
+  end
+  
+  -- execute tests
+  local status_string, failures = busted(options)
+
+  print((status_string or "").."\n")
+
+  os.exit(failures)
+end
+

--- a/lib/ext/spec-support/busted/core.lua
+++ b/lib/ext/spec-support/busted/core.lua
@@ -1,0 +1,838 @@
+local moon = require('busted.moon')
+local path = require('pl.path')
+local dir = require('pl.dir')
+local tablex = require('pl.tablex')
+local pretty = require('pl.pretty')
+local wrap_done = require('busted.done').new
+
+-- globals
+settimeout = nil
+
+-- exported module table
+local busted = {}
+busted._COPYRIGHT   = "Copyright (c) 2014 Olivine Labs, LLC."
+busted._DESCRIPTION = "A unit testing framework with a focus on being easy to use. http://www.olivinelabs.com/busted"
+busted._VERSION     = "Busted 1.11.1"
+
+-- set defaults
+busted.defaultoutput = path.is_windows and "plain_terminal" or "utf_terminal"
+busted.defaultpattern = '_spec'
+busted.defaultlua = 'luajit'
+busted.lpathprefix = "./src/?.lua;./src/?/?.lua;./src/?/init.lua"
+busted.cpathprefix = path.is_windows and "./csrc/?.dll;./csrc/?/?.dll;" or "./csrc/?.so;./csrc/?/?.so;"
+require('busted.languages.en')-- Load default language pack
+
+-- platform detection
+local system, sayer_pre, sayer_post
+if pcall(require, 'ffi') then
+  system = require('ffi').os
+elseif path.is_windows then
+  system = 'Windows'
+else
+  system = io.popen('uname -s'):read('*l')
+end
+
+if system == 'Linux' then
+  sayer_pre = 'espeak -s 160 '
+  sayer_post = ' > /dev/null 2>&1'
+elseif system and system:match('^Windows') then
+  sayer_pre = 'echo '
+  sayer_post = ' | ptts'
+else
+  sayer_pre = 'say '
+  sayer_post = ''
+end
+system = nil
+
+local options = {}
+local current_context
+local test_is_async
+local current_test_filename
+
+-- report a test-process error as a failed test
+local internal_error = function(description, err)
+  local tag = ""
+
+  if options.tags and #options.tags > 0 then
+    -- tags specified; must insert a tag to make sure the error gets displayed
+    tag = " #"..options.tags[1]
+  end
+
+  if not current_context then
+    busted.reset()
+  end
+
+  busted.describe("Busted process errors occured" .. tag, function()
+    busted.it(description .. tag, function()
+      error(err)
+    end)
+  end)
+end
+
+-- returns current time in seconds
+busted.gettime = os.clock
+if pcall(require, "socket") then
+  busted.gettime = package.loaded["socket"].gettime
+end
+
+local language = function(lang)
+  if lang then
+    busted.messages = require('busted.languages.'..lang)
+    require('luassert.languages.'..lang)
+  end
+end
+
+-- load the outputter as set in the options, revert to default if it fails
+local getoutputter  -- define first to enable recursion
+getoutputter = function(output, opath, default)
+  local success, out, f
+  if output:match(".lua$") then
+    f = function()
+      return loadfile(path.normpath(path.join(opath, output)))()
+    end
+  else
+    f = function()
+      return require('busted.output.'..output)()
+    end
+  end
+
+  success, out = pcall(f)
+
+  if not success then
+    if not default then
+      -- even default failed, so error out the hard way
+      return error("Failed to open the busted default output; " .. tostring(output) .. ".\n"..out)
+    else
+      internal_error("Unable to open output module; requested option '--output=" .. tostring(output).."'.", out)
+      -- retry with default outputter
+      return getoutputter(default, opath)
+    end
+  end
+  return out
+end
+
+-- acquire set of test files from the options specified
+local gettestfiles = function(root_file, pattern)
+  local filelist
+
+  if path.isfile(root_file) then
+    filelist = { root_file }
+  elseif path.isdir(root_file) then
+    local pattern = pattern ~= "" and pattern or busted.defaultpattern
+    filelist = dir.getallfiles(root_file)
+
+    filelist = tablex.filter(filelist, function(filename)
+      return path.basename(filename):find(pattern)
+    end)
+
+    filelist = tablex.filter(filelist, function(filename)
+      if path.is_windows then
+        return not filename:find('%\\%.%w+.%w+')
+      else
+        return not filename:find('/%.%w+.%w+')
+      end
+    end)
+  else
+    filelist = {}
+  end
+
+  return filelist
+end
+
+local is_terra = function(fname)
+  return fname:find(".t", #fname-2, true) and true or false
+end
+
+-- runs a testfile, loading its tests
+local load_testfile = function(filename)
+  current_test_filename = filename
+  local old_TEST = _TEST
+  _TEST = busted._VERSION
+
+  local success, err = pcall(function() 
+    local chunk,err
+    if moon.is_moon(filename) then
+      if moon.has_moon then
+        chunk,err = moon.loadfile(filename)
+      else
+        chunk = function()
+          busted.describe("Moon script not installed", function()
+            busted.pending("File not tested because 'moonscript' isn't installed; "..tostring(filename))
+          end)
+        end
+      end
+    elseif is_terra(filename) then
+      if terralib then
+        chunk,err = terralib.loadfile(filename)
+      else
+        chunk = function()
+          busted.describe("Not running tests under Terra", function()
+            pending("File not tested because tests are not being run with 'terra'; "..tostring(filename))
+          end)
+        end
+      end
+    else
+      chunk,err = loadfile(filename)
+    end
+    
+    if not chunk then
+      error(err,2)
+    end
+    chunk()
+  end)
+
+  if not success then
+    internal_error("Failed executing testfile; " .. tostring(filename), err)
+  end
+
+  _TEST = old_TEST
+end
+
+local play_sound = function(failures)
+  if busted.messages.failure_messages and #busted.messages.failure_messages > 0 and
+    busted.messages.success_messages and #busted.messages.success_messages > 0 then
+
+    math.randomseed(os.time())
+
+    if failures and failures > 0 then
+      io.popen(sayer_pre.."\""..busted.messages.failure_messages[math.random(1, #busted.messages.failure_messages)]:format(failures).."\""..sayer_post)
+    else
+      io.popen(sayer_pre.."\""..busted.messages.success_messages[math.random(1, #busted.messages.success_messages)].."\""..sayer_post)
+    end
+  end
+end
+
+local get_fname = function(short_src)
+  return short_src:match('%"(.-)%"') -- matches first string within double quotes
+end
+
+--=============================
+-- Test engine
+--=============================
+
+local suite = {
+  tests = {},       -- list holding all tests
+  done = {},        -- list (boolean) indicating test was completed (either succesful or failed)
+  started = {},     -- list (boolean) indicating test was started
+  test_index = 1,
+  loop = require('busted.loop.default')
+}
+
+-- execute a list of steps (functions)
+-- each step gets a callback parameter to commence to the next step
+busted.step = function(...)
+  local steps = { ... }
+  if #steps == 1 and type(steps[1]) == 'table' then
+    steps = steps[1]
+  end
+
+  local i = 0
+
+  local do_next
+  do_next = function()
+    i = i + 1
+    if steps[i] then 
+      return steps[i](do_next) -- tail call to preserve stackspace
+    end
+  end
+
+  do_next()
+end
+
+-- Required to use on async callbacks. So busted can catch any errors and mark test as failed
+busted.async = function(f)
+  test_is_async = true
+  if not f then
+    -- this allows async() to be called on its own to mark any test as async.
+    return
+  end
+  local test = suite.tests[suite.test_index]
+
+  local safef = function(...)
+    local result = { suite.loop.pcall(f, ...) }
+
+    if result[1] then
+      return unpack(result, 2)
+    else
+      local err = result[2]
+      if type(err) == "table" then
+        err = pretty.write(err)
+      end
+
+      local stack_trace = debug.traceback("", 2)
+      err, stack_trace = moon.rewrite_traceback(err, stack_trace)
+
+      test.status.type = 'failure'
+      test.status.trace = stack_trace
+      test.status.err = err
+-- TODO: line below tests 'test.done' to be function, but done may also be a table, callable. Yet no tests failed...      
+      assert(type(test.done) == 'function', 'non-test step failed (before/after/etc.):\n'..err)
+      test.done()
+    end
+  end
+
+  return safef
+end
+
+local match_tags = function(testName)
+  if #options.tags > 0 then
+
+    for t = 1, #options.tags do
+      if testName:find(options.tags[t]) then
+        return true
+      end
+    end
+
+    return false
+  else
+    -- default to true if no tags are set
+    return true
+  end
+end
+
+local match_excluded_tags = function(testName)
+  if #options.excluded_tags > 0 then
+
+    for t = 1, #options.excluded_tags do
+      if testName:find(options.excluded_tags[t]) then
+        return true
+      end
+    end
+
+  end
+
+  -- By default we return false so that Busted will not exclude a test
+  -- unless explicitly told to do so.
+  return false
+end
+
+-- wraps test callbacks (it, for_each, setup, etc.) to ensure that sync
+-- tests also call the `done` callback to mark the test/step as complete
+local syncwrapper = function(f)
+  return function(done, ...)
+    test_is_async = nil
+    f(done, ...)
+    if not test_is_async then
+      -- async function wasn't called, so it is a sync test/function
+      -- hence must call it ourselves
+      done()
+    end
+  end
+end
+
+local next_test
+
+next_test = function()
+  if #suite.done == #suite.tests     then return end  -- suite is complete
+  if suite.started[suite.test_index] then return end  -- current test already started
+    
+  suite.started[suite.test_index] = true
+
+  local this_test = suite.tests[suite.test_index]
+  this_test.index = suite.test_index
+  
+
+  assert(this_test, this_test.index..debug.traceback('', 1))
+
+  local steps = {}
+
+  local execute_test = function(do_next)
+    local timer
+    local finally_callback
+
+    finally = function(f)
+      finally_callback = f
+    end
+
+    local done = function()
+      if timer then
+        timer:stop()
+        timer = nil
+      end
+      if this_test.done_trace then
+        if this_test.status.err == nil then
+          local stack_trace = debug.traceback("", 2)
+          err, stack_trace = moon.rewrite_traceback(err, stack_trace)
+
+          this_test.status.err = 'test already "done":"'..this_test.name..'"'
+          this_test.status.err = this_test.status.err..'. First called from '..this_test.done_trace
+          this_test.status.type = 'failure'
+          this_test.status.trace = stack_trace
+        end
+        return
+      end
+
+      assert(this_test.index <= #suite.tests, 'invalid test index: '..this_test.index)
+
+      suite.done[this_test.index] = true
+      -- keep done trace for easier error location when called multiple times
+      local done_trace = debug.traceback("", 2)
+      local err, done_trace = moon.rewrite_traceback(nil, done_trace)
+
+      this_test.done_trace = pretty.write(done_trace)
+
+      if not options.defer_print then
+        busted.output.currently_executing(this_test.status, options)
+      end
+
+      this_test.context:decrement_test_count()
+      if finally_callback then
+         finally_callback()
+         finally_callback = nil
+      end
+
+      do_next()
+    end
+
+    if suite.loop.create_timer then
+      --TODO: global `settimeout` is created for an `it()` test, but never deleted, so it remains in the global namespace
+      --TODO: timeouts should also be available for before/after/before_each/after_each
+      settimeout = function(timeout)
+        if not timer then
+          timer = suite.loop.create_timer(timeout,function()
+            if not this_test.done_trace then
+              this_test.status.type = 'failure'
+              this_test.status.trace = ''
+              this_test.status.err = 'test timeout elapsed ('..timeout..'s)'
+              done()
+            end
+          end)
+        end
+      end
+    else
+      settimeout = nil
+    end
+
+    this_test.done = done
+
+    local trace
+    local ok, err = xpcall(
+      function()
+        this_test.f(wrap_done(done))
+      end,
+      function(err)
+        trace = debug.traceback("", 2)
+        return err
+      end)
+    if ok then
+      -- test returned, set default timer if one hasn't been set already
+      if settimeout and not timer and not this_test.done_trace then
+        --TODO: parametrize constant!
+        settimeout(1.0)
+      end
+    else
+      if type(err) == "table" then
+        err = pretty.write(err)
+      end
+
+      -- remove all frames after the last frame found in the test file
+      local lines = {}
+      local j = 0
+      local last_j = 0
+      for line in trace:gmatch("[^\r\n]+") do
+        j = j + 1
+        lines[j] = line
+        local fname, lineno = line:match('%s+([^:]+):(%d+):')
+        if fname == current_test_filename then
+          last_j = j
+        end
+      end
+      -- the error may not originate from testfile in all cases
+      if last_j then
+        trace = table.concat(lines, trace:match("[\r\n]+"), 1, last_j)
+      end
+
+      err, trace = moon.rewrite_traceback(err, trace)
+
+      this_test.status.type = 'failure'
+      this_test.status.trace = trace
+      this_test.status.err = err
+      done()
+    end
+  end
+
+  local check_before = function(context)
+    if context.before then
+      local execute_before = function(do_next)
+        context.before(wrap_done(
+          function()
+            context.before = nil
+            do_next()
+          end))
+      end
+
+      table.insert(steps, execute_before)
+    end
+  end
+
+  local parents = this_test.context.parents
+
+  for p=1, #parents do
+    check_before(parents[p])
+  end
+
+  check_before(this_test.context)
+
+  for p=1, #parents do
+    if parents[p].before_each then
+      table.insert(steps, parents[p].before_each)
+    end
+  end
+
+  if this_test.context.before_each then
+    table.insert(steps, this_test.context.before_each)
+  end
+
+  table.insert(steps, execute_test)
+
+  if this_test.context.after_each then
+    table.insert(steps, this_test.context.after_each)
+  end
+
+  local post_test = function(do_next)
+    local post_steps = {}
+
+    local check_after = function(context)
+      if context.after then
+        if context:all_tests_done() then
+          local execute_after = function(do_next)
+            context.after(wrap_done(
+              function()
+                context.after = nil
+                do_next()
+              end))
+          end
+
+          table.insert(post_steps, execute_after)
+        end
+      end
+    end
+
+    for p=#parents, 1, -1 do
+      if parents[p].after_each then
+        table.insert(post_steps, parents[p].after_each)
+      end
+    end
+
+    check_after(this_test.context)
+
+    for p=#parents, 1, -1 do
+      check_after(parents[p])
+    end
+
+    local forward = function(do_next)
+      suite.test_index = suite.test_index + 1
+      next_test()
+      do_next()
+    end
+
+    table.insert(post_steps, forward)
+    busted.step(post_steps)
+  end
+
+  table.insert(steps, post_test)
+  busted.step(steps)
+end
+
+local create_context = function(desc)
+  return {
+    desc = desc,
+    parents = {},
+    test_count = 0,
+    increment_test_count = function(self)
+      self.test_count = self.test_count + 1
+      for _, parent in ipairs(self.parents) do
+        parent.test_count = parent.test_count + 1
+      end
+    end,
+
+    decrement_test_count = function(self)
+      self.test_count = self.test_count - 1
+      for _, parent in ipairs(self.parents) do
+        parent.test_count = parent.test_count - 1
+      end
+    end,
+
+    all_tests_done = function(self)
+      return self.test_count == 0
+    end,
+
+    add_parent = function(self, parent)
+      table.insert(self.parents, parent)
+      if parent.desc ~= "" then
+        self.desc = parent.desc .. " / " .. self.desc
+      end
+    end
+  }
+end
+
+
+busted.raw_describe = function(desc, more)
+  local context = create_context(desc)
+
+  for _, parent in ipairs(current_context.parents) do
+    context:add_parent(parent)
+  end
+
+  context:add_parent(current_context)
+
+  local old_context = current_context
+
+  current_context = context
+  assert(type(more) == "function", "Expected function, got "..type(more))
+  more()
+
+  current_context = old_context
+end
+
+local busted_raw_describe = busted.raw_describe -- cache to local for performance (avoid table lookup)
+busted.describe = function(desc, more)
+  if type(more) == "nil" then
+    return function(more)
+      return busted_raw_describe(desc, more)
+    end
+  end
+
+  return busted_raw_describe(desc, more)
+end
+
+busted.setup = function(before_func)
+  assert(type(before_func) == "function", "Expected function, got "..type(before_func))
+  current_context.before = syncwrapper(before_func)
+end
+
+busted.before_each = function(before_func)
+  assert(type(before_func) == "function", "Expected function, got "..type(before_func))
+  current_context.before_each = syncwrapper(before_func)
+end
+
+busted.teardown = function(after_func)
+  assert(type(after_func) == "function", "Expected function, got "..type(after_func))
+  current_context.after = syncwrapper(after_func)
+end
+
+busted.after_each = function(after_func)
+  assert(type(after_func) == "function", "Expected function, got "..type(after_func))
+  current_context.after_each = syncwrapper(after_func)
+end
+
+local function buildInfo(debug_info)
+  local info = {
+    source = debug_info.source,
+    short_src = debug_info.short_src,
+    linedefined = debug_info.linedefined,
+  }
+
+  local fname = get_fname(info.short_src)
+
+  if fname and moon.is_moon(fname) then
+    info.linedefined = moon.rewrite_linenumber(fname, info.linedefined) or info.linedefined
+  end
+
+  return info
+end
+
+busted.pending = function(name)
+  local test = {
+    context = current_context,
+    name = current_context.desc .. " / " .. name
+  }
+
+  if match_excluded_tags(test.name) then
+    return
+  end
+
+  test.context:increment_test_count()
+
+  local debug_info = debug.getinfo(2)
+  test.f = syncwrapper(function() end)
+
+  test.status = {
+    description = test.name,
+    type = 'pending',
+    info = buildInfo(debug_info)
+  }
+
+  if match_tags(test.name) then
+    table.insert(suite.tests, test)
+  end
+end
+
+busted.raw_it = function(name, test_func)
+  assert(type(test_func) == "function", "Expected function, got "..type(test_func))
+
+  local test = {
+    context = current_context,
+    name = current_context.desc .. " / " .. name
+  }
+
+  if match_excluded_tags(test.name) then
+    return
+  end
+
+  test.context:increment_test_count()
+
+  local debug_info = debug.getinfo(test_func)
+  test.f = syncwrapper(test_func)
+
+  test.status = {
+    description = test.name,
+    type = 'success',
+    info = buildInfo(debug_info)
+  }
+
+  if match_tags(test.name) then
+    table.insert(suite.tests, test)
+  end
+end
+
+local busted_raw_it = busted.raw_it -- cache to local for performance (avoid table lookup)
+busted.it = function(name, test_func)
+  if type(test_func) == "nil" then
+    return function(test_func)
+      return busted_raw_it(name, test_func)
+    end
+  end
+
+  return busted_raw_it(name, test_func)
+end
+
+busted.reset = function()
+  current_context = create_context('')
+
+  suite = {
+    tests = {},
+    done = {},
+    started = {},
+    test_index = 1,
+    loop = require('busted.loop.default')
+  }
+
+  busted.output = busted.output_reset
+end
+
+busted.setloop = function(loop)
+  if type(loop) == 'string' then
+     suite.loop = require('busted.loop.'..loop)
+  else
+     assert(loop.step)
+     suite.loop = loop
+  end
+end
+
+busted.run_internal_test = function(describe_tests)
+  local suite_bak = suite
+  local output_bak = busted.output
+  local current_context_bak = current_context
+  busted.reset()
+
+  busted.output = require 'busted.output.stub'()
+  suite = {
+    tests = {},
+    done = {},
+    started = {},
+    test_index = 1,
+    loop = require('busted.loop.default')
+  }
+
+  if type(describe_tests) == 'function' then
+     describe_tests()
+  else
+     load_testfile(describe_tests)
+  end
+
+  repeat
+    next_test()
+    suite.loop.step()
+  until #suite.done == #suite.tests
+
+  local statuses = {}
+
+  for _, test in ipairs(suite.tests) do
+    table.insert(statuses, test.status)
+  end
+
+  suite = suite_bak
+  current_context = current_context_bak
+  busted.output = output_bak
+
+  return statuses
+end
+
+-- test runner
+busted.run = function(got_options)
+  options = got_options
+
+  language(options.lang)
+  busted.output = getoutputter(options.output, options.path, busted.defaultoutput)
+  busted.output_reset = busted.output  -- store in case we need a reset
+  -- if no filelist given, get them
+  options.filelist = options.filelist or gettestfiles(options.root_file, options.pattern)
+  -- load testfiles
+
+  local ms = busted.gettime()
+
+  local statuses = {}
+  local failures = 0
+  local suites = {}
+  local tests = 0
+
+  local function run_suite(s)
+    local old_TEST = _TEST
+    _TEST = busted._VERSION
+
+    suite = s
+    repeat
+      next_test()
+      suite.loop.step()
+    until #suite.done == #suite.tests
+
+    _TEST = old_TEST
+
+    for _, test in ipairs(suite.tests) do
+      table.insert(statuses, test.status)
+      if test.status.type == 'failure' then
+        failures = failures + 1
+      end
+    end
+  end
+
+  -- there's already a test! probably an error
+  if #suite.tests > 0 then
+    run_suite(suite)
+  end
+
+  for i, filename in ipairs(options.filelist) do
+    busted.reset()
+    load_testfile(filename)
+    tests = tests + #suite.tests
+    suites[i] = suite
+  end
+
+  if not options.defer_print then
+    print(busted.output.header('global', tests))
+  end
+
+  for _, s in ipairs(suites) do
+    run_suite(s)
+  end
+
+  --final run time
+  ms = busted.gettime() - ms
+
+  local status_string = busted.output.formatted_status(statuses, options, ms)
+
+  if options.sound then
+    play_sound(failures)
+  end
+
+  if tests == 0 then failures = 1 end -- no tests found, so exitcode should be non-zero
+  return status_string, failures
+end
+
+return setmetatable(busted, {
+  __call = function(self, ...)
+    return busted.run(...)
+  end
+})
+

--- a/lib/ext/spec-support/busted/done.lua
+++ b/lib/ext/spec-support/busted/done.lua
@@ -1,0 +1,110 @@
+local M = {}
+
+-- adds tokens to the current wait list, does not change order/unordered
+M.wait = function(self, ...)
+  local tlist = { ... }
+  for _, token in ipairs(tlist) do
+    if type(token) ~= "string" then
+      error("Wait tokens must be strings. Got "..type(token), 2)
+    end
+    table.insert(self.tokens, token)
+  end
+end
+
+-- set list as unordered, adds tokens to current wait list
+M.wait_unordered = function(self, ...)
+  self.ordered = false
+  self:wait(...)
+end
+
+-- set list as ordered, adds tokens to current wait list
+M.wait_ordered = function(self, ...)
+  self.ordered = true
+  self:wait(...)
+end
+
+-- generates a message listing tokens received/open
+M.tokenlist = function(self)
+  local list
+  if #self.tokens_done == 0 then
+    list = "No tokens received."
+  else
+    list = "Tokens received ("..tostring(#self.tokens_done)..")"
+    local s = ": "
+    for _,t in ipairs(self.tokens_done) do
+      list = list .. s .. "'"..t.."'"
+      s = ", "
+    end
+    list = list .. "."
+  end
+  if #self.tokens == 0 then
+    list = list .. " No more tokens expected."
+  else
+    list = list .. " Tokens not received ("..tostring(#self.tokens)..")"
+    local s = ": "
+    for _, t in ipairs(self.tokens) do
+      list = list .. s .. "'"..t.."'"
+      s = ", "
+    end
+    list = list .. "."
+  end
+  return list
+end
+
+-- marks a token as completed, checks for ordered/unordered, checks for completeness
+M.done = function(self, ...) self:_done(...) end  -- extra wrapper for same error level constant as __call method
+M._done = function(self, token)
+  if token then
+    if type(token) ~= "string" then
+      error("Wait tokens must be strings. Got "..type(token), 3)
+    end
+    if self.ordered then
+      if self.tokens[1] == token then
+        table.remove(self.tokens, 1)
+        table.insert(self.tokens_done, token)
+      else
+        if self.tokens[1] then
+          error(("Bad token, expected '%s' got '%s'. %s"):format(self.tokens[1], token, self:tokenlist()), 3)
+        else
+          error(("Bad token (no more tokens expected) got '%s'. %s"):format(token, self:tokenlist()), 3)
+        end
+      end
+    else
+      -- unordered
+      for i, t in ipairs(self.tokens) do
+        if t == token then
+          table.remove(self.tokens, i)
+          table.insert(self.tokens_done, token)
+          token = nil
+          break
+        end
+      end
+      if token then
+        error(("Unknown token '%s'. %s"):format(token, self:tokenlist()), 3)
+      end
+    end
+  end
+  if not next(self.tokens) then
+    -- no more tokens, so we're really done...
+    self.done_cb()
+  end
+end
+
+
+-- wraps a done callback into a done-object supporting tokens to sign-off
+M.new = function(done_callback)
+  local obj = {
+    tokens = {},
+    tokens_done = {},
+    done_cb = done_callback,
+    ordered = true,  -- default for sign off of tokens
+  }
+  return setmetatable( obj, {
+      __call = function(self, ...)
+        self:_done(...)
+      end,
+      __index = M,
+    })
+end
+
+return M

--- a/lib/ext/spec-support/busted/init.lua
+++ b/lib/ext/spec-support/busted/init.lua
@@ -1,0 +1,24 @@
+-- Expose luassert elements as part of global interface
+assert = require('luassert')
+spy    = require('luassert.spy')
+mock   = require('luassert.mock')
+stub   = require('luassert.stub')
+
+-- Assign default value for strict lua syntax checking
+_TEST  = nil
+
+-- Load and expose busted core as part of global interface
+local busted = require('busted.core')
+
+it          = busted.it
+describe    = busted.describe
+context     = busted.describe
+pending     = busted.pending
+setup       = busted.setup
+teardown    = busted.teardown
+before_each = busted.before_each
+after_each  = busted.after_each
+setloop     = busted.setloop
+async       = busted.async
+
+return busted

--- a/lib/ext/spec-support/busted/languages/ar.lua
+++ b/lib/ext/spec-support/busted/languages/ar.lua
@@ -1,0 +1,42 @@
+local s = require('say')
+
+s:set_namespace("ar")
+
+-- "Pending: test.lua @ 12 \n description
+s:set("output.pending", "عالِق")
+s:set("output.failure", "فَشَل")
+s:set("output.failure", "نَجاح")
+
+s:set("output.pending_plural", "عالِق")
+s:set("output.failure_plural", "إخْفاقات")
+s:set("output.success_plural", "نَجاحات")
+
+s:set("output.pending_zero", "عالِق")
+s:set("output.failure_zero", "إخْفاقات")
+s:set("output.success_zero", "نَجاحات")
+
+s:set("output.pending_single", "عالِق")
+s:set("output.failure_single", "فَشَل")
+s:set("output.success_single", "نَجاح")
+
+s:set("output.seconds", "ثَوانٍ")
+
+-- definitions following are not used within the 'say' namespace
+return {
+  failure_messages = {
+    "فَشِلَت %d مِنْ الإِختِبارات",
+    "فَشِلَت إخْتِباراتُك",
+    "برمجيَّتُكَ ضَعيْفة، أنْصَحُكَ بالتَّقاعُد",
+    "تقع برمجيَّتُكَ في مَنطِقَةِ الخَطَر",
+    "أقترِحُ ألّا تَتَقَدَّم بالإختِبار، علَّ يبْقى الطابِقُ مَستوراَ",
+    "جَدَّتي، فِي أَثْناءِ نَومِها، تَكتبُ بَرمَجياتٍ أفْضلُ مِن هذه",
+    "يَوَدُّ ليْ مُساعَدَتُكْ، لَكِنّْ..."
+  },
+  success_messages = {
+    "رائِع! تَمَّ إجْتِيازُ جَميعُ الإختِباراتِ بِنَجاحٍ",
+    "قُل ما شِئت، لا أكتَرِث: busted شَهِدَ لي!",
+    "حَقَّ عَليْكَ الإفتِخار",
+    "نَجاحٌ مُبْهِر!",
+    "عَليكَ بالإحتِفال؛ نَجَحَت جَميعُ التَجارُب"
+  }
+}

--- a/lib/ext/spec-support/busted/languages/en.lua
+++ b/lib/ext/spec-support/busted/languages/en.lua
@@ -1,0 +1,43 @@
+local s = require('say')
+
+s:set_namespace("en")
+
+-- "Pending: test.lua @ 12 \n description
+s:set("output.pending", "Pending")
+s:set("output.failure", "Failure")
+s:set("output.success", "Success")
+
+s:set("output.pending_plural", "pending")
+s:set("output.failure_plural", "failures")
+s:set("output.success_plural", "successes")
+
+s:set("output.pending_zero", "pending")
+s:set("output.failure_zero", "failures")
+s:set("output.success_zero", "successes")
+
+s:set("output.pending_single", "pending")
+s:set("output.failure_single", "failure")
+s:set("output.success_single", "success")
+
+s:set("output.seconds", "seconds")
+
+-- definitions following are not used within the 'say' namespace
+return {
+  failure_messages = {
+    "You have %d busted specs",
+    "Your specs are busted",
+    "Your code is bad and you should feel bad",
+    "Your code is in the Danger Zone",
+    "Strange game. The only way to win is not to test",
+    "My grandmother wrote better specs on a 3 86",
+    "Every time there's a failure, drink another beer",
+    "Feels bad man"
+  },
+  success_messages = {
+    "Aww yeah, passing specs",
+    "Doesn't matter, had specs",
+    "Feels good, man",
+    "Great success",
+    "Tests pass, drink another beer",
+  }
+}

--- a/lib/ext/spec-support/busted/languages/fr.lua
+++ b/lib/ext/spec-support/busted/languages/fr.lua
@@ -1,0 +1,43 @@
+local s = require('say')
+
+s:set_namespace("fr")
+
+-- "Pending: test.lua @ 12 \n description
+s:set("output.pending", "En attente")
+s:set("output.failure", "Echec")
+s:set("output.success", "Reussite")
+
+s:set("output.pending_plural", "en attente")
+s:set("output.failure_plural", "echecs")
+s:set("output.success_plural", "reussites")
+
+s:set("output.pending_zero", "en attente")
+s:set("output.failure_zero", "echec")
+s:set("output.success_zero", "reussite")
+
+s:set("output.pending_single", "en attente")
+s:set("output.failure_single", "echec")
+s:set("output.success_single", "reussite")
+
+s:set("output.seconds", "secondes")
+
+-- definitions following are not used within the 'say' namespace
+return {
+  failure_messages = {
+    "Vous avez %d test(s) qui a/ont echoue(s)",
+    "Vos tests ont echoue.",
+    "Votre code source est mauvais et vous devrez vous sentir mal",
+    "Vous avez un code source de Destruction Massive",
+    "Jeu plutot etrange game. Le seul moyen de gagner est de ne pas l'essayer",
+    "Meme ma grand-mere ecrivait de meilleurs tests sur un PIII x86",
+    "A chaque erreur, prenez une biere",
+    "Ca craint, mon pote"
+  },
+  success_messages = {
+    "Oh yeah, tests reussis",
+    "Pas grave, y'a eu du succes",
+    "C'est du bon, mon pote. Que du bon!",
+    "Reussi, haut la main!",
+    "Test reussi. Un de plus. Offre toi une biere, sur mon compte!",
+  }
+}

--- a/lib/ext/spec-support/busted/languages/ja.lua
+++ b/lib/ext/spec-support/busted/languages/ja.lua
@@ -1,0 +1,43 @@
+local s = require('say')
+
+s:set_namespace("ja")
+
+-- "Pending: test.lua @ 12 \n description
+s:set("output.pending", "保留")
+s:set("output.failure", "失敗")
+s:set("output.success", "成功")
+
+s:set("output.pending_plural", "保留")
+s:set("output.failure_plural", "失敗")
+s:set("output.success_plural", "成功")
+
+s:set("output.pending_zero", "保留")
+s:set("output.failure_zero", "失敗")
+s:set("output.success_zero", "成功")
+
+s:set("output.pending_single", "保留")
+s:set("output.failure_single", "失敗")
+s:set("output.success_single", "成功")
+
+s:set("output.seconds", "秒")
+
+-- definitions following are not used within the 'say' namespace
+return {
+  failure_messages = {
+    "%d個の仕様が破綻しています",
+    "仕様が破綻しています",
+    "あなたの書くコードは良くないので反省するべきです",
+    "あなたの書くコードは危険地帯にあります",
+    "おかしなゲームです。勝利する唯一の方法はテストをしないことです",
+    "私の祖母でもPentium Pentium III x86の上でもっといいコードを書いていましたよ",
+    "いつも失敗しているのでビールでも飲みましょう",
+    "罪悪感を持ちましょう",
+  },
+  success_messages = {
+    "オォーイェー、テストが通った",
+    "問題ない、テストがある",
+    "順調ですね",
+    "大成功",
+    "テストが通ったし、ビールでも飲もう",
+  }
+}

--- a/lib/ext/spec-support/busted/languages/nl.lua
+++ b/lib/ext/spec-support/busted/languages/nl.lua
@@ -1,0 +1,43 @@
+local s = require('say')
+
+s:set_namespace("nl")
+
+-- "Pending: test.lua @ 12 \n description
+s:set("output.pending", "Hangend")
+s:set("output.failure", "Mislukt")
+s:set("output.success", "Succes")
+
+s:set("output.pending_plural", "hangenden")
+s:set("output.failure_plural", "mislukkingen")
+s:set("output.success_plural", "successen")
+
+s:set("output.pending_zero", "hangend")
+s:set("output.failure_zero", "mislukt")
+s:set("output.success_zero", "successen")
+
+s:set("output.pending_single", "hangt")
+s:set("output.failure_single", "mislukt")
+s:set("output.success_single", "succes")
+
+s:set("output.seconds", "seconden")
+
+-- definitions following are not used within the 'say' namespace
+return {
+  failure_messages = {
+    "Je hebt %d busted specs",
+    "Je specs zijn busted",
+    "Je code is slecht en zo zou jij je ook moeten voelen",
+    "Je code zit in de Gevaren Zone",
+    "Vreemd spelletje. The enige manier om te winnen is door niet te testen",
+    "Mijn oma schreef betere specs op een 3 86",
+    "Elke keer dat iets mislukt, nog een biertje drinken",
+    "Voelt klote man"
+  },
+  success_messages = {
+    "Joeperdepoep, de specs zijn er door",
+    "Doet er niet toe, had specs",
+    "Voelt goed, man",
+    "Fantastisch success",
+    "Testen geslaagd, neem nog een biertje",
+  }
+}

--- a/lib/ext/spec-support/busted/languages/ru.lua
+++ b/lib/ext/spec-support/busted/languages/ru.lua
@@ -1,0 +1,37 @@
+local s = require('say')
+
+s:set_namespace("ru")
+
+-- "Pending: test.lua @ 12 \n description
+s:set("output.pending", "Ожидает")
+s:set("output.failure", "Поломалcя")
+s:set("output.success", "Прошeл")
+
+s:set("output.pending_plural", "ожидают")
+s:set("output.failure_plural", "поломалиcь")
+s:set("output.success_plural", "прошли")
+
+s:set("output.pending_zero", "ожидающих")
+s:set("output.failure_zero", "поломанных")
+s:set("output.success_zero", "прошедших")
+
+s:set("output.pending_single", "ожидает")
+s:set("output.failure_single", "поломался")
+s:set("output.success_single", "прошел")
+
+s:set("output.seconds", "секунд")
+
+---- definitions following are not used within the 'say' namespace
+return {
+  failure_messages = {
+    "У тебя %d просратых тестов",
+    "Твои тесты поломаны",
+    "Твой код говеный - пойди напейся!"
+  },
+  success_messages = {
+    "Поехали!",
+    "Жизнь - хороша!",
+    "Ффух в этот раз пронесло!",
+    "Ура!"
+  }
+}

--- a/lib/ext/spec-support/busted/languages/ua.lua
+++ b/lib/ext/spec-support/busted/languages/ua.lua
@@ -1,0 +1,37 @@
+local s = require('say')
+
+s:set_namespace("ua")
+
+-- "Pending: test.lua @ 12 \n description
+s:set("output.pending", "Очікує")
+s:set("output.failure", "Зламався")
+s:set("output.success", "Пройшов")
+
+s:set("output.pending_plural", "очікують")
+s:set("output.failure_plural", "зламались")
+s:set("output.success_plural", "пройшли")
+
+s:set("output.pending_zero", "очікуючих")
+s:set("output.failure_zero", "зламаних")
+s:set("output.success_zero", "пройдених")
+
+s:set("output.pending_single", "очікує")
+s:set("output.failure_single", "зламався")
+s:set("output.success_single", "пройшов")
+
+s:set("output.seconds", "секунд")
+
+
+---- definitions following are not used within the 'say' namespace
+return {
+  failure_messages = {
+    "Ти зрадив %d тестів!",
+    "Ой йо..",
+    "Вороги поламали наші тести!"
+  },
+  success_messages = {
+    "Слава Україні! Героям Слава!",
+    "Тестування успішно пройдено!",
+    "Всі баги знищено!"
+  }
+}

--- a/lib/ext/spec-support/busted/languages/zh.lua
+++ b/lib/ext/spec-support/busted/languages/zh.lua
@@ -1,0 +1,43 @@
+local s = require('say')
+
+s:set_namespace("zh")
+
+-- "Pending: test.lua @ 12 \n description
+s:set("output.pending", "开发中")
+s:set("output.failure", "失败")
+s:set("output.success", "成功")
+
+s:set("output.pending_plural", "开发中")
+s:set("output.failure_plural", "失败")
+s:set("output.success_plural", "成功")
+
+s:set("output.pending_zero", "开发中")
+s:set("output.failure_zero", "失败")
+s:set("output.success_zero", "成功")
+
+s:set("output.pending_single", "开发中")
+s:set("output.failure_single", "失败")
+s:set("output.success_single", "成功")
+
+s:set("output.seconds", "秒")
+
+-- definitions following are not used within the 'say' namespace 
+return {
+  failure_messages = {
+    "你一共提交了[%d]个测试用例",
+    "又出错了！",
+    "到底哪里不对呢？",
+    "出错了，又要加班了！",
+    "囧，出Bug了！",
+    "据说比尔盖兹也写了一堆Bug，别灰心！",
+    "又出错了，休息一下吧",
+    "Bug好多，心情好坏！"
+  },
+  success_messages = {
+    "牛X，测试通过了！",
+    "测试通过了，感觉不错吧，兄弟！",
+    "哥们，干得漂亮！",
+    "终于通过了！干一杯先！",
+    "阿弥陀佛～，菩萨显灵了！",
+  }
+}

--- a/lib/ext/spec-support/busted/loop/copas.lua
+++ b/lib/ext/spec-support/busted/loop/copas.lua
@@ -1,0 +1,19 @@
+local copas = require'copas'
+local super = require'busted.loop.default'
+
+local protected
+if _VERSION == 'Lua 5.1' then
+   protected = copcall
+else
+   protected = pcall
+end
+
+-- create OO table, using `loop.default` as the ancestor/super class
+return setmetatable({ 
+    step = function()
+      copas.step(0)
+      super.step()  -- call ancestor to check for timers 
+    end,
+    pcall = protected
+  }, { __index = super})
+

--- a/lib/ext/spec-support/busted/loop/default.lua
+++ b/lib/ext/spec-support/busted/loop/default.lua
@@ -1,0 +1,40 @@
+local busted 
+local loop = {}
+local timers = {}
+
+-- the timers implemented here will not be useful within the 
+-- context of the 'default' loop (this file). But they can be used
+-- in combination with coroutine schedulers, see 'busted.loop.copas.lua'
+-- for an example of how the timer code here can be reused.
+
+local checktimers = function()
+  local now = busted.gettime()
+  for _,t in pairs(timers) do
+    if now > t.timeout then
+      t.on_timeout()
+      t:stop()
+    end
+  end
+end
+
+loop.create_timer = function(secs,on_timeout)
+  busted = busted or require("busted")  -- lazy-load to prevent 'require-loop'
+  local timer = {
+    timeout = busted.gettime() + secs,
+    on_timeout = on_timeout,
+    stop = function(self)
+      timers[self] = nil
+    end,
+  }
+  timers[timer] = timer
+  return timer
+end
+
+loop.step = function()
+  busted = busted or require("busted")  -- lazy-load to prevent 'require-loop'
+  checktimers()
+end
+
+loop.pcall = pcall
+
+return loop

--- a/lib/ext/spec-support/busted/loop/ev.lua
+++ b/lib/ext/spec-support/busted/loop/ev.lua
@@ -1,0 +1,29 @@
+local ev = require'ev'
+
+local loop = {}
+
+loop.create_timer = function(secs,on_timeout)
+  local timer
+  timer = ev.Timer.new(function()
+    timer = nil
+    on_timeout()
+  end,secs)
+  
+  timer:start(ev.Loop.default)
+  return {
+    stop = function()
+      if timer then
+        timer:stop(ev.Loop.default)
+        timer = nil
+      end
+    end
+  }
+end
+
+loop.step = function()
+  ev.Loop.default:loop()
+end
+
+loop.pcall = pcall
+
+return loop

--- a/lib/ext/spec-support/busted/moon.lua
+++ b/lib/ext/spec-support/busted/moon.lua
@@ -1,0 +1,77 @@
+local success, ms = pcall(function() return require("moonscript") end)
+
+local is_moon = function(fname)
+  return fname:find(".moon", #fname-6, true) and true or false
+end
+
+if not success then
+  return {
+    has_moon = false,
+    is_moon = is_moon,
+    loadfile = loadfile,
+    rewrite_traceback = function(err, trace) return err, trace end
+  }
+end
+
+local util = require("moonscript.util")
+local line_tables = require("moonscript.line_tables")
+local table = require("table")
+
+local _cache = {}
+
+-- find the line number of `pos` chars into fname
+local lookup_line = function(fname, pos)
+  if not _cache[fname] then
+    local f = io.open(fname)
+    _cache[fname] = f:read("*a")
+    f:close()
+  end
+  return util.pos_to_line(_cache[fname], pos)
+end
+
+local rewrite_linenumber = function(fname, lineno)
+  local tbl = line_tables[fname]  
+  if fname and tbl then    
+    for i = lineno,0,-1 do
+      if tbl[i] then
+        return lookup_line(fname, tbl[i])
+      end
+    end
+  end
+end
+
+local rewrite_traceback = function(err, trace)
+  local lines = {}
+  local j = 0
+
+  local rewrite_one = function(line)
+    if line == nil then
+      return ""
+    end
+
+    local fname, lineno = line:match('[^"]+"([^:]+)".:(%d+):')
+
+    if fname and lineno then
+      local new_lineno = rewrite_linenumber(fname, tonumber(lineno))
+      if new_lineno then
+        line = line:gsub(':' .. lineno .. ':', ':' .. new_lineno .. ':')
+      end
+    end
+    return line
+  end
+
+  for line in trace:gmatch("[^\r\n]+") do
+    j = j + 1
+    lines[j] = rewrite_one(line)
+  end
+
+  return rewrite_one(err), table.concat(lines, trace:match("[\r\n]+"))
+end
+
+return {
+    loadfile=ms.loadfile,
+    has_moon=true,
+    is_moon=is_moon,
+    rewrite_linenumber=rewrite_linenumber,
+    rewrite_traceback=rewrite_traceback
+}

--- a/lib/ext/spec-support/busted/output/TAP.lua
+++ b/lib/ext/spec-support/busted/output/TAP.lua
@@ -1,0 +1,112 @@
+--interface:
+--  output.short_status
+--  output.descriptive_status
+--  output.currently_executing
+
+local s = require 'say'
+
+local output = function()
+  local success_string = function(test_index, test_status)
+    return string.format("ok %d - %s", test_index, test_status.description)
+  end
+
+  local failure_string = function(test_index, test_status)
+    return string.format("not ok %d - %s", test_index, test_status.description)
+  end
+  
+  local error_description = function(status, options)
+    return "\n\n"..s('output.failure')..": "..
+           status.info.short_src.." @ "..
+           status.info.linedefined..
+           "\n"..status.description..
+           "\n"..status.err
+  end
+
+  local pending_string = function(test_index, test_status, options)
+    if not options.suppress_pending then
+      return string.format("ok %d - #SKIP %s", test_index, test_status.description)
+    end
+  end
+
+  local test_length = function(context_tree)
+  end
+
+  local strings = {
+    failure = failure_string,
+    success = success_string,
+    pending = pending_string,
+  }
+
+  local index = 1
+
+  test_length = function(context_tree)
+    local length = 0
+
+    for i,c in ipairs(context_tree) do
+      if(c.type == "describe") then
+        length = length + test_length(c)
+      else
+        length = length + 1
+      end
+    end
+
+    return length
+  end
+
+  format_statuses = function (statuses, options)
+    local short_status = ""
+    local descriptive_status = ""
+    local successes = 0
+    local failures = 0
+    local pendings = 0
+
+    for i,status in ipairs(statuses) do
+      if status.type == "description" then
+        local inner_short_status, inner_descriptive_status, inner_successes, inner_failures, inner_pendings = format_statuses(status, options)
+        successes = inner_successes + successes
+        failures = inner_failures + failures
+        pendings = inner_pendings + pendings
+      elseif status.type == "success" then
+        short_status = short_status..success_string(index, status).."\n"
+        index = index + 1
+        successes = successes + 1
+      elseif status.type == "failure" then
+        short_status = short_status..failure_string(index, status).."\n"
+        descriptive_status = descriptive_status..error_description(status, options).."\n"
+        index = index + 1
+        failures = failures + 1
+      elseif status.type == "pending" then
+        short_status = short_status..pending_string(index, status, options).."\n"
+        index = index + 1
+        pendings = pendings + 1
+      end
+    end
+
+    return short_status, descriptive_status, successes, failures, pendings
+  end
+
+  return {
+    header = function(desc, test_count)
+      io.write("1.."..test_count)
+      io.flush()
+    end,
+
+    formatted_status = function(statuses, options, ms)
+      if options.defer_print then
+        index = 1
+        local str = ""
+
+        return format_statuses(statuses, options)
+      end
+
+      return ""
+    end,
+
+    currently_executing = function(test_status, options)
+      print(strings[test_status.type](index, test_status, options))
+      index = index + 1
+    end
+  }
+end
+
+return output

--- a/lib/ext/spec-support/busted/output/json.lua
+++ b/lib/ext/spec-support/busted/output/json.lua
@@ -1,0 +1,32 @@
+--interface:
+--  output.short_status
+--  output.descriptive_status
+--  output.currently_executing
+
+local json = require("dkjson")
+
+local output = function()
+  return {
+    header = function(desc, test_count)
+    end,
+
+
+    formatted_status = function(statuses, options, ms)
+      if options.defer_print then
+        index = 1
+        local str = ""
+
+        return json.encode(statuses)
+      end
+
+      return ""
+    end,
+
+    currently_executing = function(test_status, options)
+      io.write(json.encode(test_status))
+      io.flush()
+    end
+  }
+end
+
+return output

--- a/lib/ext/spec-support/busted/output/junit.lua
+++ b/lib/ext/spec-support/busted/output/junit.lua
@@ -1,0 +1,47 @@
+local xml = require "pl.xml"
+
+local hostname = assert ( io.popen ( "uname -n" ) ):read ( "*l" )
+
+return function ()
+  local node
+  return {
+    header = function(desc, test_count)
+      node = xml.new("testsuite",{
+        errors    = 0 ;
+        failures  = 0 ;
+        hostname  = hostname ;
+        name      = desc ;
+        tests     = 0 ;
+        --time      = ;
+        timestamp = os.time ( ) ;
+        skip      = 0 ;
+      })
+    end ;
+    formatted_status = function(statuses, options, ms)
+      node.attr.time = ms
+      return xml.tostring ( node , "" , "\t" )
+    end ;
+    currently_executing = function(test_status, options,...)
+      -- Update counters
+      node.attr.tests = node.attr.tests + 1
+      if test_status.type == "failure" then
+        node.attr.failures = node.attr.failures + 1
+      end
+      -- Edit node
+      node:addtag ( "testcase" , {
+        classname = test_status.info.short_src .. ":" .. test_status.info.linedefined;
+        name      = test_status.description ;
+        --time      = ;
+      })
+      if test_status.type == "failure" then
+        node:addtag ( "failure" , {
+          message = test_status.err ;
+          --type    = ;
+        })
+        :text ( test_status.trace )
+        :up()
+      end
+      node:up()
+    end ;
+  }
+end

--- a/lib/ext/spec-support/busted/output/plain_terminal.lua
+++ b/lib/ext/spec-support/busted/output/plain_terminal.lua
@@ -1,0 +1,151 @@
+--interface:
+--  output.short_status
+--  output.descriptive_status
+--  output.currently_executing
+
+local s = require 'say'
+
+local output = function()
+  local pending_description = function(status, options)
+    return "\n\n"..s('output.pending')..": "..
+    status.info.short_src.." @ "..
+    status.info.linedefined..
+    "\n"..status.description
+  end
+
+  local error_description = function(status, options)
+    return "\n\n"..s('output.failure')..": "..
+           status.info.short_src.." @ "..
+           status.info.linedefined..
+           "\n"..status.description..
+           "\n"..status.err
+  end
+
+  local success_string = function()
+    return "+"
+  end
+
+  local failure_string = function()
+    return "x"
+  end
+
+  local pending_string = function()
+    return "-"
+  end
+
+  local running_string = function()
+    return "."
+  end
+
+  local status_string = function(short_status, descriptive_status, successes, failures, pendings, ms, options)
+    local success_str = s('output.success_plural')
+    local failure_str = s('output.failure_plural')
+    local pending_str = s('output.pending_plural')
+
+    if successes == 0 then
+      success_str = s('output.success_zero')
+    elseif successes == 1 then
+      success_str = s('output.success_single')
+    end
+
+    if failures == 0 then
+      failure_str = s('output.failure_zero')
+    elseif failures == 1 then
+      failure_str = s('output.failure_single')
+    end
+
+    if pendings == 0 then
+      pending_str = s('output.pending_zero')
+    elseif pendings == 1 then
+      pending_str = s('output.pending_single')
+    end
+
+    if not options.defer_print then
+      io.write("\08 ")
+      short_status = ""
+    end
+
+    local formatted_time = ("%.6f"):format(ms):gsub("([0-9])0+$", "%1")
+
+    return short_status.."\n"..
+           successes.." "..success_str..", "..
+           failures.." "..failure_str..", and "..
+           pendings.." "..pending_str.." in "..
+           formatted_time.." "..s('output.seconds').."."..descriptive_status
+  end
+
+  local format_statuses = function (statuses, options)
+    local short_status = ""
+    local descriptive_status = ""
+    local successes = 0
+    local failures = 0
+    local pendings = 0
+
+    for i,status in ipairs(statuses) do
+      if status.type == "description" then
+        local inner_short_status, inner_descriptive_status, inner_successes, inner_failures, inner_pendings = format_statuses(status, options)
+        short_status = short_status..inner_short_status
+        descriptive_status = descriptive_status..inner_descriptive_status
+        successes = inner_successes + successes
+        failures = inner_failures + failures
+        pendings = inner_pendings + pendings
+      elseif status.type == "success" then
+        short_status = short_status..success_string(options)
+        successes = successes + 1
+      elseif status.type == "failure" then
+        short_status = short_status..failure_string(options)
+        descriptive_status = descriptive_status..error_description(status, options)
+
+        if options.verbose then
+          descriptive_status = descriptive_status.."\n"..status.trace
+        end
+
+        failures = failures + 1
+      elseif status.type == "pending" then
+        short_status = short_status..pending_string(options)
+        pendings = pendings + 1
+
+        if not options.suppress_pending then
+          descriptive_status = descriptive_status..pending_description(status, options)
+        end
+      end
+    end
+
+    return short_status, descriptive_status, successes, failures, pendings
+  end
+
+  local strings = {
+    failure = failure_string,
+    success = success_string,
+    pending = pending_string,
+  }
+
+  local on_first
+  return {
+    options = {},
+
+    header = function(desc, test_count)
+      on_first = true
+    end,
+
+
+    formatted_status = function(statuses, options, ms)
+      local short_status, descriptive_status, successes, failures, pendings = format_statuses(statuses, options)
+      return status_string(short_status, descriptive_status, successes, failures, pendings, ms, options)
+    end,
+
+    currently_executing = function(test_status, options)
+      if on_first then
+        on_first = false
+      else
+        io.write("\08")
+      end
+
+      io.write(strings[test_status.type](options)..running_string(options))
+      io.flush()
+    end
+  }
+end
+
+return output
+

--- a/lib/ext/spec-support/busted/output/stub.lua
+++ b/lib/ext/spec-support/busted/output/stub.lua
@@ -1,0 +1,18 @@
+local output = function()
+  return {
+    options = {},
+
+    header = function(desc, test_count)
+    end,
+
+
+    formatted_status = function(statuses, options, ms)
+    end,
+
+    currently_executing = function(test_status, options)
+    end
+  }
+end
+
+return output
+

--- a/lib/ext/spec-support/busted/output/utf_terminal.lua
+++ b/lib/ext/spec-support/busted/output/utf_terminal.lua
@@ -1,0 +1,153 @@
+--interface:
+--  output.short_status
+--  output.descriptive_status
+--  output.currently_executing
+
+local ansicolors = require "ansicolors"
+local s = require 'say'
+
+local output = function()
+  local pending_description = function(status, options)
+    return "\n\n"..ansicolors("%{yellow}"..s('output.pending')).." → "..
+    ansicolors("%{cyan}"..status.info.short_src).." @ "..
+    ansicolors("%{cyan}"..status.info.linedefined)..
+    "\n"..ansicolors("%{bright}"..status.description)
+  end
+
+  local error_description = function(status, options)
+    return "\n\n"..ansicolors("%{red}"..s('output.failure')).." → "..
+    ansicolors("%{cyan}"..status.info.short_src).." @ "..
+    ansicolors("%{cyan}"..status.info.linedefined)..
+    "\n"..ansicolors("%{bright}"..status.description)..
+    "\n"..status.err
+  end
+
+  local success_string = function()
+    return ansicolors('%{green}●')
+  end
+
+  local failure_string = function()
+    return ansicolors('%{red}●')
+  end
+
+  local pending_string = function()
+    return ansicolors('%{yellow}●')
+  end
+
+  local running_string = function()
+    return ansicolors('%{blue}○')
+  end
+
+  local status_string = function(short_status, descriptive_status, successes, failures, pendings, ms, options)
+    local success_str = s('output.success_plural')
+    local failure_str = s('output.failure_plural')
+    local pending_str = s('output.pending_plural')
+
+    if successes == 0 then
+      success_str = s('output.success_zero')
+    elseif successes == 1 then
+      success_str = s('output.success_single')
+    end
+
+    if failures == 0 then
+      failure_str = s('output.failure_zero')
+    elseif failures == 1 then
+      failure_str = s('output.failure_single')
+    end
+
+    if pendings == 0 then
+      pending_str = s('output.pending_zero')
+    elseif pendings == 1 then
+      pending_str = s('output.pending_single')
+    end
+
+    if not options.defer_print then
+      io.write("\08 ")
+      short_status = ""
+    end
+
+    local formatted_time = ("%.6f"):format(ms):gsub("([0-9])0+$", "%1")
+
+    return short_status.."\n"..
+    ansicolors('%{green}'..successes).." "..success_str.." / "..
+    ansicolors('%{red}'..failures).." "..failure_str.." / "..
+    ansicolors('%{yellow}'..pendings).." "..pending_str.." : "..
+    ansicolors('%{bright}'..formatted_time).." "..s('output.seconds').."."..descriptive_status
+  end
+
+  local format_statuses = function (statuses, options)
+    local short_status = ""
+    local descriptive_status = ""
+    local successes = 0
+    local failures = 0
+    local pendings = 0
+
+    for i,status in ipairs(statuses) do
+      if status.type == "description" then
+        local inner_short_status, inner_descriptive_status, inner_successes, inner_failures, inner_pendings = format_statuses(status, options)
+        short_status = short_status..inner_short_status
+        descriptive_status = descriptive_status..inner_descriptive_status
+        successes = inner_successes + successes
+        failures = inner_failures + failures
+        pendings = inner_pendings + pendings
+      elseif status.type == "success" then
+        short_status = short_status..success_string(options)
+        successes = successes + 1
+      elseif status.type == "failure" then
+        short_status = short_status..failure_string(options)
+        descriptive_status = descriptive_status..error_description(status, options)
+
+        if options.verbose then
+          descriptive_status = descriptive_status.."\n"..status.trace
+        end
+
+        failures = failures + 1
+      elseif status.type == "pending" then
+        short_status = short_status..pending_string(options)
+        pendings = pendings + 1
+
+        if not options.suppress_pending then
+          descriptive_status = descriptive_status..pending_description(status, options)
+        end
+      end
+    end
+
+    return short_status, descriptive_status, successes, failures, pendings
+  end
+
+  local strings = {
+    failure = failure_string,
+    success = success_string,
+    pending = pending_string,
+  }
+
+  local on_first
+
+  return {
+    options = {},
+    name = "utf_whatever",
+
+    header = function(desc, test_count)
+      on_first = true
+    end,
+
+
+    formatted_status = function(statuses, options, ms)
+      local short_status, descriptive_status, successes, failures, pendings = format_statuses(statuses, options)
+      return status_string(short_status, descriptive_status, successes, failures, pendings, ms, options)
+    end,
+
+    currently_executing = function(test_status, options)
+      if on_first then
+        on_first = false
+      else
+        io.write("\08")
+      end
+
+      io.write(strings[test_status.type](options)..running_string(options))
+      io.flush()
+    end
+  }
+end
+
+return output

--- a/lib/ext/spec-support/cliargs.lua
+++ b/lib/ext/spec-support/cliargs.lua
@@ -1,0 +1,568 @@
+local cli, _
+
+-- ------- --
+-- Helpers --
+-- ------- --
+
+local split = function(str, pat)
+  local t = {}
+  local fpat = "(.-)" .. pat
+  local last_end = 1
+  local s, e, cap = str:find(fpat, 1)
+  while s do
+    if s ~= 1 or cap ~= "" then
+      table.insert(t,cap)
+    end
+    last_end = e+1
+    s, e, cap = str:find(fpat, last_end)
+  end
+  if last_end <= #str then
+    cap = str:sub(last_end)
+    table.insert(t, cap)
+  end
+  return t
+end
+
+local buildline = function(words, size, overflow)
+  -- if overflow is set, a word longer than size, will overflow the size
+  -- otherwise it will be chopped in line-length pieces
+  local line = ""
+  if string.len(words[1]) > size then
+    -- word longer than line
+    if overflow then
+      line = words[1]
+      table.remove(words, 1)
+    else
+      line = words[1]:sub(1, size)
+      words[1] = words[1]:sub(size + 1, -1)
+    end
+  else
+    while words[1] and (#line + string.len(words[1]) + 1 <= size) or (line == "" and #words[1] == size) do
+      if line == "" then
+        line = words[1]
+      else
+        line = line .. " " .. words[1]
+      end
+      table.remove(words, 1)
+    end
+  end
+  return line, words
+end
+
+local wordwrap = function(str, size, pad, overflow)
+  -- if overflow is set, then words longer than a line will overflow
+  -- otherwise, they'll be chopped in pieces
+  pad = pad or 0
+
+  local line = ""
+  local out = ""
+  local padstr = string.rep(" ", pad)
+  local words = split(str, ' ')
+
+  while words[1] do
+    line, words = buildline(words, size, overflow)
+    if out == "" then
+      out = padstr .. line
+    else
+        out = out .. "\n" .. padstr .. line
+    end
+  end
+
+  return out
+end
+
+local function disect(key)
+  -- characters allowed are a-z, A-Z, 0-9
+  -- extended + values also allow; # @ _ + -
+  local k, ek, v
+  local dummy
+  -- if there is no comma, between short and extended, add one
+  _, _, dummy = key:find("^%-([%a%d])[%s]%-%-")
+  if dummy then key = key:gsub("^%-[%a%d][%s]%-%-", "-"..dummy..", --", 1) end
+  -- for a short key + value, replace space by "="
+  _, _, dummy = key:find("^%-([%a%d])[%s]")
+  if dummy then key = key:gsub("^%-([%a%d])[ ]", "-"..dummy.."=", 1) end
+  -- if there is no "=", then append one
+  if not key:find("=") then key = key .. "=" end
+  -- get value
+  _, _, v = key:find(".-%=(.+)")
+  -- get key(s), remove spaces
+  key = split(key, "=")[1]:gsub(" ", "")
+  -- get short key & extended key
+  _, _, k = key:find("^%-([%a%d]+)")
+  _, _, ek = key:find("%-%-(.+)$")
+  if v == "" then v = nil end
+  return k,ek,v
+end
+
+
+function cli_error(msg, noprint)
+  local msg = cli.name .. ": error: " .. msg .. '; re-run with --help for usage.'
+  if not noprint then print(msg) end
+  return nil, msg
+end
+
+-- -------- --
+-- CLI Main --
+-- -------- --
+
+cli = {
+  name = "",
+  required = {},
+  optional = {},
+  optargument = {maxcount = 0},
+  colsz = { 0, 0 }, -- column width, help text. Set to 0 for auto detect
+  maxlabel = 0,
+}
+
+--- Assigns the name of the program which will be used for logging.
+function cli:set_name(name)
+  self.name = name
+end
+
+-- Used internally to lookup an entry using either its short or expanded keys
+function cli:__lookup(k, ek, t)
+  t = t or self.optional
+  local _
+  for _,entry in ipairs(t) do
+    if k  and entry.key == k then return entry end
+    if ek and entry.expanded_key == ek then return entry end
+  end
+
+  return nil
+end
+
+--- Defines a required argument.
+--- Required arguments have no special notation and are order-sensitive.
+--- *Note:* the value will be stored in `args[@key]`.
+--- *Aliases: `add_argument`*
+---
+--- ### Parameters
+--- 1. **key**: the argument's "name" that will be displayed to the user
+--- 1. **desc**: a description of the argument
+---
+--- ### Usage example
+--- The following will parse the argument (if specified) and set its value in `args["root"]`:
+--- `cli:add_arg("root", "path to where root scripts can be found")`
+function cli:add_arg(key, desc)
+  assert(type(key) == "string" and type(desc) == "string", "Key and description are mandatory arguments (Strings)")
+
+  if self:__lookup(key, nil, self.required) then
+    error("Duplicate argument: " .. key .. ", please rename one of them.")
+  end
+
+  table.insert(self.required, { key = key, desc = desc, value = nil })
+  if #key > self.maxlabel then self.maxlabel = #key end
+end
+
+--- Defines an optional argument (or more than one).
+--- There can be only 1 optional argument, and is has to be the last one on the argumentlist.
+--- *Note:* the value will be stored in `args[@key]`. The value will be a 'string' if 'maxcount == 1',
+--- or a table if 'maxcount > 1'
+---
+--- ### Parameters
+--- 1. **key**: the argument's "name" that will be displayed to the user
+--- 1. **desc**: a description of the argument
+--- 1. **default**: *optional*; specify a default value (the default is "")
+--- 1. **maxcount**: *optional*; specify the maximum number of occurences allowed (default is 1)
+---
+--- ### Usage example
+--- The following will parse the argument (if specified) and set its value in `args["root"]`:
+--- `cli:add_arg("root", "path to where root scripts can be found", "", 2)`
+--- The value returned will be a table with at least 1 entry and a maximum of 2 entries
+function cli:optarg(key, desc, default, maxcount)
+  assert(type(key) == "string" and type(desc) == "string", "Key and description are mandatory arguments (Strings)")
+  default = default or ""
+  assert(type(default) == "string", "Default value must either be omitted or be a string")
+  maxcount = maxcount or 1
+  maxcount = tonumber(maxcount)
+  assert(maxcount and maxcount>0 and maxcount<1000,"Maxcount must be a number from 1 to 999")
+
+  self.optargument = { key = key, desc = desc, default = default, maxcount = maxcount, value = nil }
+  if #key > self.maxlabel then self.maxlabel = #key end
+end
+
+--- Defines an option.
+--- Optional arguments can use 3 different notations, and can accept a value.
+--- *Aliases: `add_option`*
+---
+--- ### Parameters
+--- 1. **key**: the argument identifier, can be either `-key`, or `-key, --expanded-key`:
+--- if the first notation is used then a value can be defined after a space (`'-key VALUE'`),
+--- if the 2nd notation is used then a value can be defined after an `=` (`'-key, --expanded-key=VALUE'`).
+--- As a final option it is possible to only use the expanded key (eg. `'--expanded-key'`) both with and
+--- without a value specified.
+--- 1. **desc**: a description for the argument to be shown in --help
+--- 1. **default**: *optional*; specify a default value (the default is "")
+---
+--- ### Usage example
+--- The following option will be stored in `args["i"]` and `args["input"]` with a default value of `my_file.txt`:
+--- `cli:add_option("-i, --input=FILE", "path to the input file", "my_file.txt")`
+function cli:add_opt(key, desc, default)
+
+  -- parameterize the key if needed, possible variations:
+  -- 1. -key
+  -- 2. -key VALUE
+  -- 3. -key, --expanded
+  -- 4. -key, --expanded=VALUE
+  -- 5. -key --expanded
+  -- 6. -key --expanded=VALUE
+  -- 7. --expanded
+  -- 8. --expanded=VALUE
+
+  assert(type(key) == "string" and type(desc) == "string", "Key and description are mandatory arguments (Strings)")
+  assert(type(default) == "string" or default == nil or default == false, "Default argument: expected a string or nil")
+
+  local k, ek, v = disect(key)
+
+  if default == false and v ~= nil then
+    error("A flag type option cannot have a value set; " .. key)
+  end
+
+  -- guard against duplicates
+  if self:__lookup(k, ek) then
+    error("Duplicate option: " .. (k or ek) .. ", please rename one of them.")
+  end
+
+  -- set defaults
+  if v == nil then default = false end   -- no value, so its a flag
+  if default == nil then default = "" end
+
+  -- below description of full entry record, nils included for reference
+  local entry = {
+    key = k,
+    expanded_key = ek,
+    desc = desc,
+    default = default,
+    label = key,
+    flag = (default == false),
+    value = default,
+  }
+
+  table.insert(self.optional, entry)
+  if #key > self.maxlabel then self.maxlabel = #key end
+
+end
+
+--- Define a flag argument (on/off). This is a convenience helper for cli.add_opt().
+--- See cli.add_opt() for more information.
+---
+--- ### Parameters
+-- 1. **key**: the argument's key
+-- 1. **desc**: a description of the argument to be displayed in the help listing
+function cli:add_flag(key, desc)
+  self:add_opt(key, desc, false)
+end
+
+--- Parses the arguments found in #arg and returns a table with the populated values.
+--- (NOTE: after succesful parsing, the module will delete itself to free resources)
+--- *Aliases: `parse_args`*
+---
+--- ### Parameters
+--- 1. **noprint**: set this flag to prevent any information (error or help info) from being printed
+--- 1. **dump**: set this flag to dump the parsed variables for debugging purposes, alternatively
+--- set the first option to --__DEBUG__ (option with 2 trailing and leading underscores) to dump at runtime.
+---
+--- ### Returns
+--- 1. a table containing the keys specified when the arguments were defined along with the parsed values,
+--- or nil + error message (--help option is considered an error and returns nil + help message)
+function cli:parse(noprint, dump)
+  arg = arg or {}
+  local args = {}
+  for k,v in pairs(arg) do args[k] = v end  -- copy global args local
+
+  -- starts with --help? display the help listing and abort!
+  if args[1] and (args[1] == "--help" or args[1] == "-h") then
+    return nil, self:print_help(noprint)
+  end
+
+  -- starts with --__DUMP__; set dump to true to dump the parsed arguments
+  if dump == nil then
+    if args[1] and args[1] == "--__DUMP__" then
+      dump = true
+      table.remove(args, 1)  -- delete it to prevent further parsing
+    end
+  end
+
+  while args[1] do
+    local entry = nil
+    local opt = args[1]
+    local _, optpref, optkey, optkey2, optval
+    _, _, optpref, optkey = opt:find("^(%-[%-]?)(.+)")   -- split PREFIX & NAME+VALUE
+    if optkey then
+      _, _, optkey2, optval = optkey:find("(.-)[=](.+)")       -- split value and key
+      if optval then
+        optkey = optkey2
+      end
+    end
+
+    if not optpref then
+      break   -- no optional prefix, so options are done
+    end
+
+    if optkey:sub(-1,-1) == "=" then  -- check on a blank value eg. --insert=
+      optval = ""
+      optkey = optkey:sub(1,-2)
+    end
+
+    if optkey then
+      entry =
+        self:__lookup(optpref == '-' and optkey or nil,
+                      optpref == '--' and optkey or nil)
+    end
+
+    if not optkey or not entry then
+      local option_type = optval and "option" or "flag"
+      return cli_error("unknown/bad " .. option_type .. "; " .. opt, noprint)
+    end
+
+    table.remove(args,1)
+    if optpref == "-" then
+      if optval then
+        return cli_error("short option does not allow value through '='; "..opt, noprint)
+      end
+      if entry.flag then
+        optval = true
+      else
+        -- not a flag, value is in the next argument
+        optval = args[1]
+        table.remove(args, 1)
+      end
+    elseif optpref == "--" and (not optval) then
+      -- using the expanded-key notation with no value, it is possibly a flag
+      entry = self:__lookup(nil, optkey)
+      if entry then
+        if entry.flag then
+          optval = true
+        else
+          return cli_error("option --" .. optkey .. " requires a value to be set", noprint)
+        end
+      else
+        return cli_error("unknown/bad flag; " .. opt, noprint)
+      end
+    end
+
+    entry.value = optval
+  end
+
+  -- missing any required arguments, or too many?
+  if #args < #self.required or #args > #self.required + self.optargument.maxcount then
+    if self.optargument.maxcount > 0 then
+      return cli_error("bad number of arguments; " .. #self.required .."-" .. #self.required + self.optargument.maxcount .. " argument(s) must be specified, not " .. #args, noprint)
+    else
+      return cli_error("bad number of arguments; " .. #self.required .. " argument(s) must be specified, not " .. #args, noprint)
+    end
+  end
+
+  -- deal with required args here
+  for i, entry in ipairs(self.required) do
+    entry.value = args[1]
+    table.remove(args, 1)
+  end
+  -- deal with the last optional argument
+  while args[1] do
+    if self.optargument.maxcount > 1 then
+      self.optargument.value = self.optargument.value or {}
+      table.insert(self.optargument.value, args[1])
+    else
+      self.optargument.value = args[1]
+    end
+    table.remove(args,1)
+  end
+  -- if necessary set the defaults for the last optional argument here
+  if self.optargument.maxcount > 0 and not self.optargument.value then
+    if self.optargument.maxcount == 1 then
+      self.optargument.value = self.optargument.default
+    else
+      self.optargument.value = { self.optargument.default }
+    end
+  end
+
+  -- populate the results table
+  local results = {}
+  if self.optargument.maxcount > 0 then
+    results[self.optargument.key] = self.optargument.value
+  end
+  for _, entry in pairs(self.required) do
+    results[entry.key] = entry.value
+  end
+  for _, entry in pairs(self.optional) do
+    if entry.key then results[entry.key] = entry.value end
+    if entry.expanded_key then results[entry.expanded_key] = entry.value end
+  end
+
+  if dump then
+    print("\n======= Provided command line =============")
+    print("\nNumber of arguments: ", #arg)
+    for i,v in ipairs(arg) do -- use gloabl 'arg' not the modified local 'args'
+      print(string.format("%3i = '%s'", i, v))
+    end
+
+    print("\n======= Parsed command line ===============")
+    if #self.required > 0 then print("\nArguments:") end
+    for i,v in ipairs(self.required) do
+      print("  " .. v.key .. string.rep(" ", self.maxlabel + 2 - #v.key) .. " => '" .. v.value .. "'")
+    end
+
+    if self.optargument.maxcount > 0 then
+      print("\nOptional arguments:")
+      print("  " .. self.optargument.key .. "; allowed are " .. tostring(self.optargument.maxcount) .. " arguments")
+      if self.optargument.maxcount == 1 then
+          print("  " .. self.optargument.key .. string.rep(" ", self.maxlabel + 2 - #self.optargument.key) .. " => '" .. self.optargument.key .. "'")
+      else
+        for i = 1, self.optargument.maxcount do
+          if self.optargument.value[i] then
+            print("  " .. tostring(i) .. string.rep(" ", self.maxlabel + 2 - #tostring(i)) .. " => '" .. tostring(self.optargument.value[i]) .. "'")
+          end
+        end
+      end
+    end
+
+    if #self.optional > 0 then print("\nOptional parameters:") end
+    local doubles = {}
+    for _, v in pairs(self.optional) do
+      if not doubles[v] then
+        local m = v.value
+        if type(m) == "string" then
+          m = "'"..m.."'"
+        else
+          m = tostring(m) .." (" .. type(m) .. ")"
+        end
+        print("  " .. v.label .. string.rep(" ", self.maxlabel + 2 - #v.label) .. " => " .. m)
+        doubles[v] = v
+      end
+    end
+    print("\n===========================================\n\n")
+    return cli_error("commandline dump created as requested per '--__DUMP__' option", noprint)
+  end
+
+  if not _TEST then
+    -- cleanup entire module, as it's single use
+    -- remove from package.loaded table to enable the module to
+    -- garbage collected.
+    for k, v in pairs(package.loaded) do
+      if v == cli then
+        package.loaded[k] = nil
+        break
+      end
+    end
+    -- clear table in case user holds on to module table
+    for k, _ in pairs(cli) do
+      cli[k] = nil
+    end
+  end
+
+  return results
+end
+
+--- Prints the USAGE heading.
+---
+--- ### Parameters
+ ---1. **noprint**: set this flag to prevent the line from being printed
+---
+--- ### Returns
+--- 1. a string with the USAGE message.
+function cli:print_usage(noprint)
+  -- print the USAGE heading
+  local msg = "Usage: " .. tostring(self.name)
+  if self.optional[1] then
+    msg = msg .. " [OPTIONS] "
+  end
+  if self.required[1] then
+    for _,entry in ipairs(self.required) do
+      msg = msg .. " " .. entry.key .. " "
+    end
+  end
+  if self.optargument.maxcount == 1 then
+    msg = msg .. " [" .. self.optargument.key .. "]"
+  elseif self.optargument.maxcount == 2 then
+    msg = msg .. " [" .. self.optargument.key .. "-1 [" .. self.optargument.key .. "-2]]"
+  elseif self.optargument.maxcount > 2 then
+    msg = msg .. " [" .. self.optargument.key .. "-1 [" .. self.optargument.key .. "-2 [...]]]"
+  end
+
+  if not noprint then print(msg) end
+  return msg
+end
+
+
+--- Prints the HELP information.
+---
+--- ### Parameters
+--- 1. **noprint**: set this flag to prevent the information from being printed
+---
+--- ### Returns
+--- 1. a string with the HELP message.
+function cli:print_help(noprint)
+
+  local msg = self:print_usage(true) .. "\n"
+  local col1 = self.colsz[1]
+  local col2 = self.colsz[2]
+  if col1 == 0 then col1 = cli.maxlabel end
+  col1 = col1 + 3     --add margins
+  if col2 == 0 then col2 = 72 - col1 end
+  if col2 <10 then col2 = 10 end
+
+  local append = function(label, desc)
+      label = "  " .. label .. string.rep(" ", col1 - (#label + 2))
+      desc = wordwrap(desc, col2)   -- word-wrap
+      desc = desc:gsub("\n", "\n" .. string.rep(" ", col1)) -- add padding
+
+      msg = msg .. label .. desc .. "\n"
+  end
+
+  if self.required[1] then
+    msg = msg .. "\nARGUMENTS: \n"
+    for _,entry in ipairs(self.required) do
+      append(entry.key, entry.desc .. " (required)")
+    end
+  end
+
+  if self.optargument.maxcount >0 then
+    append(self.optargument.key, self.optargument.desc .. " (optional, default: " .. self.optargument.default .. ")")
+  end
+
+  if self.optional[1] then
+    msg = msg .. "\nOPTIONS: \n"
+
+    for _,entry in ipairs(self.optional) do
+      local desc = entry.desc
+      if not entry.flag and entry.default and #tostring(entry.default) > 0 then
+        desc = desc .. " (default: " .. entry.default .. ")"
+      end
+      append(entry.label, desc)
+    end
+  end
+
+  if not noprint then print(msg) end
+  return msg
+end
+
+--- Sets the amount of space allocated to the argument keys and descriptions in the help listing.
+--- The sizes are used for wrapping long argument keys and descriptions.
+--- ### Parameters
+--- 1. **key_cols**: the number of columns assigned to the argument keys, set to 0 to auto detect (default: 0)
+--- 1. **desc_cols**: the number of columns assigned to the argument descriptions, set to 0 to auto set the total width to 72 (default: 0)
+function cli:set_colsz(key_cols, desc_cols)
+  self.colsz = { key_cols or self.colsz[1], desc_cols or self.colsz[2] }
+end
+
+
+-- finalize setup
+cli._COPYRIGHT   = "Copyright (C) 2011-2012 Ahmad Amireh"
+cli._LICENSE     = "The code is released under the MIT terms. Feel free to use it in both open and closed software as you please."
+cli._DESCRIPTION = "Commandline argument parser for Lua"
+cli._VERSION     = "cliargs 2.0-1"
+
+-- aliases
+cli.add_argument = cli.add_arg
+cli.add_option = cli.add_opt
+cli.parse_args = cli.parse    -- backward compatibility
+
+-- test aliases for local functions
+if _TEST then
+  cli.split = split
+  cli.wordwrap = wordwrap
+end
+
+return cli

--- a/lib/ext/spec-support/howl-lfs-shim.moon
+++ b/lib/ext/spec-support/howl-lfs-shim.moon
@@ -1,0 +1,38 @@
+-- Copyright 2016 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+-- This is the crudest version of an lfs implementation that allows Howl
+-- to run busted for the specs
+
+{:File} = howl.io
+
+get_file_mode = (f) ->
+  mapping = {
+    directory: 'directory',
+    regular: 'file'
+  }
+  mapping[f.file_type] or 'other'
+
+attributes = (path, name, table) ->
+  f = File path
+  if name
+    if name == 'mode'
+      return get_file_mode f
+    return nil, "Unsupported attribute '#{name}'"
+
+  error "howl-lfs-shim: Unsupported operation"
+
+dir = (path) ->
+  f = File path
+  assert f.is_directory, "Not a directory: '#{path}'"
+  kids = [f.basename for f in *f.children]
+  i = 0
+  setmetatable {}, {
+    __call: ->
+      i += 1
+      kids[i]
+  }
+
+
+:attributes, :dir
+

--- a/lib/ext/spec-support/luassert/LICENSE
+++ b/lib/ext/spec-support/luassert/LICENSE
@@ -1,0 +1,22 @@
+MIT License Terms
+=================
+
+Copyright (c) 2012 Olivine Labs, LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.

--- a/lib/ext/spec-support/luassert/assert.lua
+++ b/lib/ext/spec-support/luassert/assert.lua
@@ -1,0 +1,173 @@
+local s = require 'say'
+local astate = require 'luassert.state'
+local obj   -- the returned module table
+
+-- list of namespaces
+local namespace = {}
+
+local errorlevel = function()
+  -- find the first level, not defined in the same file as this
+  -- code file to properly report the error
+  local level = 1
+  local info = debug.getinfo(level)
+  local thisfile = (info or {}).source
+  while thisfile and thisfile == (info or {}).source do
+    level = level + 1
+    info = debug.getinfo(level)
+  end
+  if level > 1 then level = level - 1 end -- deduct call to errorlevel() itself
+  return level
+end
+
+local function extract_keys(assert_string)
+  -- get a list of token separated by _
+  local tokens = {}
+  for token in assert_string:lower():gmatch('[^_]+') do
+    table.insert(tokens, token)
+  end
+
+  -- find valid keys by coalescing tokens as needed, starting from the end
+  local keys = {}
+  local key = nil
+  for i = #tokens, 1, -1 do
+    local token = tokens[i]
+    key = key and (token .. '_' .. key) or token
+    if namespace.modifier[key] or namespace.assertion[key] then
+      table.insert(keys, 1, key)
+      key = nil
+    end
+  end
+
+  -- if there's anything left we didn't recognize it
+  if key then
+    error("luassert: unknown modifier/assertion: '" .. key .."'", errorlevel())
+  end
+
+  return keys
+end
+
+local __assertion_meta = {
+  __call = function(self, ...)
+    local state = self.state
+    local arguments = {...}
+    arguments.n = select('#',...)  -- add argument count for trailing nils
+    local val = self.callback(state, arguments)
+    local data_type = type(val)
+
+    if data_type == "boolean" then
+      if val ~= state.mod then
+        if state.mod then
+          error(s(self.positive_message, obj:format(arguments)) or "assertion failed!", errorlevel())
+        else
+          error(s(self.negative_message, obj:format(arguments)) or "assertion failed!", errorlevel())
+        end
+      else
+        return state
+      end
+    end
+    return val
+  end
+}
+
+local __state_meta = {
+
+  __call = function(self, payload, callback)
+    self.payload = payload or rawget(self, "payload")
+    if callback then callback(self) end
+    return self
+  end,
+
+  __index = function(self, key)
+    local keys = extract_keys(key)
+
+    -- execute modifiers and assertions
+    local ret = nil
+    for _, key in ipairs(keys) do
+      if namespace.modifier[key] then
+        namespace.modifier[key].state = self
+        ret = self(nil, namespace.modifier[key])
+      elseif namespace.assertion[key] then
+        namespace.assertion[key].state = self
+        ret = namespace.assertion[key]
+      end
+    end
+    return ret
+  end
+}
+
+obj = {
+  state = function() return setmetatable({mod=true, payload=nil}, __state_meta) end,
+
+  -- registers a function in namespace
+  register = function(self, nspace, name, callback, positive_message, negative_message)
+    -- register
+    local lowername = name:lower()
+    if not namespace[nspace] then
+      namespace[nspace] = {}
+    end
+    namespace[nspace][lowername] = setmetatable({
+      callback = callback,
+      name = lowername,
+      positive_message=positive_message,
+      negative_message=negative_message
+    }, __assertion_meta)
+  end,
+
+  -- registers a formatter
+  -- a formatter takes a single argument, and converts it to a string, or returns nil if it cannot format the argument
+  add_formatter = function(self, callback)
+    astate.add_formatter(callback)
+  end,
+
+  -- unregisters a formatter
+  remove_formatter = function(self, fmtr)
+    astate.remove_formatter(fmtr)
+  end,
+
+  format = function(self, args)
+    -- args.n specifies the number of arguments in case of 'trailing nil' arguments which get lost
+    local nofmt = args.nofmt or {}  -- arguments in this list should not be formatted
+    for i = 1, (args.n or #args) do -- cannot use pairs because table might have nils
+      if not nofmt[i] then
+        local val = args[i]
+        local valfmt = astate.format_argument(val)
+        if valfmt == nil then valfmt = tostring(val) end -- no formatter found
+        args[i] = valfmt
+      end
+    end
+    return args
+  end,
+
+  set_parameter = function(self, name, value)
+    astate.set_parameter(name, value)
+  end,
+  
+  get_parameter = function(self, name)
+    return astate.get_parameter(name)
+  end,  
+  
+  add_spy = function(self, spy)
+    astate.add_spy(spy)
+  end,
+  
+  snapshot = function(self)
+    return astate.snapshot()
+  end,
+}
+
+local __meta = {
+
+  __call = function(self, bool, message, ...)
+    if not bool then
+      error(message or "assertion failed!", 2)
+    end
+    return bool , message , ...
+  end,
+
+  __index = function(self, key)
+    return rawget(self, key) or self.state()[key]
+  end,
+
+}
+
+return setmetatable(obj, __meta)

--- a/lib/ext/spec-support/luassert/assertions.lua
+++ b/lib/ext/spec-support/luassert/assertions.lua
@@ -1,0 +1,150 @@
+-- module will not return anything, only register assertions with the main assert engine
+
+-- assertions take 2 parameters;
+-- 1) state
+-- 2) arguments list. The list has a member 'n' with the argument count to check for trailing nils
+-- returns; boolean; whether assertion passed
+
+local assert = require('luassert.assert')
+local util = require ('luassert.util')
+local s = require('say')
+
+local function unique(state, arguments)
+  local list = arguments[1]
+  local deep = arguments[2]
+  for k,v in pairs(list) do
+    for k2, v2 in pairs(list) do
+      if k ~= k2 then
+        if deep and util.deepcompare(v, v2, true) then
+          return false
+        else
+          if v == v2 then
+            return false
+          end
+        end
+      end
+    end
+  end
+  return true
+end
+
+local function equals(state, arguments)
+  local argcnt = arguments.n
+  assert(argcnt > 1, s("assertion.internal.argtolittle", { "equals", 2, tostring(argcnt) }))
+  for i = 2,argcnt  do
+    if arguments[1] ~= arguments[i] then
+      -- switch arguments for proper output message
+      util.tinsert(arguments, 1, arguments[i])
+      util.tremove(arguments, i + 1)
+      return false
+    end
+  end
+  return true
+end
+
+local function same(state, arguments)
+  local argcnt = arguments.n
+  assert(argcnt > 1, s("assertion.internal.argtolittle", { "same", 2, tostring(argcnt) }))
+  local prev = nil
+  for i = 2,argcnt  do
+    if type(arguments[1]) == 'table' and type(arguments[i]) == 'table' then
+      if not util.deepcompare(arguments[1], arguments[i], true) then
+        -- switch arguments for proper output message
+        util.tinsert(arguments, 1, arguments[i])
+        util.tremove(arguments, i + 1)
+        return false
+      end
+    else
+      if arguments[1] ~= arguments[i] then
+        -- switch arguments for proper output message
+        util.tinsert(arguments, 1, arguments[i])
+        util.tremove(arguments, i + 1)
+        return false
+      end
+    end
+  end
+  return true
+end
+
+local function truthy(state, arguments)
+  return arguments[1] ~= false and arguments[1] ~= nil
+end
+
+local function falsy(state, arguments)
+  return not truthy(state, arguments)
+end
+
+local function has_error(state, arguments)
+  local func = arguments[1]
+  local err_expected = arguments[2]
+  assert(util.callable(func), s("assertion.internal.badargtype", { "error", "function, or callable object", type(func) }))
+  local ok, err_actual = pcall(func)
+  arguments[1] = err_actual
+  arguments[2] = err_expected
+  if ok or err_expected == nil then
+    return not ok
+  elseif type(err_actual) == 'string' and type(err_expected) == 'string' then
+    return err_actual:find(err_expected, nil, true) ~= nil
+  end
+  return same(state, {err_expected, err_actual, ["n"] = 2})
+end
+
+local function is_true(state, arguments)
+  util.tinsert(arguments, 2, true)
+  arguments.n = arguments.n + 1
+  return arguments[1] == arguments[2]
+end
+
+local function is_false(state, arguments)
+  util.tinsert(arguments, 2, false)
+  arguments.n = arguments.n + 1
+  return arguments[1] == arguments[2]
+end
+
+local function is_type(state, arguments, etype)
+  util.tinsert(arguments, 2, "type " .. etype)
+  arguments.nofmt = arguments.nofmt or {}
+  arguments.nofmt[2] = true
+  arguments.n = arguments.n + 1
+  return arguments.n > 1 and type(arguments[1]) == etype
+end
+
+local function returned_arguments(state, arguments)
+  arguments[1] = tostring(arguments[1])
+  arguments[2] = tostring(arguments.n - 1)
+  arguments.nofmt = arguments.nofmt or {}
+  arguments.nofmt[1] = true
+  arguments.nofmt[2] = true
+  if arguments.n < 2 then arguments.n = 2 end
+  return arguments[1] == arguments[2]
+end
+
+local function is_boolean(state, arguments)  return is_type(state, arguments, "boolean")  end
+local function is_number(state, arguments)   return is_type(state, arguments, "number")   end
+local function is_string(state, arguments)   return is_type(state, arguments, "string")   end
+local function is_table(state, arguments)    return is_type(state, arguments, "table")    end
+local function is_nil(state, arguments)      return is_type(state, arguments, "nil")      end
+local function is_userdata(state, arguments) return is_type(state, arguments, "userdata") end
+local function is_function(state, arguments) return is_type(state, arguments, "function") end
+local function is_thread(state, arguments)   return is_type(state, arguments, "thread")   end
+
+assert:register("assertion", "true", is_true, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "false", is_false, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "boolean", is_boolean, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "number", is_number, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "string", is_string, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "table", is_table, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "nil", is_nil, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "userdata", is_userdata, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "function", is_function, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "thread", is_thread, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "returned_arguments", returned_arguments, "assertion.returned_arguments.positive", "assertion.returned_arguments.negative")
+
+assert:register("assertion", "same", same, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "equals", equals, "assertion.equals.positive", "assertion.equals.negative")
+assert:register("assertion", "equal", equals, "assertion.equals.positive", "assertion.equals.negative")
+assert:register("assertion", "unique", unique, "assertion.unique.positive", "assertion.unique.negative")
+assert:register("assertion", "error", has_error, "assertion.error.positive", "assertion.error.negative")
+assert:register("assertion", "errors", has_error, "assertion.error.positive", "assertion.error.negative")
+assert:register("assertion", "truthy", truthy, "assertion.truthy.positive", "assertion.truthy.negative")
+assert:register("assertion", "falsy", falsy, "assertion.falsy.positive", "assertion.falsy.negative")

--- a/lib/ext/spec-support/luassert/formatters/binarystring.lua
+++ b/lib/ext/spec-support/luassert/formatters/binarystring.lua
@@ -1,0 +1,28 @@
+local format = function (str)
+  if type(str) ~= "string" then return nil end
+  local result = "Binary string length; " .. tostring(#str) .. " bytes\n"
+  local i = 1
+  local hex = ""
+  local chr = ""
+  while i <= #str do
+    local byte = str:byte(i)
+    hex = string.format("%s%2x ", hex, byte)
+    if byte < 32 then byte = string.byte(".") end
+    chr = chr .. string.char(byte)
+    if math.floor(i/16) == i/16 or i == #str then
+      -- reached end of line
+      hex = hex .. string.rep(" ", 16 * 3 - #hex)
+      chr = chr .. string.rep(" ", 16 - #chr)
+
+      result = result .. hex:sub(1, 8 * 3) .. "  " .. hex:sub(8*3+1, -1) .. " " .. chr:sub(1,8) .. " " .. chr:sub(9,-1) .. "\n"
+
+      hex = ""
+      chr = ""
+    end
+    i = i + 1
+  end
+  return result
+end
+
+return format
+

--- a/lib/ext/spec-support/luassert/formatters/init.lua
+++ b/lib/ext/spec-support/luassert/formatters/init.lua
@@ -1,0 +1,140 @@
+-- module will not return anything, only register formatters with the main assert engine
+local assert = require('luassert.assert')
+
+local function fmt_string(arg)
+  if type(arg) == "string" then
+    return string.format("(string) '%s'", arg)
+  end
+end
+
+local function fmt_number(arg)
+  if type(arg) == "number" then
+    return string.format("(number) %s", tostring(arg))
+  end
+end
+
+local function fmt_boolean(arg)
+  if type(arg) == "boolean" then
+    return string.format("(boolean) %s", tostring(arg))
+  end
+end
+
+local function fmt_nil(arg)
+  if type(arg) == "nil" then
+    return "(nil)"
+  end
+end
+
+local type_priorities = {
+  number = 1,
+  boolean = 2,
+  string = 3,
+  table = 4,
+  ["function"] = 5,
+  userdata = 6,
+  thread = 7
+}
+
+local function is_in_array_part(key, length)
+  return type(key) == "number" and 1 <= key and key <= length and math.floor(key) == key
+end
+
+local function get_sorted_keys(t)
+  local keys = {}
+  local nkeys = 0
+
+  for key in pairs(t) do
+    nkeys = nkeys + 1
+    keys[nkeys] = key
+  end
+
+  local length = #t
+
+  local function key_comparator(key1, key2)
+    local type1, type2 = type(key1), type(key2)
+    local priority1 = is_in_array_part(key1, length) and 0 or type_priorities[type1] or 8
+    local priority2 = is_in_array_part(key2, length) and 0 or type_priorities[type2] or 8
+
+    if priority1 == priority2 then
+      if type1 == "string" or type1 == "number" then
+        return key1 < key2
+      elseif type1 == "boolean" then
+        return key1  -- put true before false
+      end
+    else
+      return priority1 < priority2
+    end
+  end
+
+  table.sort(keys, key_comparator)
+  return keys, nkeys
+end
+
+local function fmt_table(arg)
+  local tmax = assert:get_parameter("TableFormatLevel")
+  local ft
+  ft = function(t, l)
+    local result = ""
+    local keys, nkeys = get_sorted_keys(t)
+    for i = 1, nkeys do
+      local k = keys[i]
+      local v = t[k]
+      if type(v) == "table" then
+        if l < tmax or tmax < 0 then
+          result = result .. string.format(string.rep(" ",l * 2) .. "[%s] = {\n%s }\n", tostring(k), tostring(ft(v, l + 1):sub(1,-2)))
+        else
+          result = result .. string.format(string.rep(" ",l * 2) .. "[%s] = { ... more }\n", tostring(k))
+        end
+      else
+        if type(v) == "string" then v = "'"..v.."'" end
+        result = result .. string.format(string.rep(" ",l * 2) .. "[%s] = %s\n", tostring(k), tostring(v))
+      end
+    end
+    return result
+  end
+  if type(arg) == "table" then
+    local result
+    if tmax == 0 then
+      if next(arg) then
+        result = "(table): { ... more }"
+      else
+        result = "(table): { }"
+      end
+    else
+      result = "(table): {\n" .. ft(arg, 1):sub(1,-2) .. " }\n"
+      result = result:gsub("{\n }\n", "{ }\n") -- cleanup empty tables
+      result = result:sub(1,-2)                -- remove trailing newline
+    end
+    return result
+  end
+end
+
+local function fmt_function(arg)
+  if type(arg) == "function" then
+    local debug_info = debug.getinfo(arg)
+    return string.format("%s @ line %s in %s", tostring(arg), tostring(debug_info.linedefined), tostring(debug_info.source))
+  end
+end
+
+local function fmt_userdata(arg)
+  if type(arg) == "userdata" then
+    return string.format("(userdata) '%s'", tostring(arg))
+  end
+end
+
+local function fmt_thread(arg)
+  if type(arg) == "thread" then
+    return string.format("(thread) '%s'", tostring(arg))
+  end
+end
+
+assert:add_formatter(fmt_string)
+assert:add_formatter(fmt_number)
+assert:add_formatter(fmt_boolean)
+assert:add_formatter(fmt_nil)
+assert:add_formatter(fmt_table)
+assert:add_formatter(fmt_function)
+assert:add_formatter(fmt_userdata)
+assert:add_formatter(fmt_thread)
+-- Set default table display depth for table formatter
+assert:set_parameter("TableFormatLevel", 3)

--- a/lib/ext/spec-support/luassert/init.lua
+++ b/lib/ext/spec-support/luassert/init.lua
@@ -1,0 +1,15 @@
+local assert = require('luassert.assert')
+
+assert._COPYRIGHT   = "Copyright (c) 2012 Olivine Labs, LLC."
+assert._DESCRIPTION = "Extends Lua's built-in assertions to provide additional tests and the ability to create your own."
+assert._VERSION     = "Luassert 1.4"
+
+-- load basic asserts
+require('luassert.assertions')
+require('luassert.modifiers')
+require('luassert.formatters')
+
+-- load default language
+require('luassert.languages.en')
+
+return assert

--- a/lib/ext/spec-support/luassert/languages/ar.lua
+++ b/lib/ext/spec-support/luassert/languages/ar.lua
@@ -1,0 +1,21 @@
+local s = require('say')
+
+s:set_namespace("ar")
+
+s:set("assertion.same.positive", "تُوُقِّعَ تَماثُلُ الكائِنات.\nتَمَّ إدخال:\n %s.\nبَينَما كانَ مِن المُتَوقَّع:\n %s.")
+s:set("assertion.same.negative", "تُوُقِّعَ إختِلافُ الكائِنات.\nتَمَّ إدخال:\n %s.\nبَينَما كانَ مِن غَيرِ المُتَوقَّع:\n %s.")
+
+s:set("assertion.equals.positive", "تُوُقِّعَ أن تَتَساوىْ الكائِنات.\nتمَّ إِدخال:\n %s.\nبَينَما كانَ من المُتَوقَّع:\n %s.")
+s:set("assertion.equals.negative", "تُوُقِّعَ ألّا تَتَساوىْ الكائِنات.\nتمَّ إِدخال:\n %s.\nبَينَما كانَ مِن غير المُتًوقَّع:\n %s.")
+
+s:set("assertion.unique.positive", "تُوُقِّعَ أَنْ يَكونَ الكائِنٌ فَريد: \n%s")
+s:set("assertion.unique.negative", "تُوُقِّعَ أنْ يَكونَ الكائِنٌ غَيرَ فَريد: \n%s")
+
+s:set("assertion.error.positive", "تُوُقِّعَ إصدارُ خطأْ.")
+s:set("assertion.error.negative", "تُوُقِّعَ عدم إصدارِ خطأ.")
+
+s:set("assertion.truthy.positive", "تُوُقِّعَت قيمةٌ صَحيحة، بينما كانت: \n%s")
+s:set("assertion.truthy.negative", "تُوُقِّعَت قيمةٌ غيرُ صَحيحة، بينما كانت: \n%s")
+
+s:set("assertion.falsy.positive", "تُوُقِّعَت قيمةٌ خاطِئة، بَينَما كانت: \n%s")
+s:set("assertion.falsy.negative", "تُوُقِّعَت قيمةٌ غيرُ خاطِئة، بَينَما كانت: \n%s")

--- a/lib/ext/spec-support/luassert/languages/en.lua
+++ b/lib/ext/spec-support/luassert/languages/en.lua
@@ -1,0 +1,34 @@
+local s = require('say')
+
+s:set_namespace('en')
+
+s:set("assertion.same.positive", "Expected objects to be the same.\nPassed in:\n%s\nExpected:\n%s")
+s:set("assertion.same.negative", "Expected objects to not be the same.\nPassed in:\n%s\nDid not expect:\n%s")
+
+s:set("assertion.equals.positive", "Expected objects to be equal.\nPassed in:\n%s\nExpected:\n%s")
+s:set("assertion.equals.negative", "Expected objects to not be equal.\nPassed in:\n%s\nDid not expect:\n%s")
+
+s:set("assertion.unique.positive", "Expected object to be unique:\n%s")
+s:set("assertion.unique.negative", "Expected object to not be unique:\n%s")
+
+s:set("assertion.error.positive", "Expected a different error.\nCaught:\n%s\nExpected:\n%s")
+s:set("assertion.error.negative", "Expected no error, but caught:\n%s")
+
+s:set("assertion.truthy.positive", "Expected to be truthy, but value was:\n%s")
+s:set("assertion.truthy.negative", "Expected to not be truthy, but value was:\n%s")
+
+s:set("assertion.falsy.positive", "Expected to be falsy, but value was:\n%s")
+s:set("assertion.falsy.negative", "Expected to not be falsy, but value was:\n%s")
+
+s:set("assertion.called.positive", "Expected to be called %s time(s), but was called %s time(s)")
+s:set("assertion.called.negative", "Expected not to be called exactly %s time(s), but it was.")
+
+s:set("assertion.called_with.positive", "Function was not called with the arguments")
+s:set("assertion.called_with.negative", "Function was called with the arguments")
+
+s:set("assertion.returned_arguments.positive", "Expected to be called with %s argument(s), but was called with %s")
+s:set("assertion.returned_arguments.negative", "Expected not to be called with %s argument(s), but was called with %s")
+
+-- errors
+s:set("assertion.internal.argtolittle", "the '%s' function requires a minimum of %s arguments, got: %s")
+s:set("assertion.internal.badargtype", "the '%s' function requires a %s as an argument, got: %s")

--- a/lib/ext/spec-support/luassert/languages/fr.lua
+++ b/lib/ext/spec-support/luassert/languages/fr.lua
@@ -1,0 +1,21 @@
+local s = require('say')
+
+s:set_namespace("fr")
+
+s:set("assertion.same.positive", "Objets supposes de meme nature attendus.\nArgument passe:\n%s\nAttendu:\n%s")
+s:set("assertion.same.negative", "Objets supposes de natures differentes attendus.\nArgument passe:\n%s\nNon attendu:\n%s")
+
+s:set("assertion.equals.positive", "Objets supposes etre de valeur egale attendus.\nArgument passe:\n%s\nAttendu:\n%s")
+s:set("assertion.equals.negative", "Objets supposes etre de valeurs differentes attendu.\nArgument passe:\n%s\nNon attendu:\n%s")
+
+s:set("assertion.unique.positive", "Objet suppose etre unique attendu:\n%s")
+s:set("assertion.unique.negative", "Objet suppose ne pas etre unique attendu:\n%s")
+
+s:set("assertion.error.positive", "Erreur supposee etre generee.")
+s:set("assertion.error.negative", "Erreur non supposee etre generee.\n%s")
+
+s:set("assertion.truthy.positive", "Assertion supposee etre vraie mais de valeur:\n%s")
+s:set("assertion.truthy.negative", "Assertion supposee etre fausse mais de valeur:\n%s")
+
+s:set("assertion.falsy.positive", "Assertion supposee etre fausse mais de valeur:\n%s")
+s:set("assertion.falsy.negative", "Assertion supposee etre vraie mais de valeur:\n%s")

--- a/lib/ext/spec-support/luassert/languages/ja.lua
+++ b/lib/ext/spec-support/luassert/languages/ja.lua
@@ -1,0 +1,34 @@
+local s = require('say')
+
+s:set_namespace('ja')
+
+s:set("assertion.same.positive", "オブジェクトの内容が同一であることが期待されています。\n実際の値:\n%s\n期待されている値:\n%s")
+s:set("assertion.same.negative", "オブジェクトの内容が同一でないことが期待されています。\n実際の値:\n%s\n期待されていない値:\n%s")
+
+s:set("assertion.equals.positive", "オブジェクトが同一であることが期待されています。\n実際の値:\n%s\n期待されている値:\n%s")
+s:set("assertion.equals.negative", "オブジェクトが同一でないことが期待されています。\n実際の値:\n%s\n期待されていない値:\n%s")
+
+s:set("assertion.unique.positive", "オブジェクトがユニークであることが期待されています。:\n%s")
+s:set("assertion.unique.negative", "オブジェクトがユニークでないことが期待されています。:\n%s")
+
+s:set("assertion.error.positive", "エラーが発生することが期待されています。")
+s:set("assertion.error.negative", "エラーが発生しないことが期待されています。")
+
+s:set("assertion.truthy.positive", "真であることが期待されていますが、値は:\n%s")
+s:set("assertion.truthy.negative", "真でないことが期待されていますが、値は:\n%s")
+
+s:set("assertion.falsy.positive", "偽であることが期待されていますが、値は:\n%s")
+s:set("assertion.falsy.negative", "偽でないことが期待されていますが、値は:\n%s")
+
+s:set("assertion.called.positive", "%s回呼ばれることを期待されていますが、実際には%s回呼ばれています。")
+s:set("assertion.called.negative", "%s回呼ばれることを期待されていますが、実際には%s回呼ばれています。")
+
+s:set("assertion.called_with.positive", "関数が期待されている引数で呼ばれていません")
+s:set("assertion.called_with.negative", "関数が期待されている引数で呼ばれています")
+
+s:set("assertion.returned_arguments.positive", "期待されている返り値の数は%sですが、実際の返り値の数は%sです。")
+s:set("assertion.returned_arguments.negative", "期待されていない返り値の数は%sですが、実際の返り値の数は%sです。")
+
+-- errors
+s:set("assertion.internal.argtolittle", "%s関数には最低%s個の引数が必要ですが、実際の引数の数は: %s")
+s:set("assertion.internal.badargtype", "%s関数には%s個の引数が必要ですが、実際に引数の数は: %s")

--- a/lib/ext/spec-support/luassert/languages/nl.lua
+++ b/lib/ext/spec-support/luassert/languages/nl.lua
@@ -1,0 +1,25 @@
+local s = require('say')
+
+s:set_namespace('nl')
+
+s:set("assertion.same.positive", "Verwachtte objecten die vergelijkbaar zijn.\nAangeboden:\n%s\nVerwachtte:\n%s")
+s:set("assertion.same.negative", "Verwachtte objecten die niet vergelijkbaar zijn.\nAangeboden:\n%s\nVerwachtte niet:\n%s")
+
+s:set("assertion.equals.positive", "Verwachtte objecten die hetzelfde zijn.\nAangeboden:\n%s\nVerwachtte:\n%s")
+s:set("assertion.equals.negative", "Verwachtte objecten die niet hetzelfde zijn.\nAangeboden:\n%s\nVerwachtte niet:\n%s")
+
+s:set("assertion.unique.positive", "Verwachtte objecten die uniek zijn:\n%s")
+s:set("assertion.unique.negative", "Verwachtte objecten die niet uniek zijn:\n%s")
+
+s:set("assertion.error.positive", "Verwachtte een foutmelding.")
+s:set("assertion.error.negative", "Verwachtte geen foutmelding.\n%s")
+
+s:set("assertion.truthy.positive", "Verwachtte een 'warige' (thruthy) waarde, maar was:\n%s")
+s:set("assertion.truthy.negative", "Verwachtte een niet 'warige' (thruthy) waarde, maar was:\n%s")
+
+s:set("assertion.falsy.positive", "Verwachtte een 'onwarige' (falsy) waarde, maar was:\n%s")
+s:set("assertion.falsy.negative", "Verwachtte een niet 'onwarige' (falsy) waarde, maar was:\n%s")
+
+-- errors
+s:set("assertion.internal.argtolittle", "de '%s' functie verwacht minimaal %s parameters, maar kreeg er: %s")
+s:set("assertion.internal.badargtype", "de '%s' functie verwacht een %s als parameter, maar kreeg een: %s")

--- a/lib/ext/spec-support/luassert/languages/ru.lua
+++ b/lib/ext/spec-support/luassert/languages/ru.lua
@@ -1,0 +1,21 @@
+local s = require('say')
+
+s:set_namespace("ru")
+
+s:set("assertion.same.positive", "Ожидали одинаковые объекты.\nПередали:\n%s\nОжидали:\n%s")
+s:set("assertion.same.negative", "Ожидали разные объекты.\nПередали:\n%s\nНе ожидали:\n%s")
+
+s:set("assertion.equals.positive", "Ожидали эквивалентные объекты.\nПередали:\n%s\nОжидали:\n%s")
+s:set("assertion.equals.negative", "Ожидали не эквивалентные объекты.\nПередали:\n%s\nНе ожидали:\n%s")
+
+s:set("assertion.unique.positive", "Ожидали, что объект будет уникальным:\n%s")
+s:set("assertion.unique.negative", "Ожидали, что объект не будет уникальным:\n%s")
+
+s:set("assertion.error.positive", "Ожидали ошибку.")
+s:set("assertion.error.negative", "Не ожидали ошибку.\n%s")
+
+s:set("assertion.truthy.positive", "Ожидали true, но значние оказалось:\n%s")
+s:set("assertion.truthy.negative", "Ожидали не true, но значние оказалось:\n%s")
+
+s:set("assertion.falsy.positive", "Ожидали false, но значние оказалось:\n%s")
+s:set("assertion.falsy.negative", "Ожидали не false, но значние оказалось:\n%s")

--- a/lib/ext/spec-support/luassert/languages/ua.lua
+++ b/lib/ext/spec-support/luassert/languages/ua.lua
@@ -1,0 +1,21 @@
+local s = require('say')
+
+s:set_namespace("ua")
+
+s:set("assertion.same.positive", "Очікували однакові обєкти.\nПередали:\n%s\nОчікували:\n%s")
+s:set("assertion.same.negative", "Очікували різні обєкти.\nПередали:\n%s\nНе очікували:\n%s")
+
+s:set("assertion.equals.positive", "Очікували еквівалентні обєкти.\nПередали:\n%s\nОчікували:\n%s")
+s:set("assertion.equals.negative", "Очікували не еквівалентні обєкти.\nПередали:\n%s\nНе очікували:\n%s")
+
+s:set("assertion.unique.positive", "Очікували, що обєкт буде унікальним:\n%s")
+s:set("assertion.unique.negative", "Очікували, що обєкт не буде унікальним:\n%s")
+
+s:set("assertion.error.positive", "Очікували помилку.")
+s:set("assertion.error.negative", "Не очікували помилку.\n%s")
+
+s:set("assertion.truthy.positive", "Очікували true, проте значння виявилось:\n%s")
+s:set("assertion.truthy.negative", "Очікували не true, проте значння виявилось:\n%s")
+
+s:set("assertion.falsy.positive", "Очікували false, проте значння виявилось:\n%s")
+s:set("assertion.falsy.negative", "Очікували не false, проте значння виявилось:\n%s")

--- a/lib/ext/spec-support/luassert/languages/zh.lua
+++ b/lib/ext/spec-support/luassert/languages/zh.lua
@@ -1,0 +1,31 @@
+local s = require('say')
+
+s:set_namespace('zh')
+
+s:set("assertion.same.positive", "希望对象应该相同.\n实际值:\n%s\n希望值:\n%s")
+s:set("assertion.same.negative", "希望对象应该不相同.\n实际值:\n%s\n不希望与:\n%s\n相同")
+
+s:set("assertion.equals.positive", "希望对象应该相等.\n实际值:\n%s\n希望值:\n%s")
+s:set("assertion.equals.negative", "希望对象应该不相等.\n实际值:\n%s\n不希望等于:\n%s")
+
+s:set("assertion.unique.positive", "希望对象是唯一的:\n%s")
+s:set("assertion.unique.negative", "希望对象不是唯一的:\n%s")
+
+s:set("assertion.error.positive", "希望有错误被抛出.")
+s:set("assertion.error.negative", "希望没有错误被抛出.\n%s")
+
+s:set("assertion.truthy.positive", "希望结果为真，但是实际为:\n%s")
+s:set("assertion.truthy.negative", "希望结果不为真，但是实际为:\n%s")
+
+s:set("assertion.falsy.positive", "希望结果为假，但是实际为:\n%s")
+s:set("assertion.falsy.negative", "希望结果不为假，但是实际为:\n%s")
+
+s:set("assertion.called.positive", "希望被调用%s次, 但实际被调用了%s次")
+s:set("assertion.called.negative", "不希望正好被调用%s次, 但是正好被调用了那么多次.")
+
+s:set("assertion.called_with.positive", "希望没有参数的调用函数")
+s:set("assertion.called_with.negative", "希望有参数的调用函数")
+
+-- errors
+s:set("assertion.internal.argtolittle", "函数'%s'需要最少%s个参数, 实际有%s个参数\n")
+s:set("assertion.internal.badargtype", "函数'%s'需要一个%s作为参数, 实际为: %s\n")

--- a/lib/ext/spec-support/luassert/mock.lua
+++ b/lib/ext/spec-support/luassert/mock.lua
@@ -1,0 +1,27 @@
+-- module will return a single mock function, no table nor register any assertions
+local spy = require 'luassert.spy'
+local stub = require 'luassert.stub'
+
+local function mock(object, dostub, func, self, key)
+  local data_type = type(object)
+  if data_type == "table" then
+    if spy.is_spy(object) then
+      -- this table is a function already wrapped as a spy, so nothing to do here
+    else
+      for k,v in pairs(object) do
+        object[k] = mock(v, dostub, func, object, k)
+      end
+    end
+  elseif data_type == "function" then
+    if dostub then
+      return stub(self, key, func)
+    elseif self==nil then
+      return spy.new(object)
+    else
+      return spy.on(self, key)
+    end
+  end
+  return object
+end
+
+return mock

--- a/lib/ext/spec-support/luassert/modifiers.lua
+++ b/lib/ext/spec-support/luassert/modifiers.lua
@@ -1,0 +1,18 @@
+-- module will not return anything, only register assertions/modifiers with the main assert engine
+local assert = require('luassert.assert')
+
+local function is(state)
+  return state
+end
+
+local function is_not(state)
+  state.mod = not state.mod
+  return state
+end
+
+assert:register("modifier", "is", is)
+assert:register("modifier", "are", is)
+assert:register("modifier", "was", is)
+assert:register("modifier", "has", is)
+assert:register("modifier", "not", is_not)
+assert:register("modifier", "no", is_not)

--- a/lib/ext/spec-support/luassert/spy.lua
+++ b/lib/ext/spec-support/luassert/spy.lua
@@ -1,0 +1,107 @@
+-- module will return spy table, and register its assertions with the main assert engine
+local assert = require('luassert.assert')
+local util = require('luassert.util')
+
+-- Spy metatable
+local spy_mt = {
+  __call = function(self, ...)
+    local arguments = {...}
+    arguments.n = select('#',...)  -- add argument count for trailing nils
+    table.insert(self.calls, arguments)
+    return self.callback(...)
+  end }
+
+local spy   -- must make local before defining table, because table contents refers to the table (recursion)
+spy = {
+  new = function(callback)
+    if not util.callable(callback) then
+      error("Cannot spy on type '" .. type(callback) .. "', only on functions or callable elements", 2)
+    end
+    local s = setmetatable(
+    {
+      calls = {},
+      callback = callback,
+      
+      target_table = nil, -- these will be set when using 'spy.on'
+      target_key = nil,
+      
+      revert = function(self)
+        if not self.reverted then
+          if self.target_table and self.target_key then
+            self.target_table[self.target_key] = self.callback
+          end
+          self.reverted = true
+        end
+        return self.callback
+      end,
+      
+      called = function(self, times)
+        if times then
+          return (#self.calls == times), #self.calls
+        end
+
+        return (#self.calls > 0), #self.calls
+      end,
+
+      called_with = function(self, args)
+        for _,v in ipairs(self.calls) do
+          if util.deepcompare(v, args) then
+            return true
+          end
+        end
+        return false
+      end
+    }, spy_mt)
+    assert:add_spy(s)  -- register with the current state
+    return s
+  end,
+
+  is_spy = function(object)
+    return type(object) == "table" and getmetatable(object) == spy_mt
+  end,
+    
+  on = function(target_table, target_key)
+    local s = spy.new(target_table[target_key])
+    target_table[target_key] = s
+    -- store original data 
+    s.target_table = target_table
+    s.target_key = target_key
+    
+    return s
+  end
+}
+
+local function set_spy(state)
+end
+
+local function called_with(state, arguments)
+  if rawget(state, "payload") and rawget(state, "payload").called_with then
+    return state.payload:called_with(arguments)
+  else
+    error("'called_with' must be chained after 'spy(aspy)'")
+  end
+end
+
+local function called(state, arguments)
+  local num_times = arguments[1]
+  if state.payload and type(state.payload) == "table" and state.payload.called then
+    local result, count = state.payload:called(num_times)
+    arguments[1] = tostring(arguments[1])
+    table.insert(arguments, 2, tostring(count))
+    arguments.n = arguments.n + 1
+    arguments.nofmt = arguments.nofmt or {}
+    arguments.nofmt[1] = true
+    arguments.nofmt[2] = true
+    return result
+  elseif state.payload and type(state.payload) == "function" then
+    error("When calling 'spy(aspy)', 'aspy' must not be the original function, but the spy function replacing the original")
+  else
+    error("'called_with' must be chained after 'spy(aspy)'")
+  end
+end
+
+assert:register("modifier", "spy", set_spy)
+assert:register("assertion", "called_with", called_with, "assertion.called_with.positive", "assertion.called_with.negative")
+assert:register("assertion", "called", called, "assertion.called.positive", "assertion.called.negative")
+
+return spy

--- a/lib/ext/spec-support/luassert/state.lua
+++ b/lib/ext/spec-support/luassert/state.lua
@@ -1,0 +1,125 @@
+-- maintains a state of the assert engine in a linked-list fashion
+-- records; formatters, parameters, spies and stubs
+
+local state_mt = {
+      __call = function(self)
+        self:revert()
+      end }
+
+local nilvalue = {} -- unique ID to refer to nil values for parameters
+
+-- will hold the current state
+local current
+
+-- exported module table
+local state = {}
+
+------------------------------------------------------
+-- Reverts to a (specific) snapshot.
+-- @param self (optional) the snapshot to revert to. If not provided, it will revert to the last snapshot.
+state.revert = function(self)
+  if not self then
+    -- no snapshot given, so move 1 up
+    self = current
+    if not self.previous then
+      -- top of list, no previous one, nothing to do
+      return
+    end
+  end
+  if getmetatable(self) ~= state_mt then error("Value provided is not a valid snapshot", 2) end
+  
+  if self.next then
+    self.next:revert()
+  end
+  -- revert formatters in 'last'
+  self.formatters = {}
+  -- revert parameters in 'last'
+  self.parameters = {}
+  -- revert spies/stubs in 'last'
+  while self.spies[1] do
+    self.spies[1]:revert()
+    table.remove(self.spies, 1)
+  end
+  setmetatable(self, nil) -- invalidate as a snapshot
+  current = self.previous
+  current.next = nil
+end
+
+------------------------------------------------------
+-- Creates a new snapshot.
+-- @return snapshot table
+state.snapshot = function()
+  local s = current
+  local new = setmetatable ({
+    formatters = {},
+    parameters = {},
+    spies = {},
+    previous = current,
+    revert = state.revert,
+  }, state_mt)
+  if current then current.next = new end
+  current = new
+  return current
+end
+
+
+--  FORMATTERS
+state.add_formatter = function(callback)
+  table.insert(current.formatters, 1, callback)
+end
+
+state.remove_formatter = function(callback, s)
+  s = s or current
+  for i, v in ipairs(s.formatters) do
+    if v == callback then
+      table.remove(s.formatters, i)
+      break
+    end
+  end
+  -- wasn't found, so traverse up 1 state
+  if s.previous then
+    state.remove_formatter(callback, s.previous)
+  end
+end
+
+state.format_argument = function(val, s)
+  s = s or current
+  for _, fmt in ipairs(s.formatters) do
+    local valfmt = fmt(val)
+    if valfmt ~= nil then return valfmt end
+  end
+  -- nothing found, check snapshot 1 up in list
+  if s.previous then
+    return state.format_argument(val, s.previous)
+  end
+  return nil -- end of list, couldn't format
+end
+
+
+--  PARAMETERS
+state.set_parameter = function(name, value)
+  if value == nil then value = nilvalue end
+  current.parameters[name] = value
+end
+
+state.get_parameter = function(name, s)
+  s = s or current
+  local val = s.parameters[name]
+  if val == nil and s.previous then
+    -- not found, so check 1 up in list
+    return state.get_parameter(name, s.previous)
+  end
+  if val ~= nilvalue then
+    return val
+  end
+  return nil
+end
+
+--  SPIES / STUBS
+state.add_spy = function(spy)
+  table.insert(current.spies, 1, spy)
+end
+
+state.snapshot()  -- create initial state
+
+return state

--- a/lib/ext/spec-support/luassert/stub.lua
+++ b/lib/ext/spec-support/luassert/stub.lua
@@ -1,0 +1,48 @@
+-- module will return a stub module table
+local spy = require 'luassert.spy'
+local util = require 'luassert.util'
+local stubfunc = function() end
+local stub = {}
+
+function stub.new(object, key)
+  if object == nil and key == nil then
+    -- called without arguments, create a 'blank' stub
+    object = {}
+    key = ""
+  end
+  assert(type(object) == "table" and key ~= nil, "stub.new(): Can only create stub on a table key, call with 2 params; table, key")
+  assert(object[key] == nil or util.callable(object[key]), "stub.new(): The element for which to create a stub must either be callable, or be nil")
+  local old_elem = object[key]    -- keep existing element (might be nil!)
+  object[key] = stubfunc          -- set the stubfunction
+  local s = spy.on(object, key)   -- create a spy on top of the stub function
+  local spy_revert = s.revert     -- keep created revert function
+  
+  s.revert = function(self)       -- wrap revert function to restore original element
+    if not self.reverted then
+      spy_revert(self)
+      object[key] = old_elem
+      self.reverted = true
+    end
+    return old_elem
+  end
+  
+  return s
+end
+
+function stub.is_stub(object)
+  return spy.is_spy(object) and object.callback == stubfunc
+end
+
+local function set_stub(state)
+end
+
+assert:register("modifier", "stub", set_stub)
+
+return setmetatable( stub, {
+    __call = function(self, ...)
+      -- stub originally was a function only. Now that it is a module table
+      -- the __call method is required for backward compatibility
+      -- NOTE: this deviates from spy, which has no __call method
+      return stub.new(...)
+    end })
+  

--- a/lib/ext/spec-support/luassert/util.lua
+++ b/lib/ext/spec-support/luassert/util.lua
@@ -1,0 +1,100 @@
+local util = {}
+function util.deepcompare(t1,t2,ignore_mt)
+  local ty1 = type(t1)
+  local ty2 = type(t2)
+  if ty1 ~= ty2 then return false end
+  -- non-table types can be directly compared
+  if ty1 ~= 'table' then return t1 == t2 end
+  local mt1 = debug.getmetatable(t1)
+  local mt2 = debug.getmetatable(t2)
+  -- would equality be determined by metatable __eq?
+  if mt1 and mt1 == mt2 and mt1.__eq then
+    -- then use that unless asked not to
+    if not ignore_mt then return t1 == t2 end
+  else -- we can skip the deep comparison below if t1 and t2 share identity
+    if t1 == t2 then return true end
+  end
+  for k1,v1 in pairs(t1) do
+    local v2 = t2[k1]
+    if v2 == nil or not util.deepcompare(v1,v2) then return false end
+  end
+  for k2,_ in pairs(t2) do
+    -- only check wether each element has a t1 counterpart, actual comparison
+    -- has been done in first loop above
+    if t1[k2] == nil then return false end
+  end
+  return true
+end
+
+-----------------------------------------------
+-- table.insert() replacement that respects nil values.
+-- The function will use table field 'n' as indicator of the
+-- table length, if not set, it will be added.
+-- @param t table into which to insert
+-- @param pos (optional) position in table where to insert. NOTE: not optional if you want to insert a nil-value!
+-- @param val value to insert
+-- @return No return values
+function util.tinsert(...)
+  -- check optional POS value
+  local args = {...}
+  local c = select('#',...)
+  local t = args[1]
+  local pos = args[2]
+  local val = args[3]
+  if c < 3 then
+    val = pos
+    pos = nil
+  end
+  -- set length indicator n if not present (+1)
+  t.n = (t.n or #t) + 1
+  if not pos then
+    pos = t.n
+  elseif pos > t.n then
+    -- out of our range
+    t[pos] = val
+    t.n = pos
+  end
+  -- shift everything up 1 pos
+  for i = t.n, pos + 1, -1 do
+    t[i]=t[i-1]
+  end
+  -- add element to be inserted
+  t[pos] = val
+end
+-----------------------------------------------
+-- table.remove() replacement that respects nil values.
+-- The function will use table field 'n' as indicator of the
+-- table length, if not set, it will be added.
+-- @param t table from which to remove
+-- @param pos (optional) position in table to remove
+-- @return No return values
+function util.tremove(t, pos)
+  -- set length indicator n if not present (+1)
+  t.n = t.n or #t
+  if not pos then
+    pos = t.n
+  elseif pos > t.n then
+    -- out of our range
+    t[pos] = nil
+    return
+  end
+  -- shift everything up 1 pos
+  for i = pos, t.n do
+    t[i]=t[i+1]
+  end
+  -- set size, clean last
+  t[t.n] = nil
+  t.n = t.n - 1
+end
+
+-----------------------------------------------
+-- Checks an element to be callable.
+-- The type must either be a function or have a metatable
+-- containing an '__call' function.
+-- @param object element to inspect on being callable or not
+-- @return boolean, true if the object is callable
+function util.callable(object)
+  return type(object) == "function" or type((debug.getmetatable(object) or {}).__call) == "function"
+end
+
+return util

--- a/lib/ext/spec-support/pl/Date.lua
+++ b/lib/ext/spec-support/pl/Date.lua
@@ -1,0 +1,640 @@
+--- Date and Date Format classes.
+-- See  @{05-dates.md|the Guide}.
+--
+-- Dependencies: `pl.class`, `pl.stringx`
+-- @module pl.Date
+-- @pragma nostrip
+
+local class = require 'pl.class'
+local os_time, os_date = os.time, os.date
+local stringx = require 'pl.stringx'
+local utils = require 'pl.utils'
+local assert_arg,assert_string,raise = utils.assert_arg,utils.assert_string,utils.raise
+
+local Date = class()
+Date.Format = class()
+
+--- Date constructor.
+-- @param t this can be either
+--
+--   * `nil` or empty - use current date and time
+--   * number - seconds since epoch (as returned by `os.time`). Resulting time is UTC
+--   * `Date` - make a copy of this date
+--   * table - table containing year, month, etc as for `os.time`. You may leave out year, month or day,
+-- in which case current values will be used.
+--   * year (will be followed by month, day etc)
+--
+-- @param ...  true if  Universal Coordinated Time, or two to five numbers: month,day,hour,min,sec
+-- @function Date
+function Date:_init(t,...)
+    local nargs = select('#',...), time
+    if nargs > 2 then
+        local extra = {...}
+        local year = t
+        t = {
+            year = year,
+            month = extra[1],
+            day = extra[2],
+            hour = extra[3],
+            min = extra[4],
+            sec = extra[5]
+        }
+    end
+    if nargs == 1 then
+        self.utc = select(1,...) == true
+    end
+    if t == nil or t == 'utc' then
+        time = os_time()
+        self.utc = t == 'utc'
+    elseif type(t) == 'number' then
+        time = t
+        if self.utc == nil then self.utc = true end
+    elseif type(t) == 'table' then
+        if getmetatable(t) == Date then -- copy ctor
+            time = t.time
+            self.utc = t.utc
+        else
+            if not (t.year and t.month) then
+                local lt = os_date('*t')
+                if not t.year and not t.month and not t.day then
+                    t.year = lt.year
+                    t.month = lt.month
+                    t.day = lt.day
+                else
+                    t.year = t.year or lt.year
+                    t.month = t.month or (t.day and lt.month or 1)
+                    t.day = t.day or 1
+                end
+            end
+            t.day = t.day or 1
+            time = os_time(t)
+        end
+    else
+        error("bad type for Date constructor: "..type(t),2)
+    end
+    self:set(time)
+end
+
+--- set the current time of this Date object.
+-- @param t seconds since epoch
+function Date:set(t)
+    self.time = t
+    if self.utc then
+        self.tab = os_date('!*t',t)
+    else
+        self.tab = os_date('*t',t)
+    end
+end
+
+--- get the time zone offset from UTC.
+-- @return seconds ahead of UTC
+function Date.tzone (ts)
+    if ts == nil then
+        ts = os_time()
+    elseif type(ts) == "table" then
+        if getmetatable(ts) == Date then
+        	ts = ts.time
+        else
+        	ts = Date(ts).time
+        end
+    end
+    local utc = os_date('!*t',ts)
+    local lcl = os_date('*t',ts)
+    lcl.isdst = false
+    return os.difftime(os_time(lcl), os_time(utc))
+end
+
+--- convert this date to UTC.
+function Date:toUTC ()
+    local ndate = Date(self)
+    if not self.utc then
+        ndate.utc = true
+        ndate:set(ndate.time)
+    end
+    return ndate
+end
+
+--- convert this UTC date to local.
+function Date:toLocal ()
+    local ndate = Date(self)
+    if self.utc then
+        ndate.utc = false
+        ndate:set(ndate.time)
+--~         ndate:add { sec = Date.tzone(self) }
+    end
+    return ndate
+end
+
+--- set the year.
+-- @param y Four-digit year
+-- @class function
+-- @name Date:year
+
+--- set the month.
+-- @param m month
+-- @class function
+-- @name Date:month
+
+--- set the day.
+-- @param d day
+-- @class function
+-- @name Date:day
+
+--- set the hour.
+-- @param h hour
+-- @class function
+-- @name Date:hour
+
+--- set the minutes.
+-- @param min minutes
+-- @class function
+-- @name Date:min
+
+--- set the seconds.
+-- @param sec seconds
+-- @class function
+-- @name Date:sec
+
+--- set the day of year.
+-- @class function
+-- @param yday day of year
+-- @name Date:yday
+
+--- get the year.
+-- @param y Four-digit year
+-- @class function
+-- @name Date:year
+
+--- get the month.
+-- @class function
+-- @name Date:month
+
+--- get the day.
+-- @class function
+-- @name Date:day
+
+--- get the hour.
+-- @class function
+-- @name Date:hour
+
+--- get the minutes.
+-- @class function
+-- @name Date:min
+
+--- get the seconds.
+-- @class function
+-- @name Date:sec
+
+--- get the day of year.
+-- @class function
+-- @name Date:yday
+
+
+for _,c in ipairs{'year','month','day','hour','min','sec','yday'} do
+    Date[c] = function(self,val)
+        if val then
+            assert_arg(1,val,"number")
+            self.tab[c] = val
+            self:set(os_time(self.tab))
+            return self
+        else
+            return self.tab[c]
+        end
+    end
+end
+
+--- name of day of week.
+-- @param full abbreviated if true, full otherwise.
+-- @return string name
+function Date:weekday_name(full)
+    return os_date(full and '%A' or '%a',self.time)
+end
+
+--- name of month.
+-- @param full abbreviated if true, full otherwise.
+-- @return string name
+function Date:month_name(full)
+    return os_date(full and '%B' or '%b',self.time)
+end
+
+--- is this day on a weekend?.
+function Date:is_weekend()
+    return self.tab.wday == 1 or self.tab.wday == 7
+end
+
+--- add to a date object.
+-- @param t a table containing one of the following keys and a value:
+-- one of `year`,`month`,`day`,`hour`,`min`,`sec`
+-- @return this date
+function Date:add(t)
+    local old_dst = self.tab.isdst
+    local key,val = next(t)
+    self.tab[key] = self.tab[key] + val
+    self:set(os_time(self.tab))
+    if old_dst ~= self.tab.isdst then
+        self.tab.hour = self.tab.hour - (old_dist and 1 or -1)
+        self:set(os_time(self.tab))
+    end
+    return self
+end
+
+--- last day of the month.
+-- @return int day
+function Date:last_day()
+    local d = 28
+    local m = self.tab.month
+    while self.tab.month == m do
+        d = d + 1
+        self:add{day=1}
+    end
+    self:add{day=-1}
+    return self
+end
+
+--- difference between two Date objects.
+-- @param other Date object
+-- @treturn Date.Interval object
+function Date:diff(other)
+    local dt = self.time - other.time
+    if dt < 0 then error("date difference is negative!",2) end
+    return Date.Interval(dt)
+end
+
+--- long numerical ISO data format version of this date.
+function Date:__tostring()
+    local t = os_date('%Y-%m-%dT%H:%M:%S',self.time)
+    if self.utc then
+        return  t .. 'Z'
+    else
+        local offs = self:tzone()
+        if offs == 0 then
+            return t .. 'Z'
+        end
+        local sign = offs > 0 and '+' or '-'
+        local h = math.ceil(offs/3600)
+        local m = (offs % 3600)/60
+        if m == 0 then
+            return t .. ('%s%02d'):format(sign,h)
+        else
+            return t .. ('%s%02d:%02d'):format(sign,h,m)
+        end
+    end
+end
+
+--- equality between Date objects.
+function Date:__eq(other)
+    return self.time == other.time
+end
+
+--- ordering between Date objects.
+function Date:__lt(other)
+    return self.time < other.time
+end
+
+--- difference between Date objects.
+-- @function Date:__sub
+Date.__sub = Date.diff
+
+--- add a date and an interval.
+-- @param other either a `Date.Interval` object or a table such as
+-- passed to `Date:add`
+function Date:__add(other)
+    local nd = Date(self)
+    if Date.Interval:class_of(other) then
+        other = {sec=other.time}
+    end
+    nd:add(other)
+    return nd
+end
+
+Date.Interval = class(Date)
+
+---- Date.Interval constructor
+-- @param t an interval in seconds
+-- @function Date.Interval
+function Date.Interval:_init(t)
+    self:set(t)
+end
+
+function Date.Interval:set(t)
+    self.time = t
+    self.tab = os_date('!*t',self.time)
+end
+
+local function ess(n)
+    if n > 1 then return 's '
+    else return ' '
+    end
+end
+
+--- If it's an interval then the format is '2 hours 29 sec' etc.
+function Date.Interval:__tostring()
+    local t, res = self.tab, ''
+    local y,m,d = t.year - 1970, t.month - 1, t.day - 1
+    if y > 0 then res = res .. y .. ' year'..ess(y) end
+    if m > 0 then res = res .. m .. ' month'..ess(m) end
+    if d > 0 then res = res .. d .. ' day'..ess(d) end
+    if y == 0 and m == 0 then
+        local h = t.hour
+        if h > 0 then res = res .. h .. ' hour'..ess(h) end
+        if t.min > 0 then res = res .. t.min .. ' min ' end
+        if t.sec > 0 then res = res .. t.sec .. ' sec ' end
+    end
+    if res == '' then res = 'zero' end
+    return res
+end
+
+------------ Date.Format class: parsing and renderinig dates ------------
+
+-- short field names, explicit os.date names, and a mask for allowed field repeats
+local formats = {
+    d = {'day',{true,true}},
+    y = {'year',{false,true,false,true}},
+    m = {'month',{true,true}},
+    H = {'hour',{true,true}},
+    M = {'min',{true,true}},
+    S = {'sec',{true,true}},
+}
+
+--- Date.Format constructor.
+-- @param fmt. A string where the following fields are significant:
+--
+--   * d day (either d or dd)
+--   * y year (either yy or yyy)
+--   * m month (either m or mm)
+--   * H hour (either H or HH)
+--   * M minute (either M or MM)
+--   * S second (either S or SS)
+--
+-- Alternatively, if fmt is nil then this returns a flexible date parser
+-- that tries various date/time schemes in turn:
+--
+--  * [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601), like `2010-05-10 12:35:23Z` or `2008-10-03T14:30+02`
+--  * times like 15:30 or 8.05pm  (assumed to be today's date)
+--  * dates like 28/10/02 (European order!) or 5 Feb 2012
+--  * month name like march or Mar (case-insensitive, first 3 letters); here the
+-- day will be 1 and the year this current year
+--
+-- A date in format 3 can be optionally followed by a time in format 2.
+-- Please see test-date.lua in the tests folder for more examples.
+-- @usage df = Date.Format("yyyy-mm-dd HH:MM:SS")
+-- @class function
+-- @name Date.Format
+function Date.Format:_init(fmt)
+    if not fmt then
+        self.fmt = '%Y-%m-%d %H:%M:%S'
+        self.outf = self.fmt
+        self.plain = true
+        return
+    end
+    local append = table.insert
+    local D,PLUS,OPENP,CLOSEP = '\001','\002','\003','\004'
+    local vars,used = {},{}
+    local patt,outf = {},{}
+    local i = 1
+    while i < #fmt do
+        local ch = fmt:sub(i,i)
+        local df = formats[ch]
+        if df then
+            if used[ch] then error("field appeared twice: "..ch,4) end
+            used[ch] = true
+            -- this field may be repeated
+            local _,inext = fmt:find(ch..'+',i+1)
+            local cnt = not _ and 1 or inext-i+1
+            if not df[2][cnt] then error("wrong number of fields: "..ch,4) end
+            -- single chars mean 'accept more than one digit'
+            local p = cnt==1 and (D..PLUS) or (D):rep(cnt)
+            append(patt,OPENP..p..CLOSEP)
+            append(vars,ch)
+            if ch == 'y' then
+                append(outf,cnt==2 and '%y' or '%Y')
+            else
+                append(outf,'%'..ch)
+            end
+            i = i + cnt
+        else
+            append(patt,ch)
+            append(outf,ch)
+            i = i + 1
+        end
+    end
+    -- escape any magic characters
+    fmt = utils.escape(table.concat(patt))
+   -- fmt = table.concat(patt):gsub('[%-%.%+%[%]%(%)%$%^%%%?%*]','%%%1')
+    -- replace markers with their magic equivalents
+    fmt = fmt:gsub(D,'%%d'):gsub(PLUS,'+'):gsub(OPENP,'('):gsub(CLOSEP,')')
+    self.fmt = fmt
+    self.outf = table.concat(outf)
+    self.vars = vars
+end
+
+local parse_date
+
+--- parse a string into a Date object.
+-- @param str a date string
+-- @return date object
+function Date.Format:parse(str)
+    assert_string(1,str)
+    if self.plain then
+        return parse_date(str,self.us)
+    end
+    local res = {str:match(self.fmt)}
+    if #res==0 then return nil, 'cannot parse '..str end
+    local tab = {}
+    for i,v in ipairs(self.vars) do
+        local name = formats[v][1] -- e.g. 'y' becomes 'year'
+        tab[name] = tonumber(res[i])
+    end
+    -- os.date() requires these fields; if not present, we assume
+    -- that the time set is for the current day.
+    if not (tab.year and tab.month and tab.day) then
+        local today = Date()
+        tab.year = tab.year or today:year()
+        tab.month = tab.month or today:month()
+        tab.day = tab.day or today:day()
+    end
+    local Y = tab.year
+    if Y < 100 then -- classic Y2K pivot
+        tab.year = Y + (Y < 35 and 2000 or 1999)
+    elseif not Y then
+        tab.year = 1970
+    end
+    return Date(tab)
+end
+
+--- convert a Date object into a string.
+-- @param d a date object, or a time value as returned by @{os.time}
+-- @return string
+function Date.Format:tostring(d)
+    local tm = type(d) == 'number' and d or d.time
+    return os_date(self.outf,tm)
+end
+
+--- force US order in dates like 9/11/2001
+function Date.Format:US_order(yesno)
+    self.us = yesno
+end
+
+--local months = {jan=1,feb=2,mar=3,apr=4,may=5,jun=6,jul=7,aug=8,sep=9,oct=10,nov=11,dec=12}
+local months
+
+--[[
+Allowed patterns:
+- [day] [monthname] [year] [time]
+- [day]/[month][/year] [time]
+
+]]
+
+
+local is_word = stringx.isalpha
+local is_number = stringx.isdigit
+local function tonum(s,l1,l2,kind)
+    kind = kind or ''
+    local n = tonumber(s)
+    if not n then error(("%snot a number: '%s'"):format(kind,s)) end
+    if n < l1 or n > l2 then
+        error(("%s out of range: %s is not between %d and %d"):format(kind,s,l1,l2))
+    end
+    return n
+end
+
+local function  parse_iso_end(p,ns,sec)
+    -- may be fractional part of seconds
+    local _,nfrac,secfrac = p:find('^%.%d+',ns+1)
+    if secfrac then
+        sec = sec .. secfrac
+        p = p:sub(nfrac+1)
+    else
+        p = p:sub(ns+1)
+    end
+    -- ISO 8601 dates may end in Z (for UTC) or [+-][isotime]
+    -- (we're working with the date as lower case, hence 'z')
+    if p:match 'z$' then return sec, {h=0,m=0} end -- we're UTC!
+    p = p:gsub(':','') -- turn 00:30 to 0030
+    local _,_,sign,offs = p:find('^([%+%-])(%d+)')
+    if not sign then return sec, nil end -- not UTC
+
+    if #offs == 2 then offs = offs .. '00' end -- 01 to 0100
+    local tz = { h = tonumber(offs:sub(1,2)), m = tonumber(offs:sub(3,4)) }
+    if sign == '-' then tz.h = -tz.h; tz.m = -tz.m end
+    return sec, tz
+end
+
+local function parse_date_unsafe (s,US)
+    s = s:gsub('T',' ') -- ISO 8601
+    local parts = stringx.split(s:lower())
+    local i,p = 1,parts[1]
+    local function nextp() i = i + 1; p = parts[i] end
+    local year,min,hour,sec,apm
+    local tz
+    local _,nxt,day, month = p:find '^(%d+)/(%d+)'
+    if day then
+        -- swop for US case
+        if US then
+            day, month = month, day
+        end
+        _,_,year = p:find('^/(%d+)',nxt+1)
+        nextp()
+    else -- ISO
+        year,month,day = p:match('^(%d+)%-(%d+)%-(%d+)')
+        if year then
+            nextp()
+        end
+    end
+    if p and not year and is_number(p) then -- has to be date
+        if #p < 4 then
+            day = p
+            nextp()
+        else -- unless it looks like a 24-hour time
+            year = true
+        end
+    end
+    if p and is_word(p) then
+        p = p:sub(1,3)
+        if not months then
+            local ld, day1 = parse_date_unsafe '2000-12-31', {day=1}
+            months = {}
+            for i = 1,12 do
+                ld = ld:last_day()
+                ld:add(day1)
+                local mon = ld:month_name():lower()
+                months [mon] = i
+            end
+        end
+        local mon = months[p]
+        if mon then
+            month = mon
+        else error("not a month: " .. p) end
+        nextp()
+    end
+    if p and not year and is_number(p) then
+        year = p
+        nextp()
+    end
+
+    if p then -- time is hh:mm[:ss], hhmm[ss] or H.M[am|pm]
+        _,nxt,hour,min = p:find '^(%d+):(%d+)'
+        local ns
+        if nxt then -- are there seconds?
+            _,ns,sec = p:find ('^:(%d+)',nxt+1)
+            --if ns then
+                sec,tz = parse_iso_end(p,ns or nxt,sec)
+            --end
+        else -- might be h.m
+            _,ns,hour,min = p:find '^(%d+)%.(%d+)'
+            if ns then
+                apm = p:match '[ap]m$'
+            else  -- or hhmm[ss]
+                local hourmin
+                _,nxt,hourmin = p:find ('^(%d+)')
+                if nxt then
+                   hour = hourmin:sub(1,2)
+                   min = hourmin:sub(3,4)
+                   sec = hourmin:sub(5,6)
+                   if #sec == 0 then sec = nil end
+                   sec,tz = parse_iso_end(p,nxt,sec)
+                end
+            end
+        end
+    end
+    local today
+    if year == true then year = nil end
+    if not (year and month and day) then
+        today = Date()
+    end
+    day = day and tonum(day,1,31,'day') or (month and 1 or today:day())
+    month = month and tonum(month,1,12,'month') or today:month()
+    year = year and tonumber(year) or today:year()
+    if year < 100 then -- two-digit year pivot around year < 2035
+        year = year + (year < 35 and 2000 or 1900)
+    end
+    hour = hour and tonum(hour,0,apm and 12 or 24,'hour') or 12
+    if apm == 'pm' then
+        hour = hour + 12
+    end
+    min = min and tonum(min,0,59) or 0
+    sec = sec and tonum(sec,0,60) or 0  --60 used to indicate leap second
+    local res = Date {year = year, month = month, day = day, hour = hour, min = min, sec = sec}
+    if tz then -- ISO 8601 UTC time
+        res:add {hour = -tz.h}
+        if tz.m ~= 0 then res:add {min = -tz.m} end
+        res.utc = true
+        -- we're in UTC, so let's go local...
+        res = res:toLocal()
+    end
+    return res
+end
+
+function parse_date (s)
+    local ok, d = pcall(parse_date_unsafe,s)
+    if not ok then -- error
+        d = d:gsub('.-:%d+: ','')
+        return nil, d
+    else
+        return d
+    end
+end
+
+
+return Date
+

--- a/lib/ext/spec-support/pl/LICENSE.md
+++ b/lib/ext/spec-support/pl/LICENSE.md
@@ -1,0 +1,21 @@
+Copyright (C) 2009 Steve Donovan, David Manura.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/ext/spec-support/pl/List.lua
+++ b/lib/ext/spec-support/pl/List.lua
@@ -1,0 +1,568 @@
+--- Python-style list class.
+--
+-- **Please Note**: methods that change the list will return the list.
+-- This is to allow for method chaining, but please note that `ls = ls:sort()`
+-- does not mean that a new copy of the list is made. In-place (mutable) methods
+-- are marked as returning 'the list' in this documentation.
+--
+-- See the Guide for further @{02-arrays.md.Python_style_Lists|discussion}
+--
+-- See <a href="http://www.python.org/doc/current/tut/tut.html">http://www.python.org/doc/current/tut/tut.html</a>, section 5.1
+--
+-- **Note**: The comments before some of the functions are from the Python docs
+-- and contain Python code.
+--
+-- Written for Lua version Nick Trout 4.0; Redone for Lua 5.1, Steve Donovan.
+--
+-- Dependencies: `pl.utils`, `pl.tablex`
+-- @classmod pl.List
+-- @pragma nostrip
+
+local tinsert,tremove,concat,tsort = table.insert,table.remove,table.concat,table.sort
+local setmetatable, getmetatable,type,tostring,assert,string,next = setmetatable,getmetatable,type,tostring,assert,string,next
+local write = io.write
+local tablex = require 'pl.tablex'
+local filter,imap,imap2,reduce,transform,tremovevalues = tablex.filter,tablex.imap,tablex.imap2,tablex.reduce,tablex.transform,tablex.removevalues
+local tablex = tablex
+local tsub = tablex.sub
+local utils = require 'pl.utils'
+local class = require 'pl.class'
+
+local array_tostring,split,assert_arg,function_arg = utils.array_tostring,utils.split,utils.assert_arg,utils.function_arg
+local normalize_slice = tablex._normalize_slice
+
+-- metatable for our list and map objects has already been defined..
+local Multimap = utils.stdmt.MultiMap
+local List = utils.stdmt.List
+
+local iter
+
+class(nil,nil,List)
+
+-- we want the result to be _covariant_, i.e. t must have type of obj if possible
+local function makelist (t,obj)
+    local klass = List
+    if obj then
+        klass = getmetatable(obj)
+    end
+    return setmetatable(t,klass)
+end
+
+local function simple_table(t)
+    return type(t) == 'table' and not getmetatable(t) and #t > 0
+end
+
+function List._create (src)
+    if simple_table(src) then return src end
+end
+
+function List:_init (src)
+    if self == src then return end -- existing table used as self!
+    if src then
+        for v in iter(src) do
+            tinsert(self,v)
+        end
+    end
+end
+
+--- Create a new list. Can optionally pass a table;
+-- passing another instance of List will cause a copy to be created;
+-- this will return a plain table with an appropriate metatable.
+-- we pass anything which isn't a simple table to iterate() to work out
+-- an appropriate iterator
+--  @see List.iterate
+-- @param t An optional list-like table
+-- @return a new List
+-- @usage ls = List();  ls = List {1,2,3,4}
+-- @function List.new
+
+List.new = List
+
+--- Make a copy of an existing list.
+-- The difference from a plain 'copy constructor' is that this returns
+-- the actual List subtype.
+function List:clone()
+    local ls = makelist({},self)
+    ls:extend(self)
+    return ls
+end
+
+---Add an item to the end of the list.
+-- @param i An item
+-- @return the list
+function List:append(i)
+    tinsert(self,i)
+    return self
+end
+
+List.push = tinsert
+
+--- Extend the list by appending all the items in the given list.
+-- equivalent to 'a[len(a):] = L'.
+-- @param L Another List
+-- @return the list
+function List:extend(L)
+    assert_arg(1,L,'table')
+    for i = 1,#L do tinsert(self,L[i]) end
+    return self
+end
+
+--- Insert an item at a given position. i is the index of the
+-- element before which to insert.
+-- @param i index of element before whichh to insert
+-- @param x A data item
+-- @return the list
+function List:insert(i, x)
+    assert_arg(1,i,'number')
+    tinsert(self,i,x)
+    return self
+end
+
+--- Insert an item at the begining of the list.
+-- @param x a data item
+-- @return the list
+function List:put (x)
+    return self:insert(1,x)
+end
+
+--- Remove an element given its index.
+-- (equivalent of Python's del s[i])
+-- @param i the index
+-- @return the list
+function List:remove (i)
+    assert_arg(1,i,'number')
+    tremove(self,i)
+    return self
+end
+
+--- Remove the first item from the list whose value is given.
+-- (This is called 'remove' in Python; renamed to avoid confusion
+-- with table.remove)
+-- Return nil if there is no such item.
+-- @param x A data value
+-- @return the list
+function List:remove_value(x)
+    for i=1,#self do
+        if self[i]==x then tremove(self,i) return self end
+    end
+    return self
+ end
+
+--- Remove the item at the given position in the list, and return it.
+-- If no index is specified, a:pop() returns the last item in the list.
+-- The item is also removed from the list.
+-- @param i An index
+-- @return the item
+function List:pop(i)
+    if not i then i = #self end
+    assert_arg(1,i,'number')
+    return tremove(self,i)
+end
+
+List.get = List.pop
+
+--- Return the index in the list of the first item whose value is given.
+-- Return nil if there is no such item.
+-- @class function
+-- @name List:index
+-- @param x A data value
+-- @param idx where to start search (default 1)
+-- @return the index, or nil if not found.
+
+local tfind = tablex.find
+List.index = tfind
+
+--- does this list contain the value?.
+-- @param x A data value
+-- @return true or false
+function List:contains(x)
+    return tfind(self,x) and true or false
+end
+
+--- Return the number of times value appears in the list.
+-- @param x A data value
+-- @return number of times x appears
+function List:count(x)
+    local cnt=0
+    for i=1,#self do
+        if self[i]==x then cnt=cnt+1 end
+    end
+    return cnt
+end
+
+--- Sort the items of the list, in place.
+-- @param cmp an optional comparison function, default '<'
+-- @return the list
+function List:sort(cmp)
+    if cmp then cmp = function_arg(1,cmp) end
+    tsort(self,cmp)
+    return self
+end
+
+--- return a sorted copy of this list.
+-- @param cmp an optional comparison function, default '<'
+-- @return a new list
+function List:sorted(cmp)
+    return List(self):sort(cmp)
+end
+
+--- Reverse the elements of the list, in place.
+-- @return the list
+function List:reverse()
+    local t = self
+    local n = #t
+    local n2 = n/2
+    for i = 1,n2 do
+        local k = n-i+1
+        t[i],t[k] = t[k],t[i]
+    end
+    return self
+end
+
+--- return the minimum and the maximum value of the list.
+-- @return minimum value
+-- @return maximum value
+function List:minmax()
+    local vmin,vmax = 1e70,-1e70
+    for i = 1,#self do
+        local v = self[i]
+        if v < vmin then vmin = v end
+        if v > vmax then vmax = v end
+    end
+    return vmin,vmax
+end
+
+--- Emulate list slicing.  like  'list[first:last]' in Python.
+-- If first or last are negative then they are relative to the end of the list
+-- eg. slice(-2) gives last 2 entries in a list, and
+-- slice(-4,-2) gives from -4th to -2nd
+-- @param first An index
+-- @param last An index
+-- @return a new List
+function List:slice(first,last)
+    return tsub(self,first,last)
+end
+
+--- empty the list.
+-- @return the list
+function List:clear()
+    for i=1,#self do tremove(self) end
+    return self
+end
+
+local eps = 1.0e-10
+
+--- Emulate Python's range(x) function.
+-- Include it in List table for tidiness
+-- @param start A number
+-- @param finish A number greater than start; if absent,
+-- then start is 1 and finish is start
+-- @param incr an optional increment (may be less than 1)
+-- @return a List from start .. finish
+-- @usage List.range(0,3) == List{0,1,2,3}
+-- @usage List.range(4) = List{1,2,3,4}
+-- @usage List.range(5,1,-1) == List{5,4,3,2,1}
+function List.range(start,finish,incr)
+    if not finish then
+        finish = start
+        start = 1
+    end
+    if incr then
+    assert_arg(3,incr,'number')
+    if math.ceil(incr) ~= incr then finish = finish + eps end
+    else
+        incr = 1
+    end
+    assert_arg(1,start,'number')
+    assert_arg(2,finish,'number')
+    local t = List()
+    for i=start,finish,incr do tinsert(t,i) end
+    return t
+end
+
+--- list:len() is the same as #list.
+function List:len()
+    return #self
+end
+
+-- Extended operations --
+
+--- Remove a subrange of elements.
+-- equivalent to 'del s[i1:i2]' in Python.
+-- @param i1 start of range
+-- @param i2 end of range
+-- @return the list
+function List:chop(i1,i2)
+    return tremovevalues(self,i1,i2)
+end
+
+--- Insert a sublist into a list
+-- equivalent to 's[idx:idx] = list' in Python
+-- @param idx index
+-- @param list list to insert
+-- @return the list
+-- @usage  l = List{10,20}; l:splice(2,{21,22});  assert(l == List{10,21,22,20})
+function List:splice(idx,list)
+    assert_arg(1,idx,'number')
+    idx = idx - 1
+    local i = 1
+    for v in iter(list) do
+        tinsert(self,i+idx,v)
+        i = i + 1
+    end
+    return self
+end
+
+--- general slice assignment s[i1:i2] = seq.
+-- @param i1  start index
+-- @param i2  end index
+-- @param seq a list
+-- @return the list
+function List:slice_assign(i1,i2,seq)
+    assert_arg(1,i1,'number')
+    assert_arg(1,i2,'number')
+    i1,i2 = normalize_slice(self,i1,i2)
+    if i2 >= i1 then self:chop(i1,i2) end
+    self:splice(i1,seq)
+    return self
+end
+
+--- concatenation operator.
+-- @within metamethods
+-- @param L another List
+-- @return a new list consisting of the list with the elements of the new list appended
+function List:__concat(L)
+    assert_arg(1,L,'table')
+    local ls = self:clone()
+    ls:extend(L)
+    return ls
+end
+
+--- equality operator ==.  True iff all elements of two lists are equal.
+-- @within metamethods
+-- @param L another List
+-- @return true or false
+function List:__eq(L)
+    if #self ~= #L then return false end
+    for i = 1,#self do
+        if self[i] ~= L[i] then return false end
+    end
+    return true
+end
+
+--- join the elements of a list using a delimiter. <br>
+-- This method uses tostring on all elements.
+-- @param delim a delimiter string, can be empty.
+-- @return a string
+function List:join (delim)
+    delim = delim or ''
+    assert_arg(1,delim,'string')
+    return concat(array_tostring(self),delim)
+end
+
+--- join a list of strings. <br>
+-- Uses table.concat directly.
+-- @class function
+-- @name List:concat
+-- @param delim a delimiter
+-- @return a string
+List.concat = concat
+
+local function tostring_q(val)
+    local s = tostring(val)
+    if type(val) == 'string' then
+        s = '"'..s..'"'
+    end
+    return s
+end
+
+--- how our list should be rendered as a string. Uses join().
+-- @within metamethods
+-- @see List:join
+function List:__tostring()
+    return '{'..self:join(',',tostring_q)..'}'
+end
+
+--- call the function for each element of the list.
+-- @param fun a function or callable object
+-- @param ... optional values to pass to function
+function List:foreach (fun,...)
+    fun = function_arg(1,fun)
+    for i = 1,#self do
+        fun(self[i],...)
+    end
+end
+
+local function lookup_fun (obj,name)
+    local f = obj[name]
+    if not f then error(type(obj).." does not have method "..name,3) end
+    return f
+end
+
+function List:foreachm (name,...)
+    for i = 1,#self do
+        local obj = self[i]
+        local f = lookup_fun(obj,name)
+        f(obj,...)
+    end
+end
+
+--- create a list of all elements which match a function.
+-- @param fun a boolean function
+-- @param arg optional argument to be passed as second argument of the predicate
+-- @return a new filtered list.
+function List:filter (fun,arg)
+    return makelist(filter(self,fun,arg),self)
+end
+
+--- split a string using a delimiter.
+-- @param s the string
+-- @param delim the delimiter (default spaces)
+-- @return a List of strings
+-- @see pl.utils.split
+function List.split (s,delim)
+    assert_arg(1,s,'string')
+    return makelist(split(s,delim))
+end
+
+--- apply a function to all elements.
+-- Any extra arguments will be passed to the function.
+-- @param fun a function of at least one argument
+-- @param ... arbitrary extra arguments.
+-- @return a new list: {f(x) for x in self}
+-- @usage List{'one','two'}:map(string.upper) == {'ONE','TWO'}
+-- @see pl.tablex.imap
+function List:map (fun,...)
+    return makelist(imap(fun,self,...),self)
+end
+
+--- apply a function to all elements, in-place.
+-- Any extra arguments are passed to the function.
+-- @param fun A function that takes at least one argument
+-- @param ... arbitrary extra arguments.
+-- @return the list.
+function List:transform (fun,...)
+    transform(fun,self,...)
+	return self
+end
+
+--- apply a function to elements of two lists.
+-- Any extra arguments will be passed to the function
+-- @param fun a function of at least two arguments
+-- @param ls another list
+-- @param ... arbitrary extra arguments.
+-- @return a new list: {f(x,y) for x in self, for x in arg1}
+-- @see pl.tablex.imap2
+function List:map2 (fun,ls,...)
+    return makelist(imap2(fun,self,ls,...),self)
+end
+
+--- apply a named method to all elements.
+-- Any extra arguments will be passed to the method.
+-- @param name name of method
+-- @param ... extra arguments
+-- @return a new list of the results
+-- @see pl.seq.mapmethod
+function List:mapm (name,...)
+    local res = {}
+    for i = 1,#self do
+      local val = self[i]
+      local fn = lookup_fun(val,name)
+      res[i] = fn(val,...)
+    end
+    return makelist(res,self)
+end
+
+local function composite_call (method,f)
+    return function(self,...)
+        return self[method](self,f,...)
+    end
+end
+
+function List.default_map_with(T)
+    return function(self,name)
+        local m
+        if T then
+            local f = lookup_fun(T,name)
+            m = composite_call('map',f)
+        else
+            m = composite_call('mapn',name)
+        end
+        getmetatable(self)[name] = m -- and cache..
+        return m
+    end
+end
+
+List.default_map = List.default_map_with
+
+--- 'reduce' a list using a binary function.
+-- @param fun a function of two arguments
+-- @return result of the function
+-- @see pl.tablex.reduce
+function List:reduce (fun)
+    return reduce(fun,self)
+end
+
+--- partition a list using a classifier function.
+-- The function may return nil, but this will be converted to the string key '<nil>'.
+-- @param fun a function of at least one argument
+-- @param ... will also be passed to the function
+-- @return a table where the keys are the returned values, and the values are Lists
+-- of values where the function returned that key. It is given the type of Multimap.
+-- @see pl.MultiMap
+function List:partition (fun,...)
+    fun = function_arg(1,fun)
+    local res = {}
+    for i = 1,#self do
+        local val = self[i]
+        local klass = fun(val,...)
+        if klass == nil then klass = '<nil>' end
+        if not res[klass] then res[klass] = List() end
+        res[klass]:append(val)
+    end
+    return setmetatable(res,Multimap)
+end
+
+--- return an iterator over all values.
+function List:iter ()
+    return iter(self)
+end
+
+--- Create an iterator over a seqence.
+-- This captures the Python concept of 'sequence'.
+-- For tables, iterates over all values with integer indices.
+-- @param seq a sequence; a string (over characters), a table, a file object (over lines) or an iterator function
+-- @usage for x in iterate {1,10,22,55} do io.write(x,',') end ==> 1,10,22,55
+-- @usage for ch in iterate 'help' do do io.write(ch,' ') end ==> h e l p
+function List.iterate(seq)
+    if type(seq) == 'string' then
+        local idx = 0
+        local n = #seq
+        local sub = string.sub
+        return function ()
+            idx = idx + 1
+            if idx > n then return nil
+            else
+                return sub(seq,idx,idx)
+            end
+        end
+    elseif type(seq) == 'table' then
+        local idx = 0
+        local n = #seq
+        return function()
+            idx = idx + 1
+            if idx > n then return nil
+            else
+                return seq[idx]
+            end
+        end
+    elseif type(seq) == 'function' then
+        return seq
+    elseif type(seq) == 'userdata' and io.type(seq) == 'file' then
+        return seq:lines()
+    end
+end
+iter = List.iterate
+
+return List
+

--- a/lib/ext/spec-support/pl/Map.lua
+++ b/lib/ext/spec-support/pl/Map.lua
@@ -1,0 +1,117 @@
+--- A Map class.
+--
+--    > Map = require 'pl.Map'
+--    > m = Map{one=1,two=2}
+--    > m:update {three=3,four=4,two=20}
+--    > = m == M{one=1,two=20,three=3,four=4}
+--    true
+--
+-- Dependencies: `pl.utils`, `pl.class`, `pl.tablex`, `pl.pretty`
+-- @classmod pl.Map
+
+local tablex = require 'pl.tablex'
+local utils = require 'pl.utils'
+local stdmt = utils.stdmt
+local tmakeset,deepcompare,merge,keys,difference,tupdate = tablex.makeset,tablex.deepcompare,tablex.merge,tablex.keys,tablex.difference,tablex.update
+
+local pretty_write = require 'pl.pretty' . write
+local Map = stdmt.Map
+local Set = stdmt.Set
+local List = stdmt.List
+
+local class = require 'pl.class'
+
+-- the Map class ---------------------
+class(nil,nil,Map)
+
+local function makemap (m)
+    return setmetatable(m,Map)
+end
+
+function Map:_init (t)
+    local mt = getmetatable(t)
+    if mt == Set or mt == Map then
+        self:update(t)
+    else
+        return t -- otherwise assumed to be a map-like table
+    end
+end
+
+
+local function makelist(t)
+    return setmetatable(t,List)
+end
+
+--- list of keys.
+Map.keys = tablex.keys
+
+--- list of values.
+Map.values = tablex.values
+
+--- return an iterator over all key-value pairs.
+function Map:iter ()
+    return pairs(self)
+end
+
+--- return a List of all key-value pairs, sorted by the keys.
+function Map:items()
+    local ls = makelist(tablex.pairmap (function (k,v) return makelist {k,v} end, self))
+	ls:sort(function(t1,t2) return t1[1] < t2[1] end)
+	return ls
+end
+
+-- Will return the existing value, or if it doesn't exist it will set
+-- a default value and return it.
+function Map:setdefault(key, defaultval)
+   return self[key] or self:set(key,defaultval) or defaultval
+end
+
+--- size of map.
+-- note: this is a relatively expensive operation!
+-- @class function
+-- @name Map:len
+Map.len = tablex.size
+
+--- put a value into the map.
+-- @param key the key
+-- @param val the value
+function Map:set (key,val)
+    self[key] = val
+end
+
+--- get a value from the map.
+-- @param key the key
+-- @return the value, or nil if not found.
+function Map:get (key)
+    return rawget(self,key)
+end
+
+local index_by = tablex.index_by
+
+--- get a list of values indexed by a list of keys.
+-- @param keys a list-like table of keys
+-- @return a new list
+function Map:getvalues (keys)
+    return makelist(index_by(self,keys))
+end
+
+--- update the map using key/value pairs from another table.
+-- @param table
+-- @function Map:update
+Map.update = tablex.update
+
+--- equality between maps.
+-- @within metamethods
+-- @param m another map.
+function Map:__eq (m)
+    -- note we explicitly ask deepcompare _not_ to use __eq!
+    return deepcompare(self,m,true)
+end
+
+--- string representation of a map.
+-- @within metamethods
+function Map:__tostring ()
+    return pretty_write(self,'')
+end
+
+return Map

--- a/lib/ext/spec-support/pl/MultiMap.lua
+++ b/lib/ext/spec-support/pl/MultiMap.lua
@@ -1,0 +1,61 @@
+--- MultiMap, a Map which has multiple values per key.
+--
+-- Dependencies: `pl.utils`, `pl.class`, `pl.tablex`, `pl.List`
+-- @classmod pl.MultiMap
+
+local classes = require 'pl.class'
+local tablex = require 'pl.tablex'
+local utils = require 'pl.utils'
+local List = require 'pl.List'
+
+local index_by,tsort,concat = tablex.index_by,table.sort,table.concat
+local append,extend,slice = List.append,List.extend,List.slice
+local append = table.insert
+
+local class = require 'pl.class'
+local Map = require 'pl.Map'
+
+-- MultiMap is a standard MT
+local MultiMap = utils.stdmt.MultiMap
+
+class(Map,nil,MultiMap)
+MultiMap._name = 'MultiMap'
+
+function MultiMap:_init (t)
+    if not t then return end
+    self:update(t)
+end
+
+--- update a MultiMap using a table.
+-- @param t either a Multimap or a map-like table.
+-- @return the map
+function MultiMap:update (t)
+    utils.assert_arg(1,t,'table')
+    if Map:class_of(t) then
+        for k,v in pairs(t) do
+            self[k] = List()
+            self[k]:append(v)
+        end
+    else
+        for k,v in pairs(t) do
+            self[k] = List(v)
+        end
+    end
+end
+
+--- add a new value to a key.  Setting a nil value removes the key.
+-- @param key the key
+-- @param val the value
+-- @return the map
+function MultiMap:set (key,val)
+    if val == nil then
+        self[key] = nil
+    else
+        if not self[key] then
+            self[key] = List()
+        end
+        self[key]:append(val)
+    end
+end
+
+return MultiMap

--- a/lib/ext/spec-support/pl/OrderedMap.lua
+++ b/lib/ext/spec-support/pl/OrderedMap.lua
@@ -1,0 +1,166 @@
+--- OrderedMap, a map which preserves ordering.
+--
+-- Derived from `pl.Map`.
+--
+-- Dependencies: `pl.utils`, `pl.tablex`, `pl.List`
+-- @classmod pl.OrderedMap
+
+local tablex = require 'pl.tablex'
+local utils = require 'pl.utils'
+local List = require 'pl.List'
+local index_by,tsort,concat = tablex.index_by,table.sort,table.concat
+
+local class = require 'pl.class'
+local Map = require 'pl.Map'
+
+local OrderedMap = class(Map)
+OrderedMap._name = 'OrderedMap'
+
+local rawset = rawset
+
+--- construct an OrderedMap.
+-- Will throw an error if the argument is bad.
+-- @param t optional initialization table, same as for @{OrderedMap:update}
+function OrderedMap:_init (t)
+    rawset(self,'_keys',List())
+    if t then
+        local map,err = self:update(t)
+        if not map then error(err,2) end
+    end
+end
+
+local assert_arg,raise = utils.assert_arg,utils.raise
+
+--- update an OrderedMap using a table.
+-- If the table is itself an OrderedMap, then its entries will be appended. <br>
+-- if it s a table of the form <code>{{key1=val1},{key2=val2},...}</code> these will be appended. <br>
+-- Otherwise, it is assumed to be a map-like table, and order of extra entries is arbitrary.
+-- @param t a table.
+-- @return the map, or nil in case of error
+-- @return the error message
+function OrderedMap:update (t)
+    assert_arg(1,t,'table')
+    if OrderedMap:class_of(t) then
+       for k,v in t:iter() do
+           self:set(k,v)
+       end
+    elseif #t > 0 then -- an array must contain {key=val} tables
+       if type(t[1]) == 'table' then
+           for _,pair in ipairs(t) do
+               local key,value = next(pair)
+               if not key then return raise 'empty pair initialization table' end
+               self:set(key,value)
+           end
+       else
+           return raise 'cannot use an array to initialize an OrderedMap'
+       end
+    else
+       for k,v in pairs(t) do
+           self:set(k,v)
+       end
+    end
+   return self
+end
+
+--- set the key's value.   This key will be appended at the end of the map.
+--
+-- If the value is nil, then the key is removed.
+-- @param key the key
+-- @param val the value
+-- @return the map
+function OrderedMap:set (key,val)
+    if self[key] == nil and val ~= nil then -- new key
+       self._keys:append(key) -- we keep in order
+       rawset(self,key,val)  -- don't want to provoke __newindex!
+    else -- existing key-value pair
+        if val == nil then
+            self._keys:remove_value(key)
+            rawset(self,key,nil)
+        else
+            self[key] = val
+        end
+    end
+    return self
+end
+
+OrderedMap.__newindex = OrderedMap.set
+
+--- insert a key/value pair before a given position.
+-- Note: if the map already contains the key, then this effectively
+-- moves the item to the new position by first removing at the old position.
+-- Has no effect if the key does not exist and val is nil
+-- @param pos a position starting at 1
+-- @param key the key
+-- @param val the value; if nil use the old value
+function OrderedMap:insert (pos,key,val)
+    local oldval = self[key]
+    val = val or oldval
+    if oldval then
+        self._keys:remove_value(key)
+    end
+    if val then
+        self._keys:insert(pos,key)
+        rawset(self,key,val)
+    end
+    return self
+end
+
+--- return the keys in order.
+-- (Not a copy!)
+-- @return List
+function OrderedMap:keys ()
+    return self._keys
+end
+
+--- return the values in order.
+-- this is relatively expensive.
+-- @return List
+function OrderedMap:values ()
+    return List(index_by(self,self._keys))
+end
+
+--- sort the keys.
+-- @param cmp a comparison function as for @{table.sort}
+-- @return the map
+function OrderedMap:sort (cmp)
+    tsort(self._keys,cmp)
+    return self
+end
+
+--- iterate over key-value pairs in order.
+function OrderedMap:iter ()
+    local i = 0
+    local keys = self._keys
+    local n,idx = #keys
+    return function()
+        i = i + 1
+        if i > #keys then return nil end
+        idx = keys[i]
+        return idx,self[idx]
+    end
+end
+
+--- iterate over an ordered map (5.2).
+-- @within metamethods
+-- @function OrderedMap:__pairs
+OrderedMap.__pairs = OrderedMap.iter
+
+--- string representation of an ordered map.
+-- @within metamethods
+function OrderedMap:__tostring ()
+    local res = {}
+    for i,v in ipairs(self._keys) do
+        local val = self[v]
+        local vs = tostring(val)
+        if type(val) ~= 'number' then
+            vs = '"'..vs..'"'
+        end
+        res[i] = tostring(v)..'='..vs
+    end
+    return '{'..concat(res,',')..'}'
+end
+
+return OrderedMap
+
+
+

--- a/lib/ext/spec-support/pl/Set.lua
+++ b/lib/ext/spec-support/pl/Set.lua
@@ -1,0 +1,182 @@
+--- A Set class.
+--
+--     > Set = require 'pl.Set'
+--     > = Set{'one','two'} == Set{'two','one'}
+--     true
+--     > fruit = Set{'apple','banana','orange'}
+--     > = fruit['banana']
+--     true
+--     > = fruit['hazelnut']
+--     nil
+--     > colours = Set{'red','orange','green','blue'}
+--     > = fruit,colours
+--     [apple,orange,banana]   [blue,green,orange,red]
+--     > = fruit+colours
+--     [blue,green,apple,red,orange,banana]
+--     > = fruit*colours
+--     [orange]
+--
+-- Depdencies: `pl.utils`, `pl.tablex`, `pl.class`, (`pl.List` if __tostring is used)
+-- @classmod pl.Set
+
+local tablex = require 'pl.tablex'
+local utils = require 'pl.utils'
+local array_tostring, concat = utils.array_tostring, table.concat
+local tmakeset,deepcompare,merge,keys,difference,tupdate = tablex.makeset,tablex.deepcompare,tablex.merge,tablex.keys,tablex.difference,tablex.update
+local Map = require 'pl.Map'
+local class = require 'pl.class'
+local stdmt = utils.stdmt
+local Set = stdmt.Set
+
+-- the Set class --------------------
+class(Map,nil,Set)
+
+-- note: Set has _no_ methods!
+Set.__index = nil
+
+local function makeset (t)
+    return setmetatable(t,Set)
+end
+
+--- create a set. <br>
+-- @param t may be a Set, Map or list-like table.
+-- @class function
+-- @name Set
+function Set:_init (t)
+    t = t or {}
+    local mt = getmetatable(t)
+    if mt == Set or mt == Map then
+        for k in pairs(t) do self[k] = true end
+    else
+        for _,v in ipairs(t) do self[v] = true end
+    end
+end
+
+--- string representation of a set.
+-- @within metamethods
+function Set:__tostring ()
+    return '['..concat(array_tostring(Set.values(self)),',')..']'
+end
+
+--- get a list of the values in a set.
+-- @param self a Set
+-- @function Set.values
+Set.values = Map.keys
+
+--- map a function over the values of a set.
+-- @param self a Set
+-- @param fn a function
+-- @param ... extra arguments to pass to the function.
+-- @return a new set
+function Set.map (self,fn,...)
+    fn = utils.function_arg(1,fn)
+    local res = {}
+    for k in pairs(self) do
+        res[fn(k,...)] = true
+    end
+    return makeset(res)
+end
+
+--- union of two sets (also +).
+-- @param self a Set
+-- @param set another set
+-- @return a new set
+function Set.union (self,set)
+    return merge(self,set,true)
+end
+
+--- union of sets.
+-- @within metamethods
+-- @function Set.__add
+Set.__add = Set.union
+
+--- intersection of two sets (also *).
+-- @param self a Set
+-- @param set another set
+-- @return a new set
+function Set.intersection (self,set)
+    return merge(self,set,false)
+end
+
+--- intersection of sets.
+-- @within metamethods
+-- @function Set.__mul
+Set.__mul = Set.intersection
+
+--- new set with elements in the set that are not in the other (also -).
+-- @param self a Set
+-- @param set another set
+-- @return a new set
+function Set.difference (self,set)
+    return difference(self,set,false)
+end
+
+
+--- difference of sets.
+-- @within metamethods
+-- @function Set.__sub
+Set.__sub = Set.difference
+
+-- a new set with elements in _either_ the set _or_ other but not both (also ^).
+-- @param self a Set
+-- @param set another set
+-- @return a new set
+function Set.symmetric_difference (self,set)
+    return difference(self,set,true)
+end
+
+--- symmetric difference of sets.
+-- @within metamethods
+-- @function Set.__pow
+Set.__pow = Set.symmetric_difference
+
+--- is the first set a subset of the second (also <)?.
+-- @param self a Set
+-- @param set another set
+-- @return true or false
+function Set.issubset (self,set)
+    for k in pairs(self) do
+        if not set[k] then return false end
+    end
+    return true
+end
+
+--- first set subset of second?
+-- @within metamethods
+-- @function Set.__lt
+Set.__lt = Set.issubset
+
+--- is the set empty?.
+-- @param self a Set
+-- @return true or false
+function Set.isempty (self)
+    return next(self) == nil
+end
+
+--- are the sets disjoint? (no elements in common).
+-- Uses naive definition, i.e. that intersection is empty
+-- @param s1 a Set
+-- @param s2 another set
+-- @return true or false
+function Set.isdisjoint (s1,s2)
+    return Set.isempty(Set.intersection(s1,s2))
+end
+
+--- size of this set (also # for 5.2).
+-- @param s a Set
+-- @return size
+-- @function Set.len
+Set.len = tablex.size
+
+--- cardinality of set (5.2).
+-- @within metamethods
+-- @function Set.__len
+Set.__len = Set.len
+
+--- equality between sets.
+-- @within metamethods
+function Set.__eq (s1,s2)
+    return Set.issubset(s1,s2) and Set.issubset(s2,s1)
+end
+
+return Set

--- a/lib/ext/spec-support/pl/app.lua
+++ b/lib/ext/spec-support/pl/app.lua
@@ -1,0 +1,163 @@
+--- Application support functions.
+-- See @{01-introduction.md.Application_Support|the Guide}
+--
+-- Dependencies: `pl.utils`, `pl.path`
+-- @module pl.app
+
+local io,package,require = _G.io, _G.package, _G.require
+local utils = require 'pl.utils'
+local path = require 'pl.path'
+
+local app = {}
+
+local function check_script_name ()
+    if _G.arg == nil then error('no command line args available\nWas this run from a main script?') end
+    return _G.arg[0]
+end
+
+--- add the current script's path to the Lua module path.
+-- Applies to both the source and the binary module paths. It makes it easy for
+-- the main file of a multi-file program to access its modules in the same directory.
+-- `base` allows these modules to be put in a specified subdirectory, to allow for
+-- cleaner deployment and resolve potential conflicts between a script name and its
+-- library directory.
+-- @param base optional base directory.
+-- @return the current script's path with a trailing slash
+function app.require_here (base)
+    local p = path.dirname(check_script_name())
+    if not path.isabs(p) then
+        p = path.join(path.currentdir(),p)
+    end
+    if p:sub(-1,-1) ~= path.sep then
+        p = p..path.sep
+    end
+    if base then
+        p = p..base..path.sep
+    end
+    local so_ext = path.is_windows and 'dll' or 'so'
+    local lsep = package.path:find '^;' and '' or ';'
+    local csep = package.cpath:find '^;' and '' or ';'
+    package.path = ('%s?.lua;%s?%sinit.lua%s%s'):format(p,p,path.sep,lsep,package.path)
+    package.cpath = ('%s?.%s%s%s'):format(p,so_ext,csep,package.cpath)
+    return p
+end
+
+--- return a suitable path for files private to this application.
+-- These will look like '~/.SNAME/file', with '~' as with expanduser and
+-- SNAME is the name of the script without .lua extension.
+-- @param file a filename (w/out path)
+-- @return a full pathname, or nil
+-- @return 'cannot create' error
+function app.appfile (file)
+    local sname = path.basename(check_script_name())
+    local name,ext = path.splitext(sname)
+    local dir = path.join(path.expanduser('~'),'.'..name)
+    if not path.isdir(dir) then
+        local ret = path.mkdir(dir)
+        if not ret then return utils.raise ('cannot create '..dir) end
+    end
+    return path.join(dir,file)
+end
+
+--- return string indicating operating system.
+-- @return 'Windows','OSX' or whatever uname returns (e.g. 'Linux')
+function app.platform()
+    if path.is_windows then
+        return 'Windows'
+    else
+        local f = io.popen('uname')
+        local res = f:read()
+        if res == 'Darwin' then res = 'OSX' end
+        f:close()
+        return res
+    end
+end
+
+--- return the full command-line used to invoke this script.
+-- Any extra flags occupy slots, so that `lua -lpl` gives us `{[-2]='lua',[-1]='-lpl'}`
+-- @return command-line
+-- @return name of Lua program used
+function app.lua ()
+    local args = _G.arg or error "not in a main program"
+    local imin = 0
+    for i in pairs(args) do
+        if i < imin then imin = i end
+    end
+    local cmd, append = {}, table.insert
+    for i = imin,-1 do
+        local a = args[i]
+        if a:match '%s' then
+            a = '"'..a..'"'
+        end
+        append(cmd,a)
+    end
+    return table.concat(cmd,' '),args[imin]
+end
+
+--- parse command-line arguments into flags and parameters.
+-- Understands GNU-style command-line flags; short (`-f`) and long (`--flag`).
+-- These may be given a value with either '=' or ':' (`-k:2`,`--alpha=3.2`,`-n2`);
+-- note that a number value can be given without a space.
+-- Multiple short args can be combined like so: ( `-abcd`).
+-- @param args an array of strings (default is the global `arg`)
+-- @param flags_with_values any flags that take values, e.g. <code>{out=true}</code>
+-- @return a table of flags (flag=value pairs)
+-- @return an array of parameters
+-- @raise if args is nil, then the global `args` must be available!
+function app.parse_args (args,flags_with_values)
+    if not args then
+        args = _G.arg
+        if not args then error "Not in a main program: 'arg' not found" end
+    end
+    flags_with_values = flags_with_values or {}
+    local _args = {}
+    local flags = {}
+    local i = 1
+    while i <= #args do
+        local a = args[i]
+        local v = a:match('^-(.+)')
+        local is_long
+        if v then -- we have a flag
+            if v:find '^-' then
+                is_long = true
+                v = v:sub(2)
+            end
+            if flags_with_values[v] then
+                if i == #_args or args[i+1]:find '^-' then
+                    return utils.raise ("no value for '"..v.."'")
+                end
+                flags[v] = args[i+1]
+                i = i + 1
+            else
+                -- a value can also be indicated with =
+                local var,val =  utils.splitv (v,'=')
+                var = var or v
+                val = val or true
+                if not is_long then
+                    if #var > 1 then
+                        if var:find '.%d+' then -- short flag, number value
+                            val = var:sub(2)
+                            var = var:sub(1,1)
+                        else -- multiple short flags
+                            for i = 1,#var do
+                                flags[var:sub(i,i)] = true
+                            end
+                            val = nil -- prevents use of var as a flag below
+                        end
+                    else  -- single short flag (can have value, defaults to true)
+                        val = val or true
+                    end
+                end
+                if val then
+                    flags[var] = val
+                end
+            end
+        else
+            _args[#_args+1] = a
+        end
+        i = i + 1
+    end
+    return flags,_args
+end
+
+return app

--- a/lib/ext/spec-support/pl/array2d.lua
+++ b/lib/ext/spec-support/pl/array2d.lua
@@ -1,0 +1,501 @@
+--- Operations on two-dimensional arrays.
+-- See @{02-arrays.md.Operations_on_two_dimensional_tables|The Guide}
+--
+-- Dependencies: `pl.utils`, `pl.tablex`, `pl.types`
+-- @module pl.array2d
+
+local require, type,tonumber,assert,tostring,io,ipairs,string,table =
+ _G.require, _G.type,_G.tonumber,_G.assert,_G.tostring,_G.io,_G.ipairs,_G.string,_G.table
+local setmetatable,getmetatable = setmetatable,getmetatable
+
+local tablex = require 'pl.tablex'
+local utils = require 'pl.utils'
+local types = require 'pl.types'
+local imap,tmap,reduce,keys,tmap2,tset,index_by = tablex.imap,tablex.map,tablex.reduce,tablex.keys,tablex.map2,tablex.set,tablex.index_by
+local remove = table.remove
+local splitv,fprintf,assert_arg = utils.splitv,utils.fprintf,utils.assert_arg
+local byte = string.byte
+local stdout = io.stdout
+
+local array2d = {}
+
+local function obj (int,out)
+    local mt = getmetatable(int)
+    if mt then
+        setmetatable(out,mt)
+    end
+    return out
+end
+
+local function makelist (res)
+    return setmetatable(res,utils.stdmt.List)
+end
+
+
+local function index (t,k)
+    return t[k]
+end
+
+--- return the row and column size.
+-- @param t a 2d array
+-- @return number of rows
+-- @return number of cols
+function array2d.size (t)
+    assert_arg(1,t,'table')
+    return #t,#t[1]
+end
+
+--- extract a column from the 2D array.
+-- @param a 2d array
+-- @param key an index or key
+-- @return 1d array
+function array2d.column (a,key)
+    assert_arg(1,a,'table')
+    return makelist(imap(index,a,key))
+end
+local column = array2d.column
+
+--- map a function over a 2D array
+-- @param f a function of at least one argument
+-- @param a 2d array
+-- @param arg an optional extra argument to be passed to the function.
+-- @return 2d array
+function array2d.map (f,a,arg)
+    assert_arg(1,a,'table')
+    f = utils.function_arg(1,f)
+    return obj(a,imap(function(row) return imap(f,row,arg) end, a))
+end
+
+--- reduce the rows using a function.
+-- @param f a binary function
+-- @param a 2d array
+-- @return 1d array
+-- @see pl.tablex.reduce
+function array2d.reduce_rows (f,a)
+    assert_arg(1,a,'table')
+    return tmap(function(row) return reduce(f,row) end, a)
+end
+
+--- reduce the columns using a function.
+-- @param f a binary function
+-- @param a 2d array
+-- @return 1d array
+-- @see pl.tablex.reduce
+function array2d.reduce_cols (f,a)
+    assert_arg(1,a,'table')
+    return tmap(function(c) return reduce(f,column(a,c)) end, keys(a[1]))
+end
+
+--- reduce a 2D array into a scalar, using two operations.
+-- @param opc operation to reduce the final result
+-- @param opr operation to reduce the rows
+-- @param a 2D array
+function array2d.reduce2 (opc,opr,a)
+    assert_arg(3,a,'table')
+    local tmp = array2d.reduce_rows(opr,a)
+    return reduce(opc,tmp)
+end
+
+local function dimension (t)
+    return type(t[1])=='table' and 2 or 1
+end
+
+--- map a function over two arrays.
+-- They can be both or either 2D arrays
+-- @param f function of at least two arguments
+-- @param ad order of first array
+-- @param bd order of second array
+-- @param a 1d or 2d array
+-- @param b 1d or 2d array
+-- @param arg optional extra argument to pass to function
+-- @return 2D array, unless both arrays are 1D
+function array2d.map2 (f,ad,bd,a,b,arg)
+    assert_arg(1,a,'table')
+    assert_arg(2,b,'table')
+    f = utils.function_arg(1,f)
+    --local ad,bd = dimension(a),dimension(b)
+    if ad == 1 and bd == 2 then
+        return imap(function(row)
+            return tmap2(f,a,row,arg)
+        end, b)
+    elseif ad == 2 and bd == 1 then
+        return imap(function(row)
+            return tmap2(f,row,b,arg)
+        end, a)
+    elseif ad == 1 and bd == 1 then
+        return tmap2(f,a,b)
+    elseif ad == 2 and bd == 2 then
+        return tmap2(function(rowa,rowb)
+            return tmap2(f,rowa,rowb,arg)
+        end, a,b)
+    end
+end
+
+--- cartesian product of two 1d arrays.
+-- @param f a function of 2 arguments
+-- @param t1 a 1d table
+-- @param t2 a 1d table
+-- @return 2d table
+-- @usage product('..',{1,2},{'a','b'}) == {{'1a','2a'},{'1b','2b'}}
+function array2d.product (f,t1,t2)
+    f = utils.function_arg(1,f)
+    assert_arg(2,t1,'table')
+    assert_arg(3,t2,'table')
+    local res, map = {}, tablex.map
+    for i,v in ipairs(t2) do
+        res[i] = map(f,t1,v)
+    end
+    return res
+end
+
+--- flatten a 2D array.
+-- (this goes over columns first.)
+-- @param t 2d table
+-- @return a 1d table
+-- @usage flatten {{1,2},{3,4},{5,6}} == {1,2,3,4,5,6}
+function array2d.flatten (t)
+    local res = {}
+    local k = 1
+    for _,a in ipairs(t) do -- for all rows
+        for i = 1,#a do
+            res[k] = a[i]
+            k = k + 1
+        end
+    end
+    return makelist(res)
+end
+
+--- reshape a 2D array.
+-- @param t 2d array
+-- @param nrows new number of rows
+-- @param co column-order (Fortran-style) (default false)
+-- @return a new 2d array
+function array2d.reshape (t,nrows,co)
+    local nr,nc = array2d.size(t)
+    local ncols = nr*nc / nrows
+    local res = {}
+    local ir,ic = 1,1
+    for i = 1,nrows do
+        local row = {}
+        for j = 1,ncols do
+            row[j] = t[ir][ic]
+            if not co then
+                ic = ic + 1
+                if ic > nc then
+                    ir = ir + 1
+                    ic = 1
+                end
+            else
+                ir = ir + 1
+                if ir > nr then
+                    ic = ic + 1
+                    ir = 1
+                end
+            end
+        end
+        res[i] = row
+    end
+    return obj(t,res)
+end
+
+--- swap two rows of an array.
+-- @param t a 2d array
+-- @param i1 a row index
+-- @param i2 a row index
+function array2d.swap_rows (t,i1,i2)
+    assert_arg(1,t,'table')
+    t[i1],t[i2] = t[i2],t[i1]
+end
+
+--- swap two columns of an array.
+-- @param t a 2d array
+-- @param j1 a column index
+-- @param j2 a column index
+function array2d.swap_cols (t,j1,j2)
+    assert_arg(1,t,'table')
+    for i = 1,#t do
+        local row = t[i]
+        row[j1],row[j2] = row[j2],row[j1]
+    end
+end
+
+--- extract the specified rows.
+-- @param t 2d array
+-- @param ridx a table of row indices
+function array2d.extract_rows (t,ridx)
+    return obj(t,index_by(t,ridx))
+end
+
+--- extract the specified columns.
+-- @param t 2d array
+-- @param cidx a table of column indices
+function array2d.extract_cols (t,cidx)
+    assert_arg(1,t,'table')
+    local res = {}
+    for i = 1,#t do
+        res[i] = index_by(t[i],cidx)
+    end
+    return obj(t,res)
+end
+
+--- remove a row from an array.
+-- @class function
+-- @name array2d.remove_row
+-- @param t a 2d array
+-- @param i a row index
+array2d.remove_row = remove
+
+--- remove a column from an array.
+-- @param t a 2d array
+-- @param j a column index
+function array2d.remove_col (t,j)
+    assert_arg(1,t,'table')
+    for i = 1,#t do
+        remove(t[i],j)
+    end
+end
+
+local Ai = byte 'A'
+
+local function _parse (s)
+    local c,r
+    if s:sub(1,1) == 'R' then
+        r,c = s:match 'R(%d+)C(%d+)'
+        r,c = tonumber(r),tonumber(c)
+    else
+        c,r = s:match '(.)(.)'
+        c = byte(c) - byte 'A' + 1
+        r = tonumber(r)
+    end
+    assert(c ~= nil and r ~= nil,'bad cell specifier: '..s)
+    return r,c
+end
+
+--- parse a spreadsheet range.
+-- The range can be specified either as 'A1:B2' or 'R1C1:R2C2';
+-- a special case is a single element (e.g 'A1' or 'R1C1')
+-- @param s a range.
+-- @return start col
+-- @return start row
+-- @return end col
+-- @return end row
+function array2d.parse_range (s)
+    if s:find ':' then
+        local start,finish = splitv(s,':')
+        local i1,j1 = _parse(start)
+        local i2,j2 = _parse(finish)
+        return i1,j1,i2,j2
+    else -- single value
+        local i,j = _parse(s)
+        return i,j
+    end
+end
+
+--- get a slice of a 2D array using spreadsheet range notation. @see parse_range
+-- @param t a 2D array
+-- @param rstr range expression
+-- @return a slice
+-- @see array2d.parse_range
+-- @see array2d.slice
+function array2d.range (t,rstr)
+    assert_arg(1,t,'table')
+    local i1,j1,i2,j2 = array2d.parse_range(rstr)
+    if i2 then
+        return array2d.slice(t,i1,j1,i2,j2)
+    else -- single value
+        return t[i1][j1]
+    end
+end
+
+local function default_range (t,i1,j1,i2,j2)
+    local nr, nc = array2d.size(t)
+    i1,j1 = i1 or 1, j1 or 1
+    i2,j2 = i2 or nr, j2 or nc
+    if i2 < 0 then i2 = nr + i2 + 1 end
+    if j2 < 0 then j2 = nc + j2 + 1 end
+    return i1,j1,i2,j2
+end
+
+--- get a slice of a 2D array. Note that if the specified range has
+-- a 1D result, the rank of the result will be 1.
+-- @param t a 2D array
+-- @param i1 start row (default 1)
+-- @param j1 start col (default 1)
+-- @param i2 end row   (default N)
+-- @param j2 end col   (default M)
+-- @return an array, 2D in general but 1D in special cases.
+function array2d.slice (t,i1,j1,i2,j2)
+    assert_arg(1,t,'table')
+    i1,j1,i2,j2 = default_range(t,i1,j1,i2,j2)
+    local res = {}
+    for i = i1,i2 do
+        local val
+        local row = t[i]
+        if j1 == j2 then
+            val = row[j1]
+        else
+            val = {}
+            for j = j1,j2 do
+                val[#val+1] = row[j]
+            end
+        end
+        res[#res+1] = val
+    end
+    if i1 == i2 then res = res[1] end
+    return obj(t,res)
+end
+
+--- set a specified range of an array to a value.
+-- @param t a 2D array
+-- @param value the value (may be a function)
+-- @param i1 start row (default 1)
+-- @param j1 start col (default 1)
+-- @param i2 end row   (default N)
+-- @param j2 end col   (default M)
+-- @see tablex.set
+function array2d.set (t,value,i1,j1,i2,j2)
+    i1,j1,i2,j2 = default_range(t,i1,j1,i2,j2)
+    for i = i1,i2 do
+        tset(t[i],value,j1,j2)
+    end
+end
+
+--- write a 2D array to a file.
+-- @param t a 2D array
+-- @param f a file object (default stdout)
+-- @param fmt a format string (default is just to use tostring)
+-- @param i1 start row (default 1)
+-- @param j1 start col (default 1)
+-- @param i2 end row   (default N)
+-- @param j2 end col   (default M)
+function array2d.write (t,f,fmt,i1,j1,i2,j2)
+    assert_arg(1,t,'table')
+    f = f or stdout
+    local rowop
+    if fmt then
+        rowop = function(row,j) fprintf(f,fmt,row[j]) end
+    else
+        rowop = function(row,j) f:write(tostring(row[j]),' ') end
+    end
+    local function newline()
+        f:write '\n'
+    end
+    array2d.forall(t,rowop,newline,i1,j1,i2,j2)
+end
+
+--- perform an operation for all values in a 2D array.
+-- @param t 2D array
+-- @param row_op function to call on each value
+-- @param end_row_op function to call at end of each row
+-- @param i1 start row (default 1)
+-- @param j1 start col (default 1)
+-- @param i2 end row   (default N)
+-- @param j2 end col   (default M)
+function array2d.forall (t,row_op,end_row_op,i1,j1,i2,j2)
+    assert_arg(1,t,'table')
+    i1,j1,i2,j2 = default_range(t,i1,j1,i2,j2)
+    for i = i1,i2 do
+        local row = t[i]
+        for j = j1,j2 do
+            row_op(row,j)
+        end
+        if end_row_op then end_row_op(i) end
+    end
+end
+
+local min, max = math.min, math.max
+
+---- move a block from the destination to the source.
+-- @param dest a 2D array
+-- @param di start row in dest
+-- @param dj start col in dest
+-- @param src a 2D array
+-- @param i1 start row (default 1)
+-- @param j1 start col (default 1)
+-- @param i2 end row   (default N)
+-- @param j2 end col   (default M)
+function array2d.move (dest,di,dj,src,i1,j1,i2,j2)
+    assert_arg(1,dest,'table')
+    assert_arg(4,src,'table')
+    i1,j1,i2,j2 = default_range(src,i1,j1,i2,j2)
+    local nr,nc = array2d.size(dest)
+    i2, j2 = min(nr,i2), min(nc,j2)
+    --i1, j1 = max(1,i1), max(1,j1)
+    dj = dj - 1
+    for i = i1,i2 do
+        local drow, srow = dest[i+di-1], src[i]
+        for j = j1,j2 do
+            drow[j+dj] = srow[j]
+        end
+    end
+end
+
+--- iterate over all elements in a 2D array, with optional indices.
+-- @param a 2D array
+-- @param indices with indices (default false)
+-- @param i1 start row (default 1)
+-- @param j1 start col (default 1)
+-- @param i2 end row   (default N)
+-- @param j2 end col   (default M)
+-- @return either value or i,j,value depending on indices
+function array2d.iter (a,indices,i1,j1,i2,j2)
+    assert_arg(1,a,'table')
+    local norowset = not (i2 and j2)
+    i1,j1,i2,j2 = default_range(a,i1,j1,i2,j2)
+    local n,i,j = i2-i1+1,i1-1,j1-1
+    local row,nr = nil,0
+    local onr = j2 - j1 + 1
+    return function()
+        j = j + 1
+        if j > nr then
+            j = j1
+            i = i + 1
+            if i > i2 then return nil end
+            row = a[i]
+            nr = norowset and #row or onr
+        end
+        if indices then
+            return i,j,row[j]
+        else
+            return row[j]
+        end
+    end
+end
+
+--- iterate over all columns.
+-- @param a a 2D array
+-- @return each column in turn
+function array2d.columns (a)
+    assert_arg(1,a,'table')
+    local n = a[1][1]
+    local i = 0
+    return function()
+        i = i + 1
+        if i > n then return nil end
+        return column(a,i)
+    end
+end
+
+--- new array of specified dimensions
+-- @param rows number of rows
+-- @param cols number of cols
+-- @param val initial value; if it's a function then use `val(i,j)`
+-- @return new 2d array
+function array2d.new(rows,cols,val)
+    local res = {}
+    local fun = types.is_callable(val)
+    for i = 1,rows do
+        local row = {}
+        if fun then
+            for j = 1,cols do row[j] = val(i,j) end
+        else
+            for j = 1,cols do row[j] = val end
+        end
+        res[i] = row
+    end
+    return res
+end
+
+return array2d
+
+

--- a/lib/ext/spec-support/pl/class.lua
+++ b/lib/ext/spec-support/pl/class.lua
@@ -1,0 +1,250 @@
+--- Provides a reuseable and convenient framework for creating classes in Lua.
+-- Two possible notations:
+--
+--    B = class(A)
+--    class.B(A)
+--
+-- The latter form creates a named class within the current environment. Note
+-- that this implicitly brings in `pl.utils` as a dependency.
+--
+-- See the Guide for further @{01-introduction.md.Simplifying_Object_Oriented_Programming_in_Lua|discussion}
+-- @module pl.class
+
+local error, getmetatable, io, pairs, rawget, rawset, setmetatable, tostring, type =
+    _G.error, _G.getmetatable, _G.io, _G.pairs, _G.rawget, _G.rawset, _G.setmetatable, _G.tostring, _G.type
+local compat
+
+-- this trickery is necessary to prevent the inheritance of 'super' and
+-- the resulting recursive call problems.
+local function call_ctor (c,obj,...)
+    -- nice alias for the base class ctor
+    local base = rawget(c,'_base')
+    if base then
+        local parent_ctor = rawget(base,'_init')
+        while not parent_ctor do
+            base = rawget(base,'_base')
+            if not base then break end
+            parent_ctor = rawget(base,'_init')
+        end
+        if parent_ctor then
+            rawset(obj,'super',function(obj,...)
+                call_ctor(base,obj,...)
+            end)
+        end
+    end
+    local res = c._init(obj,...)
+    rawset(obj,'super',nil)
+    return res
+end
+
+--- initializes an __instance__ upon creation.
+-- @function class:_init
+-- @param ... parameters passed to the constructor
+-- @usage local Cat = class()
+-- function Cat:_init(name)
+--   --self:super(name)   -- call the ancestor initializer if needed
+--   self.name = name
+-- end
+--
+-- local pussycat = Cat("pussycat")
+-- print(pussycat.name)  --> pussycat
+
+--- checks whether an __instance__ is derived from some class.
+-- Works the other way around as `class_of`.
+-- @function instance:is_a
+-- @param some_class class to check against
+-- @return `true` if `instance` is derived from `some_class`
+-- @usage local pussycat = Lion()  -- assuming Lion derives from Cat
+-- if pussycat:is_a(Cat) then
+--   -- it's true
+-- end
+local function is_a(self,klass)
+    local m = getmetatable(self)
+    if not m then return false end --*can't be an object!
+    while m do
+        if m == klass then return true end
+        m = rawget(m,'_base')
+    end
+    return false
+end
+
+--- checks whether an __instance__ is derived from some class.
+-- Works the other way around as `is_a`.
+-- @function some_class:class_of
+-- @param some_instance instance to check against
+-- @return `true` if `some_instance` is derived from `some_class`
+-- @usage local pussycat = Lion()  -- assuming Lion derives from Cat
+-- if Cat:class_of(pussycat) then
+--   -- it's true
+-- end
+local function class_of(klass,obj)
+    if type(klass) ~= 'table' or not rawget(klass,'is_a') then return false end
+    return klass.is_a(obj,klass)
+end
+
+--- cast an object to another class.
+-- It is not clever (or safe!) so use carefully.
+-- @param some_instance the object to be changed
+-- @function some_class:cast
+local function cast (klass, obj)
+    return setmetatable(obj,klass)
+end
+
+
+local function _class_tostring (obj)
+    local mt = obj._class
+    local name = rawget(mt,'_name')
+    setmetatable(obj,nil)
+    local str = tostring(obj)
+    setmetatable(obj,mt)
+    if name then str = name ..str:gsub('table','') end
+    return str
+end
+
+local function tupdate(td,ts,dont_override)
+    for k,v in pairs(ts) do
+        if not dont_override or td[k] == nil then
+            td[k] = v
+        end
+    end
+end
+
+local function _class(base,c_arg,c)
+    -- the class `c` will be the metatable for all its objects,
+    -- and they will look up their methods in it.
+    local mt = {}   -- a metatable for the class to support __call and _handler
+    -- can define class by passing it a plain table of methods
+    local plain = type(base) == 'table' and not getmetatable(base)
+    if plain then
+        c = base
+        base = c._base
+    else
+        c = c or {}
+    end
+   
+    if type(base) == 'table' then
+        -- our new class is a shallow copy of the base class!
+        -- but be careful not to wipe out any methods we have been given at this point!
+        tupdate(c,base,plain)
+        c._base = base
+        -- inherit the 'not found' handler, if present
+        if rawget(c,'_handler') then mt.__index = c._handler end
+    elseif base ~= nil then
+        error("must derive from a table type",3)
+    end
+
+    c.__index = c
+    setmetatable(c,mt)
+    if not plain then
+        c._init = nil
+    end
+
+    if base and rawget(base,'_class_init') then
+        base._class_init(c,c_arg)
+    end
+
+    -- expose a ctor which can be called by <classname>(<args>)
+    mt.__call = function(class_tbl,...)
+        local obj
+        if rawget(c,'_create') then obj = c._create(...) end
+        if not obj then obj = {} end
+        setmetatable(obj,c)
+
+        if rawget(c,'_init') then -- explicit constructor
+            local res = call_ctor(c,obj,...)
+            if res then -- _if_ a ctor returns a value, it becomes the object...
+                obj = res
+                setmetatable(obj,c)
+            end
+        elseif base and rawget(base,'_init') then -- default constructor
+            -- make sure that any stuff from the base class is initialized!
+            call_ctor(base,obj,...)
+        end
+
+        if base and rawget(base,'_post_init') then
+            base._post_init(obj)
+        end
+
+        if not rawget(c,'__tostring') then
+            c.__tostring = _class_tostring
+        end
+        return obj
+    end
+    -- Call Class.catch to set a handler for methods/properties not found in the class!
+    c.catch = function(self, handler)
+        if type(self) == "function" then
+            -- called using . instead of :
+            handler = self
+        end
+        c._handler = handler
+        mt.__index = handler
+    end
+    c.is_a = is_a
+    c.class_of = class_of
+    c.cast = cast
+    c._class = c
+
+    return c
+end
+
+--- create a new class, derived from a given base class.
+-- Supporting two class creation syntaxes:
+-- either `Name = class(base)` or `class.Name(base)`.
+-- The first form returns the class directly and does not set its `_name`.
+-- The second form creates a variable `Name` in the current environment set
+-- to the class, and also sets `_name`.
+-- @function class
+-- @param base optional base class
+-- @param c_arg optional parameter to class constructor
+-- @param c optional table to be used as class
+local class
+class = setmetatable({},{
+    __call = function(fun,...)
+        return _class(...)
+    end,
+    __index = function(tbl,key)
+        if key == 'class' then
+            io.stderr:write('require("pl.class").class is deprecated. Use require("pl.class")\n')
+            return class
+        end
+        compat = compat or require 'pl.compat'
+        local env = compat.getfenv(2)
+        return function(...)
+            local c = _class(...)
+            c._name = key
+            rawset(env,key,c)
+            return c
+        end
+    end
+})
+
+class.properties = class()
+
+function class.properties._class_init(klass)
+    klass.__index = function(t,key)
+        -- normal class lookup!
+        local v = klass[key]
+        if v then return v end
+        -- is it a getter?
+        v = rawget(klass,'get_'..key)
+        if v then
+            return v(t)
+        end
+        -- is it a field?
+        return rawget(t,'_'..key)
+    end
+    klass.__newindex = function (t,key,value)
+        -- if there's a setter, use that, otherwise directly set table
+        local p = 'set_'..key
+        local setter = klass[p]
+        if setter then
+            setter(t,value)
+        else
+            rawset(t,key,value)
+        end
+    end
+end
+
+
+return class
+

--- a/lib/ext/spec-support/pl/compat.lua
+++ b/lib/ext/spec-support/pl/compat.lua
@@ -1,0 +1,137 @@
+----------------
+--- Lua 5.1/5.2 compatibility
+-- Ensures that `table.pack` and `package.searchpath` are available
+-- for Lua 5.1 and LuaJIT.
+-- The exported function `load` is Lua 5.2 compatible.
+-- `compat.setfenv` and `compat.getfenv` are available for Lua 5.2, although
+-- they are not always guaranteed to work.
+-- @module pl.compat
+
+local compat = {}
+
+compat.lua51 = _VERSION == 'Lua 5.1'
+
+--- execute a shell command.
+-- This is a compatibility function that returns the same for Lua 5.1 and Lua 5.2
+-- @param cmd a shell command
+-- @return true if successful
+-- @return actual return code
+function compat.execute (cmd)
+    local res1,res2,res2 = os.execute(cmd)
+    if compat.lua51 then
+        return res1==0,res1
+    else
+        return res1,res2
+    end
+end
+
+----------------
+-- Load Lua code as a text or binary chunk.
+-- @param ld code string or loader
+-- @param[opt] source name of chunk for errors
+-- @param[opt] mode 'b', 't' or 'bt'
+-- @param[opt] env environment to load the chunk in
+-- @function compat.load
+
+---------------
+-- Get environment of a function.
+-- With Lua 5.2, may return nil for a function with no global references!
+-- Based on code by [Sergey Rozhenko](http://lua-users.org/lists/lua-l/2010-06/msg00313.html)
+-- @param f a function or a call stack reference
+-- @function compat.setfenv
+
+---------------
+-- Set environment of a function
+-- @param f a function or a call stack reference
+-- @param env a table that becomes the new environment of `f`
+-- @function compat.setfenv
+
+if compat.lua51 then -- define Lua 5.2 style load()
+    if not tostring(assert):match 'builtin' then -- but LuaJIT's load _is_ compatible
+        local lua51_load = load
+        function compat.load(str,src,mode,env)
+            local chunk,err
+            if type(str) == 'string' then
+                if str:byte(1) == 27 and not (mode or 'bt'):find 'b' then
+                    return nil,"attempt to load a binary chunk"
+                end
+                chunk,err = loadstring(str,src)
+            else
+                chunk,err = lua51_load(str,src)
+            end
+            if chunk and env then setfenv(chunk,env) end
+            return chunk,err
+        end
+    else
+        compat.load = load
+    end
+    compat.setfenv, compat.getfenv = setfenv, getfenv
+else
+    compat.load = load
+    -- setfenv/getfenv replacements for Lua 5.2
+    -- by Sergey Rozhenko
+    -- http://lua-users.org/lists/lua-l/2010-06/msg00313.html
+    -- Roberto Ierusalimschy notes that it is possible for getfenv to return nil
+    -- in the case of a function with no globals:
+    -- http://lua-users.org/lists/lua-l/2010-06/msg00315.html
+    function compat.setfenv(f, t)
+        f = (type(f) == 'function' and f or debug.getinfo(f + 1, 'f').func)
+        local name
+        local up = 0
+        repeat
+            up = up + 1
+            name = debug.getupvalue(f, up)
+        until name == '_ENV' or name == nil
+        if name then
+            debug.upvaluejoin(f, up, function() return name end, 1) -- use unique upvalue
+            debug.setupvalue(f, up, t)
+        end
+        if f ~= 0 then return f end
+    end
+
+    function compat.getfenv(f)
+        local f = f or 0
+        f = (type(f) == 'function' and f or debug.getinfo(f + 1, 'f').func)
+        local name, val
+        local up = 0
+        repeat
+            up = up + 1
+            name, val = debug.getupvalue(f, up)
+        until name == '_ENV' or name == nil
+        return val
+    end
+end
+
+--- Lua 5.2 Functions Available for 5.1
+-- @section lua52
+
+--- pack an argument list into a table.
+-- @param ... any arguments
+-- @return a table with field n set to the length
+-- @return the length
+-- @function table.pack
+if not table.pack then
+    function table.pack (...)
+        return {n=select('#',...); ...}
+    end
+end
+
+------
+-- return the full path where a Lua module name would be matched.
+-- @param mod module name, possibly dotted
+-- @param path a path in the same form as package.path or package.cpath
+-- @see path.package_path
+-- @function package.searchpath
+if not package.searchpath then
+    local sep = package.config:sub(1,1)
+    function package.searchpath (mod,path)
+        mod = mod:gsub('%.',sep)
+        for m in path:gmatch('[^;]+') do
+            local nm = m:gsub('?',mod)
+            local f = io.open(nm,'r')
+            if f then f:close(); return nm end
+        end
+    end
+end
+
+return compat

--- a/lib/ext/spec-support/pl/comprehension.lua
+++ b/lib/ext/spec-support/pl/comprehension.lua
@@ -1,0 +1,286 @@
+--- List comprehensions implemented in Lua.
+--
+-- See the [wiki page](http://lua-users.org/wiki/ListComprehensions)
+--
+--    local C= require 'pl.comprehension' . new()
+--
+--    C ('x for x=1,10') ()
+--    ==> {1,2,3,4,5,6,7,8,9,10}
+--    C 'x^2 for x=1,4' ()
+--    ==> {1,4,9,16}
+--    C '{x,x^2} for x=1,4' ()
+--    ==> {{1,1},{2,4},{3,9},{4,16}}
+--    C '2*x for x' {1,2,3}
+--    ==> {2,4,6}
+--    dbl = C '2*x for x'
+--    dbl {10,20,30}
+--    ==> {20,40,60}
+--    C 'x for x if x % 2 == 0' {1,2,3,4,5}
+--    ==> {2,4}
+--    C '{x,y} for x = 1,2 for y = 1,2' ()
+--    ==> {{1,1},{1,2},{2,1},{2,2}}
+--    C '{x,y} for x for y' ({1,2},{10,20})
+--    ==> {{1,10},{1,20},{2,10},{2,20}}
+--    assert(C 'sum(x^2 for x)' {2,3,4} == 2^2+3^2+4^2)
+--
+-- (c) 2008 David Manura. Licensed under the same terms as Lua (MIT license).
+--
+-- Dependencies: `pl.utils`, `pl.luabalanced`
+--
+-- See @{07-functional.md.List_Comprehensions|the Guide}
+-- @module pl.comprehension
+
+local utils = require 'pl.utils'
+
+local status,lb = pcall(require, "pl.luabalanced")
+if not status then
+    lb = require 'luabalanced'
+end
+
+local math_max = math.max
+local table_concat = table.concat
+
+-- fold operations
+-- http://en.wikipedia.org/wiki/Fold_(higher-order_function)
+local ops = {
+  list = {init=' {} ', accum=' __result[#__result+1] = (%s) '},
+  table = {init=' {} ', accum=' local __k, __v = %s __result[__k] = __v '},
+  sum = {init=' 0 ', accum=' __result = __result + (%s) '},
+  min = {init=' nil ', accum=' local __tmp = %s ' ..
+                             ' if __result then if __tmp < __result then ' ..
+                             '__result = __tmp end else __result = __tmp end '},
+  max = {init=' nil ', accum=' local __tmp = %s ' ..
+                             ' if __result then if __tmp > __result then ' ..
+                             '__result = __tmp end else __result = __tmp end '},
+}
+
+
+-- Parses comprehension string expr.
+-- Returns output expression list <out> string, array of for types
+-- ('=', 'in' or nil) <fortypes>, array of input variable name
+-- strings <invarlists>, array of input variable value strings
+-- <invallists>, array of predicate expression strings <preds>,
+-- operation name string <opname>, and number of placeholder
+-- parameters <max_param>.
+--
+-- The is equivalent to the mathematical set-builder notation:
+--
+--   <opname> { <out> | <invarlist> in <invallist> , <preds> }
+--
+-- @usage   "x^2 for x"                 -- array values
+-- @usage  "x^2 for x=1,10,2"          -- numeric for
+-- @usage  "k^v for k,v in pairs(_1)"  -- iterator for
+-- @usage  "(x+y)^2 for x for y if x > y"  -- nested
+--
+local function parse_comprehension(expr)
+  local t = {}
+  local pos = 1
+
+  -- extract opname (if exists)
+  local opname
+  local tok, post = expr:match('^%s*([%a_][%w_]*)%s*%(()', pos)
+  local pose = #expr + 1
+  if tok then
+    local tok2, posb = lb.match_bracketed(expr, post-1)
+    assert(tok2, 'syntax error')
+    if expr:match('^%s*$', posb) then
+      opname = tok
+      pose = posb - 1
+      pos = post
+    end
+  end
+  opname = opname or "list"
+
+  -- extract out expression list
+  local out; out, pos = lb.match_explist(expr, pos)
+  assert(out, "syntax error: missing expression list")
+  out = table_concat(out, ', ')
+
+  -- extract "for" clauses
+  local fortypes = {}
+  local invarlists = {}
+  local invallists = {}
+  while 1 do
+    local post = expr:match('^%s*for%s+()', pos)
+    if not post then break end
+    pos = post
+
+    -- extract input vars
+    local iv; iv, pos = lb.match_namelist(expr, pos)
+    assert(#iv > 0, 'syntax error: zero variables')
+    for _,ident in ipairs(iv) do
+      assert(not ident:match'^__',
+             "identifier " .. ident .. " may not contain __ prefix")
+    end
+    invarlists[#invarlists+1] = iv
+
+    -- extract '=' or 'in' (optional)
+    local fortype, post = expr:match('^(=)%s*()', pos)
+    if not fortype then fortype, post = expr:match('^(in)%s+()', pos) end
+    if fortype then
+      pos = post
+      -- extract input value range
+      local il; il, pos = lb.match_explist(expr, pos)
+      assert(#il > 0, 'syntax error: zero expressions')
+      assert(fortype ~= '=' or #il == 2 or #il == 3,
+             'syntax error: numeric for requires 2 or three expressions')
+      fortypes[#invarlists] = fortype
+      invallists[#invarlists] = il
+    else
+      fortypes[#invarlists] = false
+      invallists[#invarlists] = false
+    end
+  end
+  assert(#invarlists > 0, 'syntax error: missing "for" clause')
+
+  -- extract "if" clauses
+  local preds = {}
+  while 1 do
+    local post = expr:match('^%s*if%s+()', pos)
+    if not post then break end
+    pos = post
+    local pred; pred, pos = lb.match_expression(expr, pos)
+    assert(pred, 'syntax error: predicated expression not found')
+    preds[#preds+1] = pred
+  end
+
+  -- extract number of parameter variables (name matching "_%d+")
+  local stmp = ''; lb.gsub(expr, function(u, sin)  -- strip comments/strings
+    if u == 'e' then stmp = stmp .. ' ' .. sin .. ' ' end
+  end)
+  local max_param = 0; stmp:gsub('[%a_][%w_]*', function(s)
+    local s = s:match('^_(%d+)$')
+    if s then max_param = math_max(max_param, tonumber(s)) end
+  end)
+
+  if pos ~= pose then
+    assert(false, "syntax error: unrecognized " .. expr:sub(pos))
+  end
+
+  --DEBUG:
+  --print('----\n', string.format("%q", expr), string.format("%q", out), opname)
+  --for k,v in ipairs(invarlists) do print(k,v, invallists[k]) end
+  --for k,v in ipairs(preds) do print(k,v) end
+
+  return out, fortypes, invarlists, invallists, preds, opname, max_param
+end
+
+
+-- Create Lua code string representing comprehension.
+-- Arguments are in the form returned by parse_comprehension.
+local function code_comprehension(
+    out, fortypes, invarlists, invallists, preds, opname, max_param
+)
+  local op = assert(ops[opname])
+  local code = op.accum:gsub('%%s',  out)
+
+  for i=#preds,1,-1 do local pred = preds[i]
+    code = ' if ' .. pred .. ' then ' .. code .. ' end '
+  end
+  for i=#invarlists,1,-1 do
+    if not fortypes[i] then
+      local arrayname = '__in' .. i
+      local idx = '__idx' .. i
+      code =
+        ' for ' .. idx .. ' = 1, #' .. arrayname .. ' do ' ..
+        ' local ' .. invarlists[i][1] .. ' = ' .. arrayname .. '['..idx..'] ' ..
+        code .. ' end '
+    else
+      code =
+        ' for ' ..
+        table_concat(invarlists[i], ', ') ..
+        ' ' .. fortypes[i] .. ' ' ..
+        table_concat(invallists[i], ', ') ..
+        ' do ' .. code .. ' end '
+    end
+  end
+  code = ' local __result = ( ' .. op.init .. ' ) ' .. code
+  return code
+end
+
+
+-- Convert code string represented by code_comprehension
+-- into Lua function.  Also must pass ninputs = #invarlists,
+-- max_param, and invallists (from parse_comprehension).
+-- Uses environment env.
+local function wrap_comprehension(code, ninputs, max_param, invallists, env)
+  assert(ninputs > 0)
+  local ts = {}
+  for i=1,max_param do
+    ts[#ts+1] = '_' .. i
+  end
+  for i=1,ninputs do
+    if not invallists[i] then
+      local name = '__in' .. i
+      ts[#ts+1] = name
+    end
+  end
+  if #ts > 0 then
+    code = ' local ' .. table_concat(ts, ', ') .. ' = ... ' .. code
+  end
+  code = code .. ' return __result '
+  --print('DEBUG:', code)
+  local f, err = utils.load(code,'tmp','t',env)
+  if not f then assert(false, err .. ' with generated code ' .. code) end
+  return f
+end
+
+
+-- Build Lua function from comprehension string.
+-- Uses environment env.
+local function build_comprehension(expr, env)
+  local out, fortypes, invarlists, invallists, preds, opname, max_param
+    = parse_comprehension(expr)
+  local code = code_comprehension(
+    out, fortypes, invarlists, invallists, preds, opname, max_param)
+  local f = wrap_comprehension(code, #invarlists, max_param, invallists, env)
+  return f
+end
+
+
+-- Creates new comprehension cache.
+-- Any list comprehension function created are set to the environment
+-- env (defaults to caller of new).
+local function new(env)
+  -- Note: using a single global comprehension cache would have had
+  -- security implications (e.g. retrieving cached functions created
+  -- in other environments).
+  -- The cache lookup function could have instead been written to retrieve
+  -- the caller's environment, lookup up the cache private to that
+  -- environment, and then looked up the function in that cache.
+  -- That would avoid the need for this <new> call to
+  -- explicitly manage caches; however, that might also have an undue
+  -- performance penalty.
+
+  if not env then
+    env = utils.getfenv(2)
+  end
+
+  local mt = {}
+  local cache = setmetatable({}, mt)
+
+  -- Index operator builds, caches, and returns Lua function
+  -- corresponding to comprehension expression string.
+  --
+  -- Example: f = comprehension['x^2 for x']
+  --
+  function mt:__index(expr)
+    local f = build_comprehension(expr, env)
+    self[expr] = f  -- cache
+    return f
+  end
+
+  -- Convenience syntax.
+  -- Allows comprehension 'x^2 for x' instead of comprehension['x^2 for x'].
+  mt.__call = mt.__index
+
+  cache.new = new
+
+  return cache
+end
+
+
+local comprehension = {}
+comprehension.new = new
+
+return comprehension

--- a/lib/ext/spec-support/pl/config.lua
+++ b/lib/ext/spec-support/pl/config.lua
@@ -1,0 +1,203 @@
+--- Reads configuration files into a Lua table.
+--  Understands INI files, classic Unix config files, and simple
+-- delimited columns of values. See @{06-data.md.Reading_Configuration_Files|the Guide}
+--
+--    # test.config
+--    # Read timeout in seconds
+--    read.timeout=10
+--    # Write timeout in seconds
+--    write.timeout=5
+--    #acceptable ports
+--    ports = 1002,1003,1004
+--
+--    -- readconfig.lua
+--    local config = require 'config'
+--    local t = config.read 'test.config'
+--    print(pretty.write(t))
+--
+--    ### output #####
+--    {
+--      ports = {
+--        1002,
+--        1003,
+--        1004
+--      },
+--      write_timeout = 5,
+--      read_timeout = 10
+--    }
+--
+-- @module pl.config
+
+local type,tonumber,ipairs,io, table = _G.type,_G.tonumber,_G.ipairs,_G.io,_G.table
+
+local function split(s,re)
+    local res = {}
+    local t_insert = table.insert
+    re = '[^'..re..']+'
+    for k in s:gmatch(re) do t_insert(res,k) end
+    return res
+end
+
+local function strip(s)
+    return s:gsub('^%s+',''):gsub('%s+$','')
+end
+
+local function strip_quotes (s)
+    return s:gsub("['\"](.*)['\"]",'%1')
+end
+
+local config = {}
+
+--- like io.lines(), but allows for lines to be continued with '\'.
+-- @param file a file-like object (anything where read() returns the next line) or a filename.
+-- Defaults to stardard input.
+-- @return an iterator over the lines, or nil
+-- @return error 'not a file-like object' or 'file is nil'
+function config.lines(file)
+    local f,openf,err
+    local line = ''
+    if type(file) == 'string' then
+        f,err = io.open(file,'r')
+        if not f then return nil,err end
+        openf = true
+    else
+        f = file or io.stdin
+        if not file.read then return nil, 'not a file-like object' end
+    end
+    if not f then return nil, 'file is nil' end
+    return function()
+        local l = f:read()
+        while l do
+            -- only for non-blank lines that don't begin with either ';' or '#'
+            if l:match '%S' and not l:match '^%s*[;#]' then
+                -- does the line end with '\'?
+                local i = l:find '\\%s*$'
+                if i then -- if so,
+                    line = line..l:sub(1,i-1)
+                elseif line == '' then
+                    return l
+                else
+                    l = line..l
+                    line = ''
+                    return l
+                end
+            end
+            l = f:read()
+        end
+        if openf then f:close() end
+    end
+end
+
+--- read a configuration file into a table
+-- @param file either a file-like object or a string, which must be a filename
+-- @param cnfg a configuration table that may contain these fields:
+--
+--  * `smart`  try to deduce what kind of config file we have (default false)
+--  * `variablilize` make names into valid Lua identifiers (default true)
+--  * `convert_numbers` try to convert values into numbers (default true)
+--  * `trim_space` ensure that there is no starting or trailing whitespace with values (default true)
+--  * `trim_quotes` remove quotes from strings (default false)
+--  * `list_delim` delimiter to use when separating columns (default ',')
+--  * `keysep` separator between key and value pairs (default '=')
+-- 
+-- @return a table containing items, or `nil`
+-- @return error message (same as @{config.lines}
+function config.read(file,cnfg)
+    local f,openf,err,auto
+
+    local iter,err = config.lines(file)
+    if not iter then return nil,err end
+    local line = iter()
+    cnfg = cnfg or {}
+    if cnfg.smart then
+        auto = true
+        if line:match '^[^=]+=' then
+            cnfg.keysep = '='
+        elseif line:match '^[^:]+:' then
+            cnfg.keysep = ':'
+            cnfg.list_delim = ':'
+        elseif line:match '^%S+%s+' then
+            cnfg.keysep = ' '
+            -- more than two columns assume that it's a space-delimited list
+            -- cf /etc/fstab with /etc/ssh/ssh_config
+            if line:match '^%S+%s+%S+%s+%S+' then
+                cnfg.list_delim = ' '
+            end
+            cnfg.variabilize = false
+        end
+    end
+
+
+    local function check_cnfg (var,def)
+        local val = cnfg[var]
+        if val == nil then return def else return val end
+    end
+
+    local initial_digits = '^[%d%+%-]'
+    local t = {}
+    local top_t = t
+    local variablilize = check_cnfg ('variabilize',true)
+    local list_delim = check_cnfg('list_delim',',')
+    local convert_numbers = check_cnfg('convert_numbers',true)
+    local trim_space = check_cnfg('trim_space',true)
+    local trim_quotes = check_cnfg('trim_quotes',false)
+    local ignore_assign = check_cnfg('ignore_assign',false)
+    local keysep = check_cnfg('keysep','=')
+    local keypat = keysep == ' ' and '%s+' or '%s*'..keysep..'%s*'
+    if list_delim == ' ' then list_delim = '%s+' end
+
+    local function process_name(key)
+        if variablilize then
+            key = key:gsub('[^%w]','_')
+        end
+        return key
+    end
+
+    local function process_value(value)
+        if list_delim and value:find(list_delim) then
+            value = split(value,list_delim)
+            for i,v in ipairs(value) do
+                value[i] = process_value(v)
+            end
+        elseif convert_numbers and value:find(initial_digits) then
+            local val = tonumber(value)
+            if not val and value:match ' kB$' then
+                value = value:gsub(' kB','')
+                val = tonumber(value)
+            end
+            if val then value = val end
+        end
+        if type(value) == 'string' then
+           if trim_space then value = strip(value) end
+           if not trim_quotes and auto and value:match '^"' then
+                trim_quotes = true
+            end
+           if trim_quotes then value = strip_quotes(value) end
+        end
+        return value
+    end
+
+    while line do
+        if line:find('^%[') then -- section!
+            local section = process_name(line:match('%[([^%]]+)%]'))
+            t = top_t
+            t[section] = {}
+            t = t[section]
+        else
+            line = line:gsub('^%s*','')
+            local i1,i2 = line:find(keypat)
+            if i1 and not ignore_assign then -- key,value assignment
+                local key = process_name(line:sub(1,i1-1))
+                local value = process_value(line:sub(i2+1))
+                t[key] = value
+            else -- a plain list of values...
+                t[#t+1] = process_value(line)
+            end
+        end
+        line = iter()
+    end
+    return top_t
+end
+
+return config
+

--- a/lib/ext/spec-support/pl/data.lua
+++ b/lib/ext/spec-support/pl/data.lua
@@ -1,0 +1,653 @@
+--- Reading and querying simple tabular data.
+--
+--    data.read 'test.txt'
+--    ==> {{10,20},{2,5},{40,50},fieldnames={'x','y'},delim=','}
+--
+-- Provides a way of creating basic SQL-like queries.
+--
+--    require 'pl'
+--    local d = data.read('xyz.txt')
+--    local q = d:select('x,y,z where x > 3 and z < 2 sort by y')
+--    for x,y,z in q do
+--        print(x,y,z)
+--    end
+--
+-- See @{06-data.md.Reading_Columnar_Data|the Guide}
+--
+-- Dependencies: `pl.utils`, `pl.array2d` (fallback methods)
+-- @module pl.data
+
+local utils = require 'pl.utils'
+local _DEBUG = rawget(_G,'_DEBUG')
+
+local patterns,function_arg,usplit,array_tostring = utils.patterns,utils.function_arg,utils.split,utils.array_tostring
+local append,concat = table.insert,table.concat
+local gsub = string.gsub
+local io = io
+local _G,print,type,tonumber,ipairs,setmetatable,pcall,error = _G,print,type,tonumber,ipairs,setmetatable,pcall,error
+
+
+local data = {}
+
+local parse_select
+
+local function count(s,chr)
+    chr = utils.escape(chr)
+    local _,cnt = s:gsub(chr,' ')
+    return cnt
+end
+
+local function rstrip(s)
+    return (s:gsub('%s+$',''))
+end
+
+local function strip (s)
+    return (rstrip(s):gsub('^%s*',''))
+end
+
+-- this gives `l` the standard List metatable, so that if you
+-- do choose to pull in pl.List, you can use its methods on such lists.
+local function make_list(l)
+    return setmetatable(l,utils.stdmt.List)
+end
+
+local function map(fun,t)
+    local res = {}
+    for i = 1,#t do
+        res[i] = fun(t[i])
+    end
+    return res
+end
+
+local function split(line,delim,csv,n)
+    local massage
+    -- CSV fields may be double-quoted and may contain commas!
+    if csv and line:match '"' then
+        line = line:gsub('"([^"]+)"',function(str)
+            local s,cnt = str:gsub(',','\001')
+            if cnt > 0 then massage = true end
+            return s
+        end)
+        if massage then
+            massage = function(s) return (s:gsub('\001',',')) end
+        end
+    end
+    local res = (usplit(line,delim,false,n))
+    if csv then
+        -- restore CSV commas-in-fields
+        if massage then res = map(massage,res) end
+        -- in CSV mode trailiing commas are significant!
+        if line:match ',$' then append(res,'') end
+    end
+    return make_list(res)
+end
+
+local function find(t,v)
+    for i = 1,#t do
+        if v == t[i] then return i end
+    end
+end
+
+local DataMT = {
+    column_by_name = function(self,name)
+        if type(name) == 'number' then
+            name = '$'..name
+        end
+        local arr = {}
+        for res in data.query(self,name) do
+            append(arr,res)
+        end
+        return make_list(arr)
+    end,
+
+    copy_select = function(self,condn)
+        condn = parse_select(condn,self)
+        local iter = data.query(self,condn)
+        local res = {}
+        local row = make_list{iter()}
+        while #row > 0 do
+            append(res,row)
+            row = make_list{iter()}
+        end
+        res.delim = self.delim
+        return data.new(res,split(condn.fields,','))
+    end,
+
+    column_names = function(self)
+        return self.fieldnames
+    end,
+}
+
+local array2d
+
+DataMT.__index = function(self,name)
+    local f = DataMT[name]
+    if f then return f end
+    if not array2d then
+        array2d = require 'pl.array2d'
+    end
+    return array2d[name]
+end
+
+--- return a particular column as a list of values (method).
+-- @param name either name of column, or numerical index.
+-- @function Data.column_by_name
+
+--- return a query iterator on this data (method).
+-- @param condn the query expression
+-- @function Data.select
+-- @see data.query
+
+--- return a row iterator on this data (method).
+-- @param condn the query expression
+-- @function Data.select_row
+
+--- return a new data object based on this query (method).
+-- @param condn the query expression
+-- @function Data.copy_select
+
+--- return the field names of this data object (method).
+-- @function Data.column_names
+
+--- write out a row (method).
+-- @param f file-like object
+-- @function Data.write_row
+
+--- write data out to file (method).
+-- @param f file-like object
+-- @function Data.write
+
+
+-- [guessing delimiter] We check for comma, tab and spaces in that order.
+-- [issue] any other delimiters to be checked?
+local delims = {',','\t',' ',';'}
+
+local function guess_delim (line)
+    if line=='' then return ' ' end
+    for _,delim in ipairs(delims) do
+        if count(line,delim) > 0 then
+            return delim == ' ' and '%s+' or delim
+        end
+    end
+    return ' '
+end
+
+-- [file parameter] If it's a string, we try open as a filename. If nil, then
+-- either stdin or stdout depending on the mode. Otherwise, check if this is
+-- a file-like object (implements read or write depending)
+local function open_file (f,mode)
+    local opened, err
+    local reading = mode == 'r'
+    if type(f) == 'string' then
+        if f == 'stdin'  then
+            f = io.stdin
+        elseif f == 'stdout'  then
+            f = io.stdout
+        else
+            f,err = io.open(f,mode)
+            if not f then return nil,err end
+            opened = true
+        end
+    end
+    if f and ((reading and not f.read) or (not reading and not f.write)) then
+        return nil, "not a file-like object"
+    end
+    return f,nil,opened
+end
+
+local function all_n ()
+
+end
+
+--- read a delimited file in a Lua table.
+-- By default, attempts to treat first line as separated list of fieldnames.
+-- @param file a filename or a file-like object (default stdin)
+-- @param cnfg options table: can override `delim` (a string pattern), `fieldnames` (a list),
+-- specify `no_convert` (default is to conversion), `numfields` (indices of columns known
+-- to be numbers) and `thousands_dot` (thousands separator in Excel CSV is '.').
+-- If `csv` is set then fields may be double-quoted and contain commas;
+-- @return `data` object, or `nil`
+-- @return error message. May be a file error, 'not a file-like object'
+-- or a conversion error
+function data.read(file,cnfg)
+    local err,opened,count,line,csv
+    local D = {}
+    if not cnfg then cnfg = {} end
+    local f,err,opened = open_file(file,'r')
+    if not f then return nil, err end
+    local thousands_dot = cnfg.thousands_dot
+
+    -- note that using dot as the thousands separator (@thousands_dot)
+    -- requires a special conversion function!
+    local tonumber = tonumber
+    local function try_number(x)
+        if thousands_dot then x = x:gsub('%.(...)','%1') end
+        local v = tonumber(x)
+        if v == nil then return nil,"not a number" end
+        return v
+    end
+
+    csv = cnfg.csv
+    if csv then cnfg.delim = ',' end
+    count = 1
+    line = f:read()
+    if not line then return nil, "empty file" end
+
+    -- first question: what is the delimiter?
+    D.delim = cnfg.delim and cnfg.delim or guess_delim(line)
+    local delim = D.delim
+
+    local conversion
+    local numfields = {}
+    local function append_conversion (idx,conv)
+        conversion = conversion or {}
+        append(numfields,idx)
+        append(conversion,conv)
+    end
+    if cnfg.numfields then
+        for _,n in ipairs(cnfg.numfields) do append_conversion(n,try_number) end
+    end
+
+    -- some space-delimited data starts with a space.  This should not be a column,
+    -- although it certainly would be for comma-separated, etc.
+    local stripper
+    if delim == '%s+' and line:find(delim) == 1 then
+        stripper = function(s)  return s:gsub('^%s+','') end
+        line = stripper(line)
+    end
+    -- first line will usually be field names. Unless fieldnames are specified,
+    -- we check if it contains purely numerical values for the case of reading
+    -- plain data files.
+    if not cnfg.fieldnames then
+        local fields,nums
+        fields = split(line,delim,csv)
+        if not cnfg.convert then
+            nums = map(tonumber,fields)
+            if #nums == #fields then -- they're ALL numbers!
+                append(D,nums) -- add the first converted row
+                -- and specify conversions for subsequent rows
+                for i = 1,#nums do append_conversion(i,try_number) end
+            else -- we'll try to check numbers just now..
+                nums = nil
+            end
+        else -- [explicit column conversions] (any deduced number conversions will be added)
+            for idx,conv in pairs(cnfg.convert) do append_conversion(idx,conv) end
+        end
+        if nums == nil then
+            cnfg.fieldnames = fields
+        end
+        line = f:read()
+        count = count + 1
+        if stripper then line = stripper(line) end
+    elseif type(cnfg.fieldnames) == 'string' then
+        cnfg.fieldnames = split(cnfg.fieldnames,delim,csv)
+    end
+    local nfields
+    -- at this point, the column headers have been read in. If the first
+    -- row consisted of numbers, it has already been added to the dataset.
+    if cnfg.fieldnames then
+        D.fieldnames = cnfg.fieldnames
+        -- [collecting end field] If @last_field_collect then we'll
+        -- only split as many fields as there are fieldnames
+        if cnfg.last_field_collect then
+            nfields = #D.fieldnames
+        end
+        -- [implicit column conversion] unless @no_convert, we need the numerical field indices
+        -- of the first data row. These can also be specified explicitly by @numfields.
+        if not cnfg.no_convert then
+            local fields = split(line,D.delim,csv,nfields)
+            for i = 1,#fields do
+                if not find(numfields,i) and tonumber(fields[i]) then
+                    append_conversion(i,try_number)
+                end
+            end
+        end
+    end
+    -- keep going until finished
+    while line do
+        if not line:find ('^%s*$') then -- [blank lines] ignore them!
+            if stripper then line = stripper(line) end
+            local fields = split(line,delim,csv,nfields)
+            if conversion then -- there were field conversions...
+                for k = 1,#numfields do
+                    local i,conv = numfields[k],conversion[k]
+                    local val,err = conv(fields[i])
+                    if val == nil then
+                        return nil, err..": "..fields[i].." at line "..count
+                    else
+                        fields[i] = val
+                    end
+                end
+            end
+            append(D,fields)
+        end
+        line = f:read()
+        count = count + 1
+    end
+    if opened then f:close() end
+    if delim == '%s+' then D.delim = ' ' end
+    if not D.fieldnames then D.fieldnames = {} end
+    return data.new(D)
+end
+
+local function write_row (data,f,row,delim)
+    data.temp = array_tostring(row,data.temp)
+    f:write(concat(data.temp,delim),'\n')
+end
+
+function DataMT:write_row(f,row)
+    write_row(self,f,row,self.delim)
+end
+
+--- write 2D data to a file.
+-- Does not assume that the data has actually been
+-- generated with `new` or `read`.
+-- @param data 2D array
+-- @param file filename or file-like object
+-- @param fieldnames list of fields (optional)
+-- @param delim delimiter (default tab)
+function data.write (data,file,fieldnames,delim)
+    local f,err,opened = open_file(file,'w')
+    if not f then return nil, err end
+    if fieldnames and #fieldnames > 0 then
+        f:write(concat(data.fieldnames,delim),'\n')
+    end
+    delim = delim or '\t'
+    for i = 1,#data do
+        write_row(data,f,data[i],delim)
+    end
+    if opened then f:close() end
+end
+
+
+function DataMT:write(file)
+    data.write(self,file,self.fieldnames,self.delim)
+end
+
+local function massage_fieldnames (fields,copy)
+    -- fieldnames must be valid Lua identifiers; ignore any surrounding padding
+    -- but keep the original fieldnames...
+    for i = 1,#fields do
+        local f = strip(fields[i])
+        copy[i] = f
+        fields[i] = f:gsub('%W','_')
+    end
+end
+
+--- create a new dataset from a table of rows.
+-- Can specify the fieldnames, else the table must have a field called
+-- 'fieldnames', which is either a string of delimiter-separated names,
+-- or a table of names. <br>
+-- If the table does not have a field called 'delim', then an attempt will be
+-- made to guess it from the fieldnames string, defaults otherwise to tab.
+-- @param d the table.
+-- @param fieldnames optional fieldnames
+-- @return the table.
+function data.new (d,fieldnames)
+    d.fieldnames = d.fieldnames or fieldnames or ''
+    if not d.delim and type(d.fieldnames) == 'string' then
+        d.delim = guess_delim(d.fieldnames)
+        d.fieldnames = split(d.fieldnames,d.delim)
+    end
+    d.fieldnames = make_list(d.fieldnames)
+    d.original_fieldnames = {}
+    massage_fieldnames(d.fieldnames,d.original_fieldnames)
+    setmetatable(d,DataMT)
+    -- a query with just the fieldname will return a sequence
+    -- of values, which seq.copy turns into a table.
+    return d
+end
+
+local sorted_query = [[
+return function (t)
+    local i = 0
+    local v
+    local ls = {}
+    for i,v in ipairs(t) do
+        if CONDITION then
+            ls[#ls+1] = v
+        end
+    end
+    table.sort(ls,function(v1,v2)
+        return SORT_EXPR
+    end)
+    local n = #ls
+    return function()
+        i = i + 1
+        v = ls[i]
+        if i > n then return end
+        return FIELDLIST
+    end
+end
+]]
+
+-- question: is this optimized case actually worth the extra code?
+local simple_query = [[
+return function (t)
+    local n = #t
+    local i = 0
+    local v
+    return function()
+        repeat
+            i = i + 1
+            v = t[i]
+        until i > n or CONDITION
+        if i > n then return end
+        return FIELDLIST
+    end
+end
+]]
+
+local function is_string (s)
+    return type(s) == 'string'
+end
+
+local field_error
+
+local function fieldnames_as_string (data)
+    return concat(data.fieldnames,',')
+end
+
+local function massage_fields(data,f)
+    local idx
+    if f:find '^%d+$' then
+        idx = tonumber(f)
+    else
+        idx = find(data.fieldnames,f)
+    end
+    if idx then
+        return 'v['..idx..']'
+    else
+        field_error = f..' not found in '..fieldnames_as_string(data)
+        return f
+    end
+end
+
+
+local function process_select (data,parms)
+    --- preparing fields ----
+    local res,ret
+    field_error = nil
+    local fields = parms.fields
+    local numfields = fields:find '%$'  or #data.fieldnames == 0
+    if fields:find '^%s*%*%s*' then
+        if not numfields then
+            fields = fieldnames_as_string(data)
+        else
+            local ncol = #data[1]
+            fields = {}
+            for i = 1,ncol do append(fields,'$'..i) end
+            fields = concat(fields,',')
+        end
+    end
+    local idpat = patterns.IDEN
+    if numfields then
+        idpat = '%$(%d+)'
+    else
+        -- massage field names to replace non-identifier chars
+        fields = rstrip(fields):gsub('[^,%w]','_')
+    end
+    local massage_fields = utils.bind1(massage_fields,data)
+    ret = gsub(fields,idpat,massage_fields)
+    if field_error then return nil,field_error end
+    parms.fields = fields
+    parms.proc_fields = ret
+    parms.where = parms.where or  'true'
+    if is_string(parms.where) then
+        parms.where = gsub(parms.where,idpat,massage_fields)
+        field_error = nil
+    end
+    return true
+end
+
+
+parse_select = function(s,data)
+    local endp
+    local parms = {}
+    local w1,w2 = s:find('where ')
+    local s1,s2 = s:find('sort by ')
+    if w1 then -- where clause!
+        endp = (s1 or 0)-1
+        parms.where = s:sub(w2+1,endp)
+    end
+    if s1 then -- sort by clause (must be last!)
+        parms.sort_by = s:sub(s2+1)
+    end
+    endp = (w1 or s1 or 0)-1
+    parms.fields = s:sub(1,endp)
+    local status,err = process_select(data,parms)
+    if not status then return nil,err
+    else return parms end
+end
+
+--- create a query iterator from a select string.
+-- Select string has this format: <br>
+-- FIELDLIST [ where LUA-CONDN [ sort by FIELD] ]<br>
+-- FIELDLIST is a comma-separated list of valid fields, or '*'. <br> <br>
+-- The condition can also be a table, with fields 'fields' (comma-sep string or
+-- table), 'sort_by' (string) and 'where' (Lua expression string or function)
+-- @param data table produced by read
+-- @param condn select string or table
+-- @param context a list of tables to be searched when resolving functions
+-- @param return_row if true, wrap the results in a row table
+-- @return an iterator over the specified fields, or nil
+-- @return an error message
+function data.query(data,condn,context,return_row)
+    local err
+    if is_string(condn) then
+        condn,err = parse_select(condn,data)
+        if not condn then return nil,err end
+    elseif type(condn) == 'table' then
+        if type(condn.fields) == 'table' then
+            condn.fields = concat(condn.fields,',')
+        end
+        if not condn.proc_fields then
+            local status,err = process_select(data,condn)
+            if not status then return nil,err end
+        end
+    else
+        return nil, "condition must be a string or a table"
+    end
+    local query, k
+    if condn.sort_by then -- use sorted_query
+        query = sorted_query
+    else
+        query = simple_query
+    end
+    local fields = condn.proc_fields or condn.fields
+    if return_row then
+        fields = '{'..fields..'}'
+    end
+    query,k = query:gsub('FIELDLIST',fields)
+    if is_string(condn.where) then
+        query = query:gsub('CONDITION',condn.where)
+        condn.where = nil
+    else
+       query = query:gsub('CONDITION','_condn(v)')
+       condn.where = function_arg(0,condn.where,'condition.where must be callable')
+    end
+    if condn.sort_by then
+        local expr,sort_var,sort_dir
+        local sort_by = condn.sort_by
+        local i1,i2 = sort_by:find('%s+')
+        if i1 then
+            sort_var,sort_dir = sort_by:sub(1,i1-1),sort_by:sub(i2+1)
+        else
+            sort_var = sort_by
+            sort_dir = 'asc'
+        end
+        if sort_var:match '^%$' then sort_var = sort_var:sub(2) end
+        sort_var = massage_fields(data,sort_var)
+        if field_error then return nil,field_error end
+        if sort_dir == 'asc' then
+            sort_dir = '<'
+        else
+            sort_dir = '>'
+        end
+        expr = ('%s %s %s'):format(sort_var:gsub('v','v1'),sort_dir,sort_var:gsub('v','v2'))
+        query = query:gsub('SORT_EXPR',expr)
+    end
+    if condn.where then
+        query = 'return function(_condn) '..query..' end'
+    end
+    if _DEBUG then print(query) end
+
+    local fn,err = utils.load(query,'tmp')
+    if not fn then return nil,err end
+    fn = fn() -- get the function
+    if condn.where then
+        fn = fn(condn.where)
+    end
+    local qfun = fn(data)
+    if context then
+        -- [specifying context for condition] @context is a list of tables which are
+        -- 'injected'into the condition's custom context
+        append(context,_G)
+        local lookup = {}
+        utils.setfenv(qfun,lookup)
+        setmetatable(lookup,{
+            __index = function(tbl,key)
+               -- _G.print(tbl,key)
+                for k,t in ipairs(context) do
+                    if t[key] then return t[key] end
+                end
+            end
+        })
+    end
+    return qfun
+end
+
+
+DataMT.select = data.query
+DataMT.select_row = function(d,condn,context)
+    return data.query(d,condn,context,true)
+end
+
+--- Filter input using a query.
+-- @param Q a query string
+-- @param infile filename or file-like object
+-- @param outfile filename or file-like object
+-- @param dont_fail true if you want to return an error, not just fail
+function data.filter (Q,infile,outfile,dont_fail)
+    local err
+    local d = data.read(infile or 'stdin')
+    local out = open_file(outfile or 'stdout')
+    local iter,err = d:select(Q)
+    local delim = d.delim
+    if not iter then
+        err = 'error: '..err
+        if dont_fail then
+            return nil,err
+        else
+            utils.quit(1,err)
+        end
+    end
+    while true do
+        local res = {iter()}
+        if #res == 0 then break end
+        out:write(concat(res,delim),'\n')
+    end
+end
+
+return data
+

--- a/lib/ext/spec-support/pl/dir.lua
+++ b/lib/ext/spec-support/pl/dir.lua
@@ -1,0 +1,476 @@
+--- Getting directory contents and matching them against wildcards.
+--
+-- Dependencies: `pl.utils`, `pl.path`, `pl.tablex`
+--
+-- Soft Dependencies: `alien`, `ffi` (either are used on Windows for copying/moving files)
+-- @module pl.dir
+
+local utils = require 'pl.utils'
+local path = require 'pl.path'
+local is_windows = path.is_windows
+local tablex = require 'pl.tablex'
+local ldir = path.dir
+local chdir = path.chdir
+local mkdir = path.mkdir
+local rmdir = path.rmdir
+local sub = string.sub
+local os,pcall,ipairs,pairs,require,setmetatable,_G = os,pcall,ipairs,pairs,require,setmetatable,_G
+local remove = os.remove
+local append = table.insert
+local wrap = coroutine.wrap
+local yield = coroutine.yield
+local assert_arg,assert_string,raise = utils.assert_arg,utils.assert_string,utils.raise
+local List = utils.stdmt.List
+
+local dir = {}
+
+local function assert_dir (n,val)
+    assert_arg(n,val,'string',path.isdir,'not a directory',4)
+end
+
+local function assert_file (n,val)
+    assert_arg(n,val,'string',path.isfile,'not a file',4)
+end
+
+local function filemask(mask)
+    mask = utils.escape(mask)
+    return mask:gsub('%%%*','.+'):gsub('%%%?','.')..'$'
+end
+
+--- does the filename match the shell pattern?.
+-- (cf. fnmatch.fnmatch in Python, 11.8)
+-- @param file A file name
+-- @param pattern A shell pattern
+-- @return true or false
+-- @raise file and pattern must be strings
+function dir.fnmatch(file,pattern)
+    assert_string(1,file)
+    assert_string(2,pattern)
+    return path.normcase(file):find(filemask(pattern)) ~= nil
+end
+
+--- return a list of all files which match the pattern.
+-- (cf. fnmatch.filter in Python, 11.8)
+-- @param files A table containing file names
+-- @param pattern A shell pattern.
+-- @return list of files
+-- @raise file and pattern must be strings
+function dir.filter(files,pattern)
+    assert_arg(1,files,'table')
+    assert_string(2,pattern)
+    local res = {}
+    local mask = filemask(pattern)
+    for i,f in ipairs(files) do
+        if f:find(mask) then append(res,f) end
+    end
+    return setmetatable(res,List)
+end
+
+local function _listfiles(dir,filemode,match)
+    local res = {}
+    local check = utils.choose(filemode,path.isfile,path.isdir)
+    if not dir then dir = '.' end
+    for f in ldir(dir) do
+        if f ~= '.' and f ~= '..' then
+            local p = path.join(dir,f)
+            if check(p) and (not match or match(p)) then
+                append(res,p)
+            end
+        end
+    end
+    return setmetatable(res,List)
+end
+
+--- return a list of all files in a directory which match the a shell pattern.
+-- @param dir A directory. If not given, all files in current directory are returned.
+-- @param mask  A shell pattern. If not given, all files are returned.
+-- @return lsit of files
+-- @raise dir and mask must be strings
+function dir.getfiles(dir,mask)
+    assert_dir(1,dir)
+    if mask then assert_string(2,mask) end
+    local match
+    if mask then
+        mask = filemask(mask)
+        match = function(f)
+            return f:find(mask)
+        end
+    end
+    return _listfiles(dir,true,match)
+end
+
+--- return a list of all subdirectories of the directory.
+-- @param dir A directory
+-- @return a list of directories
+-- @raise dir must be a string
+function dir.getdirectories(dir)
+    assert_dir(1,dir)
+    return _listfiles(dir,false)
+end
+
+local function quote_argument (f)
+    f = path.normcase(f)
+    if f:find '%s' then
+        return '"'..f..'"'
+    else
+        return f
+    end
+end
+
+
+local alien,ffi,ffi_checked,CopyFile,MoveFile,GetLastError,win32_errors,cmd_tmpfile
+
+local function execute_command(cmd,parms)
+   if not cmd_tmpfile then cmd_tmpfile = path.tmpname () end
+   local err = path.is_windows and ' > ' or ' 2> '
+    cmd = cmd..' '..parms..err..cmd_tmpfile
+    local ret = utils.execute(cmd)
+    if not ret then
+        return false,(utils.readfile(cmd_tmpfile):gsub('\n(.*)',''))
+    else
+        return true
+    end
+end
+
+local function find_ffi_copyfile ()
+    if not ffi_checked then
+        ffi_checked = true
+        local res
+        res,alien = pcall(require,'alien')
+        if not res then
+            alien = nil
+            res, ffi = pcall(require,'ffi')
+        end
+        if not res then
+            ffi = nil
+            return
+        end
+    else
+        return
+    end
+    if alien then
+        -- register the Win32 CopyFile and MoveFile functions
+        local kernel = alien.load('kernel32.dll')
+        CopyFile = kernel.CopyFileA
+        CopyFile:types{'string','string','int',ret='int',abi='stdcall'}
+        MoveFile = kernel.MoveFileA
+        MoveFile:types{'string','string',ret='int',abi='stdcall'}
+        GetLastError = kernel.GetLastError
+        GetLastError:types{ret ='int', abi='stdcall'}
+    elseif ffi then
+        ffi.cdef [[
+            int CopyFileA(const char *src, const char *dest, int iovr);
+            int MoveFileA(const char *src, const char *dest);
+            int GetLastError();
+        ]]
+        CopyFile = ffi.C.CopyFileA
+        MoveFile = ffi.C.MoveFileA
+        GetLastError = ffi.C.GetLastError
+    end
+    win32_errors = {
+        ERROR_FILE_NOT_FOUND    =         2,
+        ERROR_PATH_NOT_FOUND    =         3,
+        ERROR_ACCESS_DENIED    =          5,
+        ERROR_WRITE_PROTECT    =          19,
+        ERROR_BAD_UNIT         =          20,
+        ERROR_NOT_READY        =          21,
+        ERROR_WRITE_FAULT      =          29,
+        ERROR_READ_FAULT       =          30,
+        ERROR_SHARING_VIOLATION =         32,
+        ERROR_LOCK_VIOLATION    =         33,
+        ERROR_HANDLE_DISK_FULL  =         39,
+        ERROR_BAD_NETPATH       =         53,
+        ERROR_NETWORK_BUSY      =         54,
+        ERROR_DEV_NOT_EXIST     =         55,
+        ERROR_FILE_EXISTS       =         80,
+        ERROR_OPEN_FAILED       =         110,
+        ERROR_INVALID_NAME      =         123,
+        ERROR_BAD_PATHNAME      =         161,
+        ERROR_ALREADY_EXISTS    =         183,
+    }
+end
+
+local function two_arguments (f1,f2)
+    return quote_argument(f1)..' '..quote_argument(f2)
+end
+
+local function file_op (is_copy,src,dest,flag)
+    if flag == 1 and path.exists(dest) then
+        return false,"cannot overwrite destination"
+    end
+    if is_windows then
+        -- if we haven't tried to load Alien/LuaJIT FFI before, then do so
+        find_ffi_copyfile()
+        -- fallback if there's no Alien, just use DOS commands *shudder*
+        -- 'rename' involves a copy and then deleting the source.
+        if not CopyFile then
+            src = path.normcase(src)
+            dest = path.normcase(dest)
+            local cmd = is_copy and 'copy' or 'rename'
+            local res, err = execute_command('copy',two_arguments(src,dest))
+            if not res then return nil,err end
+            if not is_copy then
+                return execute_command('del',quote_argument(src))
+            end
+        else
+            if path.isdir(dest) then
+                dest = path.join(dest,path.basename(src))
+            end
+			local ret
+            if is_copy then ret = CopyFile(src,dest,flag)
+            else ret = MoveFile(src,dest) end
+            if ret == 0 then
+                local err = GetLastError()
+                for name,value in pairs(win32_errors) do
+                    if value == err then return false,name end
+                end
+                return false,"Error #"..err
+            else return true
+            end
+        end
+    else -- for Unix, just use cp for now
+        return execute_command(is_copy and 'cp' or 'mv',
+            two_arguments(src,dest))
+    end
+end
+
+--- copy a file.
+-- @param src source file
+-- @param dest destination file or directory
+-- @param flag true if you want to force the copy (default)
+-- @return true if operation succeeded
+-- @raise src and dest must be strings
+function dir.copyfile (src,dest,flag)
+    assert_string(1,src)
+    assert_string(2,dest)
+    flag = flag==nil or flag
+    return file_op(true,src,dest,flag and 0 or 1)
+end
+
+--- move a file.
+-- @param src source file
+-- @param dest destination file or directory
+-- @return true if operation succeeded
+-- @raise src and dest must be strings
+function dir.movefile (src,dest)
+    assert_string(1,src)
+    assert_string(2,dest)
+    return file_op(false,src,dest,0)
+end
+
+local function _dirfiles(dir,attrib)
+    local dirs = {}
+    local files = {}
+    for f in ldir(dir) do
+        if f ~= '.' and f ~= '..' then
+            local p = path.join(dir,f)
+            local mode = attrib(p,'mode')
+            if mode=='directory' then
+                append(dirs,f)
+            else
+                append(files,f)
+            end
+        end
+    end
+    return setmetatable(dirs,List),setmetatable(files,List)
+end
+
+
+local function _walker(root,bottom_up,attrib)
+    local dirs,files = _dirfiles(root,attrib)
+    if not bottom_up then yield(root,dirs,files) end
+    for i,d in ipairs(dirs) do
+        _walker(root..path.sep..d,bottom_up,attrib)
+    end
+    if bottom_up then yield(root,dirs,files) end
+end
+
+--- return an iterator which walks through a directory tree starting at root.
+-- The iterator returns (root,dirs,files)
+-- Note that dirs and files are lists of names (i.e. you must say path.join(root,d)
+-- to get the actual full path)
+-- If bottom_up is false (or not present), then the entries at the current level are returned
+-- before we go deeper. This means that you can modify the returned list of directories before
+-- continuing.
+-- This is a clone of os.walk from the Python libraries.
+-- @param root A starting directory
+-- @param bottom_up False if we start listing entries immediately.
+-- @param follow_links follow symbolic links
+-- @return an iterator returning root,dirs,files
+-- @raise root must be a string
+function dir.walk(root,bottom_up,follow_links)
+    assert_dir(1,root)
+    local attrib
+    if path.is_windows or not follow_links then
+        attrib = path.attrib
+    else
+        attrib = path.link_attrib
+    end
+    return wrap(function () _walker(root,bottom_up,attrib) end)
+end
+
+--- remove a whole directory tree.
+-- @param fullpath A directory path
+-- @return true or nil
+-- @return error if failed
+-- @raise fullpath must be a string
+function dir.rmtree(fullpath)
+    assert_dir(1,fullpath)
+    if path.islink(fullpath) then return false,'will not follow symlink' end
+    for root,dirs,files in dir.walk(fullpath,true) do
+        for i,f in ipairs(files) do
+            remove(path.join(root,f))
+        end
+        rmdir(root)
+    end
+    return true
+end
+
+local dirpat
+if path.is_windows then
+    dirpat = '(.+)\\[^\\]+$'
+else
+    dirpat = '(.+)/[^/]+$'
+end
+
+local _makepath
+function _makepath(p)
+    -- windows root drive case
+    if p:find '^%a:[\\]*$' then
+        return true
+    end
+   if not path.isdir(p) then
+    local subp = p:match(dirpat)
+    local ok, err = _makepath(subp)
+    if not ok then return nil, err end
+    return mkdir(p)
+   else
+    return true
+   end
+end
+
+--- create a directory path.
+-- This will create subdirectories as necessary!
+-- @param p A directory path
+-- @return true on success, nil + errormsg on failure
+-- @raise failure to create
+function dir.makepath (p)
+    assert_string(1,p)
+    return _makepath(path.normcase(path.abspath(p)))
+end
+
+
+--- clone a directory tree. Will always try to create a new directory structure
+-- if necessary.
+-- @param path1 the base path of the source tree
+-- @param path2 the new base path for the destination
+-- @param file_fun an optional function to apply on all files
+-- @param verbose an optional boolean to control the verbosity of the output.
+--  It can also be a logging function that behaves like print()
+-- @return true, or nil
+-- @return error message, or list of failed directory creations
+-- @return list of failed file operations
+-- @raise path1 and path2 must be strings
+-- @usage clonetree('.','../backup',copyfile)
+function dir.clonetree (path1,path2,file_fun,verbose)
+    assert_string(1,path1)
+    assert_string(2,path2)
+    if verbose == true then verbose = print end
+    local abspath,normcase,isdir,join = path.abspath,path.normcase,path.isdir,path.join
+    local faildirs,failfiles = {},{}
+    if not isdir(path1) then return raise 'source is not a valid directory' end
+    path1 = abspath(normcase(path1))
+    path2 = abspath(normcase(path2))
+    if verbose then verbose('normalized:',path1,path2) end
+    -- particularly NB that the new path isn't fully contained in the old path
+    if path1 == path2 then return raise "paths are the same" end
+    local i1,i2 = path2:find(path1,1,true)
+    if i2 == #path1 and path2:sub(i2+1,i2+1) == path.sep then
+        return raise 'destination is a subdirectory of the source'
+    end
+    local cp = path.common_prefix (path1,path2)
+    local idx = #cp
+    if idx == 0 then -- no common path, but watch out for Windows paths!
+        if path1:sub(2,2) == ':' then idx = 3 end
+    end
+    for root,dirs,files in dir.walk(path1) do
+        local opath = path2..root:sub(idx)
+        if verbose then verbose('paths:',opath,root) end
+        if not isdir(opath) then
+            local ret = dir.makepath(opath)
+            if not ret then append(faildirs,opath) end
+            if verbose then verbose('creating:',opath,ret) end
+        end
+        if file_fun then
+            for i,f in ipairs(files) do
+                local p1 = join(root,f)
+                local p2 = join(opath,f)
+                local ret = file_fun(p1,p2)
+                if not ret then append(failfiles,p2) end
+                if verbose then
+                    verbose('files:',p1,p2,ret)
+                end
+            end
+        end
+    end
+    return true,faildirs,failfiles
+end
+
+--- return an iterator over all entries in a directory tree
+-- @param d a directory
+-- @return an iterator giving pathname and mode (true for dir, false otherwise)
+-- @raise d must be a non-empty string
+function dir.dirtree( d )
+    assert( d and d ~= "", "directory parameter is missing or empty" )
+    local exists, isdir = path.exists, path.isdir
+    local sep = path.sep
+
+    local last = sub ( d, -1 )
+    if last == sep or last == '/' then
+        d = sub( d, 1, -2 )
+    end
+
+    local function yieldtree( dir )
+        for entry in ldir( dir ) do
+            if entry ~= "." and entry ~= ".." then
+                entry = dir .. sep .. entry
+                if exists(entry) then  -- Just in case a symlink is broken.
+                    local is_dir = isdir(entry)
+                    yield( entry, is_dir )
+                    if is_dir then
+                        yieldtree( entry )
+                    end
+                end
+            end
+        end
+    end
+
+    return wrap( function() yieldtree( d ) end )
+end
+
+
+---	Recursively returns all the file starting at <i>path</i>. It can optionally take a shell pattern and
+--	only returns files that match <i>pattern</i>. If a pattern is given it will do a case insensitive search.
+--	@param start_path {string} A directory. If not given, all files in current directory are returned.
+--	@param pattern {string} A shell pattern. If not given, all files are returned.
+--	@return Table containing all the files found recursively starting at <i>path</i> and filtered by <i>pattern</i>.
+--  @raise start_path must be a string
+function dir.getallfiles( start_path, pattern )
+    assert_dir(1,start_path)
+    pattern = pattern or ""
+
+    local files = {}
+    local normcase = path.normcase
+    for filename, mode in dir.dirtree( start_path ) do
+        if not mode then
+            local mask = filemask( pattern )
+            if normcase(filename):find( mask ) then
+                files[#files + 1] = filename
+            end
+        end
+    end
+
+    return files
+end
+
+return dir

--- a/lib/ext/spec-support/pl/file.lua
+++ b/lib/ext/spec-support/pl/file.lua
@@ -1,0 +1,70 @@
+--- File manipulation functions: reading, writing, moving and copying.
+--
+-- Dependencies: `pl.utils`, `pl.dir`, `pl.path`
+-- @module pl.file
+local os = os
+local utils = require 'pl.utils'
+local dir = require 'pl.dir'
+local path = require 'pl.path'
+
+--[[
+module ('pl.file',utils._module)
+]]
+local file = {}
+
+--- return the contents of a file as a string
+-- @class function
+-- @name file.read
+-- @param filename The file path
+-- @return file contents
+file.read = utils.readfile
+
+--- write a string to a file
+-- @class function
+-- @name file.write
+-- @param filename The file path
+-- @param str The string
+file.write = utils.writefile
+
+--- copy a file.
+-- @class function
+-- @name file.copy
+-- @param src source file
+-- @param dest destination file
+-- @param flag true if you want to force the copy (default)
+-- @return true if operation succeeded
+file.copy = dir.copyfile
+
+--- move a file.
+-- @class function
+-- @name file.move
+-- @param src source file
+-- @param dest destination file
+-- @return true if operation succeeded, else false and the reason for the error.
+file.move = dir.movefile
+
+--- Return the time of last access as the number of seconds since the epoch.
+-- @class function
+-- @name file.access_time
+-- @param path A file path
+file.access_time = path.getatime
+
+---Return when the file was created.
+-- @class function
+-- @name file.creation_time
+-- @param path A file path
+file.creation_time = path.getctime
+
+--- Return the time of last modification
+-- @class function
+-- @name file.modified_time
+-- @param path A file path
+file.modified_time = path.getmtime
+
+--- Delete a file
+-- @class function
+-- @name file.delete
+-- @param path A file path
+file.delete = os.remove
+
+return file

--- a/lib/ext/spec-support/pl/func.lua
+++ b/lib/ext/spec-support/pl/func.lua
@@ -1,0 +1,376 @@
+--- Functional helpers like composition, binding and placeholder expressions.
+-- Placeholder expressions are useful for short anonymous functions, and were
+-- inspired by the Boost Lambda library.
+--
+--    > utils.import 'pl.func'
+--    > ls = List{10,20,30}
+--    > = ls:map(_1+1)
+--    {11,21,31}
+--
+-- They can also be used to _bind_ particular arguments of a function.
+--
+--    > p = bind(print,'start>',_0)
+--    > p(10,20,30)
+--    > start>   10   20  30
+--
+-- See @{07-functional.md.Creating_Functions_from_Functions|the Guide}
+--
+-- Dependencies: `pl.utils`, `pl.tablex`
+-- @module pl.func
+local type,select,setmetatable,getmetatable,rawset = type,select,setmetatable,getmetatable,rawset
+local concat,append = table.concat,table.insert
+local max = math.max
+local print,tostring = print,tostring
+local utils = require 'pl.utils'
+local pairs,ipairs,loadstring,rawget,unpack  = pairs,ipairs,loadstring,rawget,utils.unpack
+local _G = _G
+local tablex = require 'pl.tablex'
+local map = tablex.map
+local _DEBUG = rawget(_G,'_DEBUG')
+local assert_arg = utils.assert_arg
+
+local func = {}
+
+-- metatable for Placeholder Expressions (PE)
+local _PEMT = {}
+
+local function P (t)
+    setmetatable(t,_PEMT)
+    return t
+end
+
+func.PE = P
+
+local function isPE (obj)
+    return getmetatable(obj) == _PEMT
+end
+
+func.isPE = isPE
+
+-- construct a placeholder variable (e.g _1 and _2)
+local function PH (idx)
+    return P {op='X',repr='_'..idx, index=idx}
+end
+
+-- construct a constant placeholder variable (e.g _C1 and _C2)
+local function CPH (idx)
+    return P {op='X',repr='_C'..idx, index=idx}
+end
+
+func._1,func._2,func._3,func._4,func._5 = PH(1),PH(2),PH(3),PH(4),PH(5)
+func._0 = P{op='X',repr='...',index=0}
+
+function func.Var (name)
+    local ls = utils.split(name,'[%s,]+')
+    local res = {}
+    for _,n in ipairs(ls) do
+        append(res,P{op='X',repr=n,index=0})
+    end
+    return unpack(res)
+end
+
+function func._ (value)
+    return P{op='X',repr=value,index='wrap'}
+end
+
+local repr
+
+func.Nil = func.Var 'nil'
+
+function _PEMT.__index(obj,key)
+    return P{op='[]',obj,key}
+end
+
+function _PEMT.__call(fun,...)
+    return P{op='()',fun,...}
+end
+
+function _PEMT.__tostring (e)
+    return repr(e)
+end
+
+function _PEMT.__unm(arg)
+    return P{op='-',arg}
+end
+
+function func.Not (arg)
+    return P{op='not',arg}
+end
+
+function func.Len (arg)
+    return P{op='#',arg}
+end
+
+
+local function binreg(context,t)
+    for name,op in pairs(t) do
+        rawset(context,name,function(x,y)
+            return P{op=op,x,y}
+        end)
+    end
+end
+
+local function import_name (name,fun,context)
+    rawset(context,name,function(...)
+        return P{op='()',fun,...}
+    end)
+end
+
+local imported_functions = {}
+
+local function is_global_table (n)
+    return type(_G[n]) == 'table'
+end
+
+--- wrap a table of functions. This makes them available for use in
+-- placeholder expressions.
+-- @param tname a table name
+-- @param context context to put results, defaults to environment of caller
+function func.import(tname,context)
+    assert_arg(1,tname,'string',is_global_table,'arg# 1: not a name of a global table')
+    local t = _G[tname]
+    context = context or _G
+    for name,fun in pairs(t) do
+        import_name(name,fun,context)
+        imported_functions[fun] = name
+    end
+end
+
+--- register a function for use in placeholder expressions.
+-- @param fun a function
+-- @param name an optional name
+-- @return a placeholder functiond
+function func.register (fun,name)
+    assert_arg(1,fun,'function')
+    if name then
+        assert_arg(2,name,'string')
+        imported_functions[fun] = name
+    end
+    return function(...)
+        return P{op='()',fun,...}
+    end
+end
+
+function func.lookup_imported_name (fun)
+    return imported_functions[fun]
+end
+
+local function _arg(...) return ... end
+
+function func.Args (...)
+    return P{op='()',_arg,...}
+end
+
+-- binary and unary operators, with their precedences (see 2.5.6)
+local operators = {
+    ['or'] = 0,
+    ['and'] = 1,
+    ['=='] = 2, ['~='] = 2, ['<'] = 2, ['>'] = 2,  ['<='] = 2,   ['>='] = 2,
+    ['..'] = 3,
+    ['+'] = 4, ['-'] = 4,
+    ['*'] = 5, ['/'] = 5, ['%'] = 5,
+    ['not'] = 6, ['#'] = 6, ['-'] = 6,
+    ['^'] = 7
+}
+
+-- comparisons (as prefix functions)
+binreg (func,{And='and',Or='or',Eq='==',Lt='<',Gt='>',Le='<=',Ge='>='})
+
+-- standard binary operators (as metamethods)
+binreg (_PEMT,{__add='+',__sub='-',__mul='*',__div='/',__mod='%',__pow='^',__concat='..'})
+
+binreg (_PEMT,{__eq='=='})
+
+--- all elements of a table except the first.
+-- @param ls a list-like table.
+function func.tail (ls)
+    assert_arg(1,ls,'table')
+    local res = {}
+    for i = 2,#ls do
+        append(res,ls[i])
+    end
+    return res
+end
+
+--- create a string representation of a placeholder expression.
+-- @param e a placeholder expression
+-- @param lastpred not used
+function repr (e,lastpred)
+    local tail = func.tail
+    if isPE(e) then
+        local pred = operators[e.op]
+        local ls = map(repr,e,pred)
+        if pred then --unary or binary operator
+            if #ls ~= 1 then
+                local s = concat(ls,' '..e.op..' ')
+                if lastpred and lastpred > pred then
+                    s = '('..s..')'
+                end
+                return s
+            else
+                return e.op..' '..ls[1]
+            end
+        else -- either postfix, or a placeholder
+            if e.op == '[]' then
+                return ls[1]..'['..ls[2]..']'
+            elseif e.op == '()' then
+                local fn
+                if ls[1] ~= nil then -- was _args, undeclared!
+                    fn = ls[1]
+                else
+                    fn = ''
+                end
+                return fn..'('..concat(tail(ls),',')..')'
+            else
+                return e.repr
+            end
+        end
+    elseif type(e) == 'string' then
+        return '"'..e..'"'
+    elseif type(e) == 'function' then
+        local name = func.lookup_imported_name(e)
+        if name then return name else return tostring(e) end
+    else
+        return tostring(e) --should not really get here!
+    end
+end
+func.repr = repr
+
+-- collect all the non-PE values in this PE into vlist, and replace each occurence
+-- with a constant PH (_C1, etc). Return the maximum placeholder index found.
+local collect_values
+function collect_values (e,vlist)
+    if isPE(e) then
+        if e.op ~= 'X' then
+            local m = 0
+            for i,subx in ipairs(e) do
+                local pe = isPE(subx)
+                if pe then
+                    if subx.op == 'X' and subx.index == 'wrap' then
+                        subx = subx.repr
+                        pe = false
+                    else
+                        m = max(m,collect_values(subx,vlist))
+                    end
+                end
+                if not pe then
+                    append(vlist,subx)
+                    e[i] = CPH(#vlist)
+                end
+            end
+            return m
+        else -- was a placeholder, it has an index...
+            return e.index
+        end
+    else -- plain value has no placeholder dependence
+        return 0
+    end
+end
+func.collect_values = collect_values
+
+--- instantiate a PE into an actual function. First we find the largest placeholder used,
+-- e.g. _2; from this a list of the formal parameters can be build. Then we collect and replace
+-- any non-PE values from the PE, and build up a constant binding list.
+-- Finally, the expression can be compiled, and e.__PE_function is set.
+-- @param e a placeholder expression
+-- @return a function
+function func.instantiate (e)
+    local consts,values,parms = {},{},{}
+    local rep, err, fun
+    local n = func.collect_values(e,values)
+    for i = 1,#values do
+        append(consts,'_C'..i)
+        if _DEBUG then print(i,values[i]) end
+    end
+    for i =1,n do
+        append(parms,'_'..i)
+    end
+    consts = concat(consts,',')
+    parms = concat(parms,',')
+    rep = repr(e)
+    local fstr = ('return function(%s) return function(%s) return %s end end'):format(consts,parms,rep)
+    if _DEBUG then print(fstr) end
+    fun,err = utils.load(fstr,'fun')
+    if not fun then return nil,err end
+    fun = fun()  -- get wrapper
+    fun = fun(unpack(values)) -- call wrapper (values could be empty)
+    e.__PE_function = fun
+    return fun
+end
+
+--- instantiate a PE unless it has already been done.
+-- @param e a placeholder expression
+-- @return the function
+function func.I(e)
+    if rawget(e,'__PE_function')  then
+        return e.__PE_function
+    else return func.instantiate(e)
+    end
+end
+
+utils.add_function_factory(_PEMT,func.I)
+
+--- bind the first parameter of the function to a value.
+-- @function func.bind1
+-- @param fn a function of one or more arguments
+-- @param p a value
+-- @return a function of one less argument
+-- @usage (bind1(math.max,10))(20) == math.max(10,20)
+func.bind1 = utils.bind1
+func.curry = func.bind1
+
+--- create a function which chains two functions.
+-- @param f a function of at least one argument
+-- @param g a function of at least one argument
+-- @return a function
+-- @usage printf = compose(io.write,string.format)
+function func.compose (f,g)
+    return function(...) return f(g(...)) end
+end
+
+--- bind the arguments of a function to given values.
+-- bind(fn,v,_2) is equivalent to curry(fn,v).
+-- @param fn a function of at least one argument
+-- @param ... values or placeholder variables
+-- @return a function
+-- @usage (bind(f,_1,a))(b) == f(a,b)
+-- @usage (bind(f,_2,_1))(a,b) == f(b,a)
+function func.bind(fn,...)
+    local args = table.pack(...)
+    local holders,parms,bvalues,values = {},{},{'fn'},{}
+    local nv,maxplace,varargs = 1,0,false
+    for i = 1,args.n do
+        local a = args[i]
+        if isPE(a) and a.op == 'X' then
+            append(holders,a.repr)
+            maxplace = max(maxplace,a.index)
+            if a.index == 0 then varargs = true end
+        else
+            local v = '_v'..nv
+            append(bvalues,v)
+            append(holders,v)
+            append(values,a)
+            nv = nv + 1
+        end
+    end
+    for np = 1,maxplace do
+        append(parms,'_'..np)
+    end
+    if varargs then append(parms,'...') end
+    bvalues = concat(bvalues,',')
+    parms = concat(parms,',')
+    holders = concat(holders,',')
+    local fstr = ([[
+return function (%s)
+    return function(%s) return fn(%s) end
+end
+]]):format(bvalues,parms,holders)
+    if _DEBUG then print(fstr) end
+    local res,err = utils.load(fstr)
+    res = res()
+    return res(fn,unpack(values))
+end
+
+return func
+
+

--- a/lib/ext/spec-support/pl/import_into.lua
+++ b/lib/ext/spec-support/pl/import_into.lua
@@ -1,0 +1,89 @@
+--------------
+-- PL loader, for loading all PL libraries, only on demand.
+-- Whenever a module is implicitly accesssed, the table will have the module automatically injected.
+-- (e.g. `_ENV.tablex`)
+-- then that module is dynamically loaded. The submodules are all brought into
+-- the table that is provided as the argument, or returned in a new table.
+-- If a table is provided, that table's metatable is clobbered, but the values are not.
+-- This module returns a single function, which is passed the environment.
+-- If this is `true`, then return a 'shadow table' as the module
+-- See @{01-introduction.md.To_Inject_or_not_to_Inject_|the Guide}
+
+-- @module pl.import_into
+
+return function(env)
+    local mod
+    if env == true then
+        mod = {}
+        env = {}
+    end
+	local env = env or {}
+
+	local modules = {
+	    utils = true,path=true,dir=true,tablex=true,stringio=true,sip=true,
+	    input=true,seq=true,lexer=true,stringx=true,
+	    config=true,pretty=true,data=true,func=true,text=true,
+	    operator=true,lapp=true,array2d=true,
+	    comprehension=true,xml=true,types=true,
+	    test = true, app = true, file = true, class = true, List = true,
+	    Map = true, Set = true, OrderedMap = true, MultiMap = true,
+	    Date = true,
+	    -- classes --
+	}
+	rawset(env,'utils',require 'pl.utils')
+
+	for name,klass in pairs(env.utils.stdmt) do
+	    klass.__index = function(t,key)
+	        return require ('pl.'..name)[key]
+	    end;
+	end
+
+	-- ensure that we play nice with libraries that also attach a metatable
+	-- to the global table; always forward to a custom __index if we don't
+	-- match
+
+	local _hook,_prev_index
+	local gmt = {}
+	local prevenvmt = getmetatable(env)
+	if prevenvmt then
+	    _prev_index = prevenvmt.__index
+	    if prevenvmt.__newindex then
+	        gmt.__index = prevenvmt.__newindex
+	    end
+	end
+
+	function gmt.hook(handler)
+	    _hook = handler
+	end
+
+	function gmt.__index(t,name)
+	    local found = modules[name]
+	    -- either true, or the name of the module containing this class.
+	    -- either way, we load the required module and make it globally available.
+	    if found then
+	        -- e..g pretty.dump causes pl.pretty to become available as 'pretty'
+	        rawset(env,name,require('pl.'..name))
+	        return env[name]
+	    else
+	        local res
+	        if _hook then
+	            res = _hook(t,name)
+	            if res then return res end
+	        end
+	        if _prev_index then
+	            return _prev_index(t,name)
+	        end
+	    end
+	end
+
+    if mod then
+        function gmt.__newindex(t,name,value)
+            mod[name] = value
+            rawset(t,name,value)
+        end
+    end
+
+	setmetatable(env,gmt)
+
+	return env,mod or env
+end

--- a/lib/ext/spec-support/pl/init.lua
+++ b/lib/ext/spec-support/pl/init.lua
@@ -1,0 +1,11 @@
+--------------
+-- Entry point for loading all PL libraries only on demand, into the global space.
+-- Requiring 'pl' means that whenever a module is implicitly accesssed
+-- (e.g. `utils.split`)
+-- then that module is dynamically loaded. The submodules are all brought into
+-- the global space.
+--Updated to use @{pl.import_into}
+-- @module pl
+require'pl.import_into'(_G)
+
+if rawget(_G,'PENLIGHT_STRICT') then require 'pl.strict' end

--- a/lib/ext/spec-support/pl/input.lua
+++ b/lib/ext/spec-support/pl/input.lua
@@ -1,0 +1,171 @@
+--- Iterators for extracting words or numbers from an input source.
+--
+--    require 'pl'
+--    local total,n = seq.sum(input.numbers())
+--    print('average',total/n)
+--
+-- See @{06-data.md.Reading_Unstructured_Text_Data|here}
+--
+-- Dependencies: `pl.utils`
+-- @module pl.input
+local strfind = string.find
+local strsub = string.sub
+local strmatch = string.match
+local utils = require 'pl.utils'
+local unpack = utils.unpack
+local pairs,type,tonumber = pairs,type,tonumber
+local patterns = utils.patterns
+local io = io
+local assert_arg = utils.assert_arg
+
+
+local input = {}
+
+--- create an iterator over all tokens.
+-- based on allwords from PiL, 7.1
+-- @param getter any function that returns a line of text
+-- @param pattern
+-- @param fn  Optionally can pass a function to process each token as it/s found.
+-- @return an iterator
+function input.alltokens (getter,pattern,fn)
+    local line = getter()  -- current line
+    local pos = 1           -- current position in the line
+    return function ()      -- iterator function
+        while line do         -- repeat while there are lines
+          local s, e = strfind(line, pattern, pos)
+          if s then           -- found a word?
+            pos = e + 1       -- next position is after this token
+            local res = strsub(line, s, e)     -- return the token
+            if fn then res = fn(res) end
+            return res
+          else
+            line = getter()  -- token not found; try next line
+            pos = 1           -- restart from first position
+          end
+        end
+        return nil            -- no more lines: end of traversal
+   end
+end
+local alltokens = input.alltokens
+
+-- question: shd this _split_ a string containing line feeds?
+
+--- create a function which grabs the next value from a source. If the source is a string, then the getter
+-- will return the string and thereafter return nil. If not specified then the source is assumed to be stdin.
+-- @param f a string or a file-like object (i.e. has a read() method which returns the next line)
+-- @return a getter function
+function input.create_getter(f)
+  if f then
+    if type(f) == 'string' then
+      local ls = utils.split(f,'\n')
+      local i,n = 0,#ls
+      return function()
+         i = i + 1
+         if i > n then return nil end
+         return ls[i]
+       end
+    else
+      -- anything that supports the read() method!
+      if not f.read then error('not a file-like object') end
+      return function() return f:read() end
+    end
+  else
+    return io.read  -- i.e. just read from stdin
+  end
+end
+
+--- generate a sequence of numbers from a source.
+-- @param f A source
+-- @return An iterator
+function input.numbers(f)
+    return alltokens(input.create_getter(f),
+        '('..patterns.FLOAT..')',tonumber)
+end
+
+--- generate a sequence of words from a source.
+-- @param f A source
+-- @return An iterator
+function input.words(f)
+    return alltokens(input.create_getter(f),"%w+")
+end
+
+local function apply_tonumber (no_fail,...)
+    local args = {...}
+    for i = 1,#args do
+        local n = tonumber(args[i])
+        if  n == nil then
+            if not no_fail then return nil,args[i] end
+        else
+            args[i] = n
+        end
+    end
+    return args
+end
+
+--- parse an input source into fields.
+-- By default, will fail if it cannot convert a field to a number.
+-- @param ids a list of field indices, or a maximum field index
+-- @param delim delimiter to parse fields (default space)
+-- @param f a source @see create_getter
+-- @param opts option table, {no_fail=true}
+-- @return an iterator with the field values
+-- @usage for x,y in fields {2,3} do print(x,y) end -- 2nd and 3rd fields from stdin
+function input.fields (ids,delim,f,opts)
+  local sep
+  local s
+  local getter = input.create_getter(f)
+  local no_fail = opts and opts.no_fail
+  local no_convert = opts and opts.no_convert
+  if not delim or delim == ' ' then
+      delim = '%s'
+      sep = '%s+'
+      s = '%s*'
+  else
+      sep = delim
+      s = ''
+  end
+  local max_id = 0
+  if type(ids) == 'table' then
+    for i,id in pairs(ids) do
+      if id > max_id then max_id = id end
+    end
+  else
+    max_id = ids
+    ids = {}
+    for i = 1,max_id do ids[#ids+1] = i end
+  end
+  local pat = '[^'..delim..']*'
+  local k = 1
+  for i = 1,max_id do
+    if ids[k] == i then
+      k = k + 1
+      s = s..'('..pat..')'
+    else
+      s = s..pat
+    end
+    if i < max_id then
+      s = s..sep
+    end
+  end
+  local linecount = 1
+  return function()
+    local line,results,err
+    repeat
+        line = getter()
+        linecount = linecount + 1
+        if not line then return nil end
+        if no_convert then
+            results = {strmatch(line,s)}
+        else
+            results,err = apply_tonumber(no_fail,strmatch(line,s))
+            if not results then
+                utils.quit("line "..(linecount-1)..": cannot convert '"..err.."' to number")
+            end
+        end
+    until #results > 0
+    return unpack(results)
+  end
+end
+
+return input
+

--- a/lib/ext/spec-support/pl/lapp.lua
+++ b/lib/ext/spec-support/pl/lapp.lua
@@ -1,0 +1,417 @@
+--- Simple command-line parsing using human-readable specification.
+-- Supports GNU-style parameters.
+--
+--      lapp = require 'pl.lapp'
+--      local args = lapp [[
+--      Does some calculations
+--        -o,--offset (default 0.0)  Offset to add to scaled number
+--        -s,--scale  (number)  Scaling factor
+--         <number>; (number )  Number to be scaled
+--      ]]
+--
+--      print(args.offset + args.scale * args.number)
+--
+-- Lines begining with '-' are flags; there may be a short and a long name;
+-- lines begining wih '<var>' are arguments.  Anything in parens after
+-- the flag/argument is either a default, a type name or a range constraint.
+--
+-- See @{08-additional.md.Command_line_Programs_with_Lapp|the Guide}
+--
+-- Dependencies: `pl.sip`
+-- @module pl.lapp
+
+local status,sip = pcall(require,'pl.sip')
+if not status then
+    sip = require 'sip'
+end
+local match = sip.match_at_start
+local append,tinsert = table.insert,table.insert
+
+sip.custom_pattern('X','(%a[%w_%-]*)')
+
+local function lines(s) return s:gmatch('([^\n]*)\n') end
+local function lstrip(str)  return str:gsub('^%s+','')  end
+local function strip(str)  return lstrip(str):gsub('%s+$','') end
+local function at(s,k)  return s:sub(k,k) end
+local function isdigit(s) return s:find('^%d+$') == 1 end
+
+local lapp = {}
+
+local open_files,parms,aliases,parmlist,usage,windows,script
+
+lapp.callback = false -- keep Strict happy
+
+local filetypes = {
+    stdin = {io.stdin,'file-in'}, stdout = {io.stdout,'file-out'},
+    stderr = {io.stderr,'file-out'}
+}
+
+--- controls whether to dump usage on error.
+-- Defaults to true
+lapp.show_usage_error = true
+
+--- quit this script immediately.
+-- @param msg optional message
+-- @param no_usage suppress 'usage' display
+function lapp.quit(msg,no_usage)
+    if no_usage == 'throw' then
+        error(msg)
+    end
+    if msg then
+        io.stderr:write(msg..'\n\n')
+    end
+    if not no_usage then
+        io.stderr:write(usage)
+    end
+    os.exit(1)
+end
+
+--- print an error to stderr and quit.
+-- @param msg a message
+-- @param no_usage suppress 'usage' display
+function lapp.error(msg,no_usage)
+    if not lapp.show_usage_error then
+        no_usage = true
+    elseif lapp.show_usage_error == 'throw' then
+        no_usage = 'throw'
+    end
+    lapp.quit(script..': '..msg,no_usage)
+end
+
+--- open a file.
+-- This will quit on error, and keep a list of file objects for later cleanup.
+-- @param file filename
+-- @param opt same as second parameter of <code>io.open</code>
+function lapp.open (file,opt)
+    local val,err = io.open(file,opt)
+    if not val then lapp.error(err,true) end
+    append(open_files,val)
+    return val
+end
+
+--- quit if the condition is false.
+-- @param condn a condition
+-- @param msg an optional message
+function lapp.assert(condn,msg)
+    if not condn then
+        lapp.error(msg)
+    end
+end
+
+local function range_check(x,min,max,parm)
+    lapp.assert(min <= x and max >= x,parm..' out of range')
+end
+
+local function xtonumber(s)
+    local val = tonumber(s)
+    if not val then lapp.error("unable to convert to number: "..s) end
+    return val
+end
+
+local types = {}
+
+local builtin_types = {string=true,number=true,['file-in']='file',['file-out']='file',boolean=true}
+
+local function convert_parameter(ps,val)
+    if ps.converter then
+        val = ps.converter(val)
+    end
+    if ps.type == 'number' then
+        val = xtonumber(val)
+    elseif builtin_types[ps.type] == 'file' then
+        val = lapp.open(val,(ps.type == 'file-in' and 'r') or 'w' )
+    elseif ps.type == 'boolean' then
+        return val
+    end
+    if ps.constraint then
+        ps.constraint(val)
+    end
+    return val
+end
+
+--- add a new type to Lapp. These appear in parens after the value like
+-- a range constraint, e.g. '<ival> (integer) Process PID'
+-- @param name name of type
+-- @param converter either a function to convert values, or a Lua type name.
+-- @param constraint optional function to verify values, should use lapp.error
+-- if failed.
+function lapp.add_type (name,converter,constraint)
+    types[name] = {converter=converter,constraint=constraint}
+end
+
+local function force_short(short)
+    lapp.assert(#short==1,short..": short parameters should be one character")
+end
+
+-- deducing type of variable from default value;
+local function process_default (sval,vtype)
+    local val
+    if not vtype or vtype == 'number' then
+        val = tonumber(sval)
+    end
+    if val then -- we have a number!
+        return val,'number'
+    elseif filetypes[sval] then
+        local ft = filetypes[sval]
+        return ft[1],ft[2]
+    else
+        if sval == 'true' and not vtype then
+            return true, 'boolean'
+        end
+        if sval:match '^["\']' then sval = sval:sub(2,-2) end
+        return sval,vtype or 'string'
+    end
+end
+
+--- process a Lapp options string.
+-- Usually called as lapp().
+-- @param str the options text
+-- @param args a table of arguments (default is `_G.arg`)
+-- @return a table with parameter-value pairs
+function lapp.process_options_string(str,args)
+    local results = {}
+    local opts = {at_start=true}
+    local varargs
+    local arg = args or _G.arg
+    open_files = {}
+    parms = {}
+    aliases = {}
+    parmlist = {}
+
+    local function check_varargs(s)
+        local res,cnt = s:gsub('^%.%.%.%s*','')
+        return res, (cnt > 0)
+    end
+
+    local function set_result(ps,parm,val)
+        parm = type(parm) == "string" and parm:gsub("%W", "_") or parm -- so foo-bar becomes foo_bar in Lua
+        if not ps.varargs then
+            results[parm] = val
+        else
+            if not results[parm] then
+                results[parm] = { val }
+            else
+                append(results[parm],val)
+            end
+        end
+    end
+
+    usage = str
+
+    for line in lines(str) do
+        local res = {}
+        local optspec,optparm,i1,i2,defval,vtype,constraint,rest
+        line = lstrip(line)
+        local function check(str)
+            return match(str,line,res)
+        end
+
+        -- flags: either '-<short>', '-<short>,--<long>' or '--<long>'
+        if check '-$v{short}, --$o{long} $' or check '-$v{short} $' or check '--$o{long} $' then
+            if res.long then
+                optparm = res.long:gsub('[^%w%-]','_')  -- I'm not sure the $o pattern will let anything else through?
+                if res.short then aliases[res.short] = optparm  end
+            else
+                optparm = res.short
+            end
+            if res.short and not lapp.slack then force_short(res.short) end
+            res.rest, varargs = check_varargs(res.rest)
+        elseif check '$<{name} $'  then -- is it <parameter_name>?
+            -- so <input file...> becomes input_file ...
+            optparm,rest = res.name:match '([^%.]+)(.*)'
+            optparm = optparm:gsub('%A','_')
+            varargs = rest == '...'
+            append(parmlist,optparm)
+        end
+        -- this is not a pure doc line and specifies the flag/parameter type
+        if res.rest then
+            line = res.rest
+            res = {}
+            local optional
+            -- do we have ([optional] [<type>] [default <val>])?
+            if match('$({def} $',line,res) or match('$({def}',line,res) then
+                local typespec = strip(res.def)
+                local ftype, rest = typespec:match('^(%S+)(.*)$')
+                rest = strip(rest)
+                if ftype == 'optional' then
+                    ftype, rest = rest:match('^(%S+)(.*)$')
+                    rest = strip(rest)
+                    optional = true
+                end
+                local default
+                if ftype == 'default' then
+                    default = true
+                    if rest == '' then lapp.error("value must follow default") end
+                else -- a type specification
+                    if match('$f{min}..$f{max}',ftype,res) then
+                        -- a numerical range like 1..10
+                        local min,max = res.min,res.max
+                        vtype = 'number'
+                        constraint = function(x)
+                            range_check(x,min,max,optparm)
+                        end
+                    elseif not ftype:match '|' then -- plain type
+                        vtype = ftype
+                    else
+                        -- 'enum' type is a string which must belong to
+                        -- one of several distinct values
+                        local enums = ftype
+                        local enump = '|' .. enums .. '|'
+                        vtype = 'string'
+                        constraint = function(s)
+                            lapp.assert(enump:match('|'..s..'|'),
+                              "value '"..s.."' not in "..enums
+                            )
+                        end
+                    end
+                end
+                res.rest = rest
+                typespec = res.rest
+                -- optional 'default value' clause. Type is inferred as
+                -- 'string' or 'number' if there's no explicit type
+                if default or match('default $r{rest}',typespec,res) then
+                    defval,vtype = process_default(res.rest,vtype)
+                end
+            else -- must be a plain flag, no extra parameter required
+                defval = false
+                vtype = 'boolean'
+            end
+            local ps = {
+                type = vtype,
+                defval = defval,
+                required = defval == nil and not optional,
+                comment = res.rest or optparm,
+                constraint = constraint,
+                varargs = varargs
+            }
+            varargs = nil
+            if types[vtype] then
+                local converter = types[vtype].converter
+                if type(converter) == 'string' then
+                    ps.type = converter
+                else
+                    ps.converter = converter
+                end
+                ps.constraint = types[vtype].constraint
+            elseif not builtin_types[vtype] then
+                lapp.error(vtype.." is unknown type")
+            end
+            parms[optparm] = ps
+        end
+    end
+    -- cool, we have our parms, let's parse the command line args
+    local iparm = 1
+    local iextra = 1
+    local i = 1
+    local parm,ps,val
+
+    local function check_parm (parm)
+        local eqi = parm:find '='
+        if eqi then
+            tinsert(arg,i+1,parm:sub(eqi+1))
+            parm = parm:sub(1,eqi-1)
+        end
+        return parm,eqi
+    end
+
+    local function is_flag (parm)
+        return parms[aliases[parm] or parm]
+    end
+
+    while i <= #arg do
+        local theArg = arg[i]
+        local res = {}
+        -- look for a flag, -<short flags> or --<long flag>
+        if match('--$S{long}',theArg,res) or match('-$S{short}',theArg,res) then
+            if res.long then -- long option
+                parm = check_parm(res.long)
+            elseif #res.short == 1 or is_flag(res.short) then
+                parm = res.short
+            else
+                local parmstr,eq = check_parm(res.short)
+                if not eq then
+                    parm = at(parmstr,1)
+                    local flag = is_flag(parm)
+                    if flag.type ~= 'boolean' then
+                    --if isdigit(at(parmstr,2)) then
+                        -- a short option followed by a digit is an exception (for AW;))
+                        -- push ahead into the arg array
+                        tinsert(arg,i+1,parmstr:sub(2))
+                    else
+                        -- push multiple flags into the arg array!
+                        for k = 2,#parmstr do
+                            tinsert(arg,i+k-1,'-'..at(parmstr,k))
+                        end
+                    end
+                else
+                    parm = parmstr
+                end
+            end
+            if aliases[parm] then parm = aliases[parm] end
+            if not parms[parm] and (parm == 'h' or parm == 'help') then
+                lapp.quit()
+            end
+        else -- a parameter
+            parm = parmlist[iparm]
+            if not parm then
+               -- extra unnamed parameters are indexed starting at 1
+               parm = iextra
+               ps = { type = 'string' }
+               parms[parm] = ps
+               iextra = iextra + 1
+            else
+                ps = parms[parm]
+            end
+            if not ps.varargs then
+                iparm = iparm + 1
+            end
+            val = theArg
+        end
+        ps = parms[parm]
+        if not ps then lapp.error("unrecognized parameter: "..parm) end
+        if ps.type ~= 'boolean' then -- we need a value! This should follow
+            if not val then
+                i = i + 1
+                val = arg[i]
+            end
+            lapp.assert(val,parm.." was expecting a value")
+        else -- toggle boolean flags (usually false -> true)
+            val = not ps.defval
+        end
+        ps.used = true
+        val = convert_parameter(ps,val)
+        set_result(ps,parm,val)
+        if builtin_types[ps.type] == 'file' then
+            set_result(ps,parm..'_name',theArg)
+        end
+        if lapp.callback then
+            lapp.callback(parm,theArg,res)
+        end
+        i = i + 1
+        val = nil
+    end
+    -- check unused parms, set defaults and check if any required parameters were missed
+    for parm,ps in pairs(parms) do
+        if not ps.used then
+            if ps.required then lapp.error("missing required parameter: "..parm) end
+            set_result(ps,parm,ps.defval)
+        end
+    end
+    return results
+end
+
+if arg then
+    script = arg[0]:gsub('.+[\\/]',''):gsub('%.%a+$','')
+else
+    script = "inter"
+end
+
+
+setmetatable(lapp, {
+    __call = function(tbl,str,args) return lapp.process_options_string(str,args) end,
+})
+
+
+return lapp
+
+

--- a/lib/ext/spec-support/pl/lexer.lua
+++ b/lib/ext/spec-support/pl/lexer.lua
@@ -1,0 +1,456 @@
+--- Lexical scanner for creating a sequence of tokens from text.
+-- `lexer.scan(s)` returns an iterator over all tokens found in the
+-- string `s`. This iterator returns two values, a token type string
+-- (such as 'string' for quoted string, 'iden' for identifier) and the value of the
+-- token.
+--
+-- Versions specialized for Lua and C are available; these also handle block comments
+-- and classify keywords as 'keyword' tokens. For example:
+--
+--    > s = 'for i=1,n do'
+--    > for t,v in lexer.lua(s)  do print(t,v) end
+--    keyword for
+--    iden    i
+--    =       =
+--    number  1
+--    ,       ,
+--    iden    n
+--    keyword do
+--
+-- See the Guide for further @{06-data.md.Lexical_Scanning|discussion}
+-- @module pl.lexer
+
+local yield,wrap = coroutine.yield,coroutine.wrap
+local strfind = string.find
+local strsub = string.sub
+local append = table.insert
+
+local function assert_arg(idx,val,tp)
+    if type(val) ~= tp then
+        error("argument "..idx.." must be "..tp, 2)
+    end
+end
+
+local lexer = {}
+
+local NUMBER1 = '^[%+%-]?%d+%.?%d*[eE][%+%-]?%d+'
+local NUMBER2 = '^[%+%-]?%d+%.?%d*'
+local NUMBER3 = '^0x[%da-fA-F]+'
+local NUMBER4 = '^%d+%.?%d*[eE][%+%-]?%d+'
+local NUMBER5 = '^%d+%.?%d*'
+local IDEN = '^[%a_][%w_]*'
+local WSPACE = '^%s+'
+local STRING0 = [[^(['\"]).-\\%1]]
+local STRING1 = [[^(['\"]).-[^\]%1]]
+local STRING3 = "^((['\"])%2)" -- empty string
+local PREPRO = '^#.-[^\\]\n'
+
+local plain_matches,lua_matches,cpp_matches,lua_keyword,cpp_keyword
+
+local function tdump(tok)
+    return yield(tok,tok)
+end
+
+local function ndump(tok,options)
+    if options and options.number then
+        tok = tonumber(tok)
+    end
+    return yield("number",tok)
+end
+
+-- regular strings, single or double quotes; usually we want them
+-- without the quotes
+local function sdump(tok,options)
+    if options and options.string then
+        tok = tok:sub(2,-2)
+    end
+    return yield("string",tok)
+end
+
+-- long Lua strings need extra work to get rid of the quotes
+local function sdump_l(tok,options)
+    if options and options.string then
+        tok = tok:sub(3,-3)
+    end
+    return yield("string",tok)
+end
+
+local function chdump(tok,options)
+    if options and options.string then
+        tok = tok:sub(2,-2)
+    end
+    return yield("char",tok)
+end
+
+local function cdump(tok)
+    return yield('comment',tok)
+end
+
+local function wsdump (tok)
+    return yield("space",tok)
+end
+
+local function pdump (tok)
+    return yield('prepro',tok)
+end
+
+local function plain_vdump(tok)
+    return yield("iden",tok)
+end
+
+local function lua_vdump(tok)
+    if lua_keyword[tok] then
+        return yield("keyword",tok)
+    else
+        return yield("iden",tok)
+    end
+end
+
+local function cpp_vdump(tok)
+    if cpp_keyword[tok] then
+        return yield("keyword",tok)
+    else
+        return yield("iden",tok)
+    end
+end
+
+--- create a plain token iterator from a string or file-like object.
+-- @param s the string
+-- @param matches an optional match table (set of pattern-action pairs)
+-- @param filter a table of token types to exclude, by default {space=true}
+-- @param options a table of options; by default, {number=true,string=true},
+-- which means convert numbers and strip string quotes.
+function lexer.scan (s,matches,filter,options)
+    --assert_arg(1,s,'string')
+    local file = type(s) ~= 'string' and s
+    filter = filter or {space=true}
+    options = options or {number=true,string=true}
+    if filter then
+        if filter.space then filter[wsdump] = true end
+        if filter.comments then
+            filter[cdump] = true
+        end
+    end
+    if not matches then
+        if not plain_matches then
+            plain_matches = {
+                {WSPACE,wsdump},
+                {NUMBER3,ndump},
+                {IDEN,plain_vdump},
+                {NUMBER1,ndump},
+                {NUMBER2,ndump},
+                {STRING3,sdump},
+                {STRING0,sdump},
+                {STRING1,sdump},
+                {'^.',tdump}
+            }
+        end
+        matches = plain_matches
+    end
+    local function lex ()
+        local i1,i2,idx,res1,res2,tok,pat,fun,capt
+        local line = 1
+        if file then s = file:read()..'\n' end
+        local sz = #s
+        local idx = 1
+        --print('sz',sz)
+        while true do
+            for _,m in ipairs(matches) do
+                pat = m[1]
+                fun = m[2]
+                i1,i2 = strfind(s,pat,idx)
+                if i1 then
+                    tok = strsub(s,i1,i2)
+                    idx = i2 + 1
+                    if not (filter and filter[fun]) then
+                        lexer.finished = idx > sz
+                        res1,res2 = fun(tok,options)
+                    end
+                    if res1 then
+                        local tp = type(res1)
+                        -- insert a token list
+                        if tp=='table' then
+                            yield('','')
+                            for _,t in ipairs(res1) do
+                                yield(t[1],t[2])
+                            end
+                        elseif tp == 'string' then -- or search up to some special pattern
+                            i1,i2 = strfind(s,res1,idx)
+                            if i1 then
+                                tok = strsub(s,i1,i2)
+                                idx = i2 + 1
+                                yield('',tok)
+                            else
+                                yield('','')
+                                idx = sz + 1
+                            end
+                            --if idx > sz then return end
+                        else
+                            yield(line,idx)
+                        end
+                    end
+                    if idx > sz then
+                        if file then
+                            --repeat -- next non-empty line
+                                line = line + 1
+                                s = file:read()
+                                if not s then return end
+                            --until not s:match '^%s*$'
+                            s = s .. '\n'
+                            idx ,sz = 1,#s
+                            break
+                        else
+                            return
+                        end
+                    else break end
+                end
+            end
+        end
+    end
+    return wrap(lex)
+end
+
+local function isstring (s)
+    return type(s) == 'string'
+end
+
+--- insert tokens into a stream.
+-- @param tok a token stream
+-- @param a1 a string is the type, a table is a token list and
+-- a function is assumed to be a token-like iterator (returns type & value)
+-- @param a2 a string is the value
+function lexer.insert (tok,a1,a2)
+    if not a1 then return end
+    local ts
+    if isstring(a1) and isstring(a2) then
+        ts = {{a1,a2}}
+    elseif type(a1) == 'function' then
+        ts = {}
+        for t,v in a1() do
+            append(ts,{t,v})
+        end
+    else
+        ts = a1
+    end
+    tok(ts)
+end
+
+--- get everything in a stream upto a newline.
+-- @param tok a token stream
+-- @return a string
+function lexer.getline (tok)
+    local t,v = tok('.-\n')
+    return v
+end
+
+--- get current line number. <br>
+-- Only available if the input source is a file-like object.
+-- @param tok a token stream
+-- @return the line number and current column
+function lexer.lineno (tok)
+    return tok(0)
+end
+
+--- get the rest of the stream.
+-- @param tok a token stream
+-- @return a string
+function lexer.getrest (tok)
+    local t,v = tok('.+')
+    return v
+end
+
+--- get the Lua keywords as a set-like table.
+-- So <code>res["and"]</code> etc would be <code>true</code>.
+-- @return a table
+function lexer.get_keywords ()
+    if not lua_keyword then
+        lua_keyword = {
+            ["and"] = true, ["break"] = true,  ["do"] = true,
+            ["else"] = true, ["elseif"] = true, ["end"] = true,
+            ["false"] = true, ["for"] = true, ["function"] = true,
+            ["if"] = true, ["in"] = true,  ["local"] = true, ["nil"] = true,
+            ["not"] = true, ["or"] = true, ["repeat"] = true,
+            ["return"] = true, ["then"] = true, ["true"] = true,
+            ["until"] = true,  ["while"] = true
+        }
+    end
+    return lua_keyword
+end
+
+
+--- create a Lua token iterator from a string or file-like object.
+-- Will return the token type and value.
+-- @param s the string
+-- @param filter a table of token types to exclude, by default {space=true,comments=true}
+-- @param options a table of options; by default, {number=true,string=true},
+-- which means convert numbers and strip string quotes.
+function lexer.lua(s,filter,options)
+    filter = filter or {space=true,comments=true}
+    lexer.get_keywords()
+    if not lua_matches then
+        lua_matches = {
+            {WSPACE,wsdump},
+            {NUMBER3,ndump},
+            {IDEN,lua_vdump},
+            {NUMBER4,ndump},
+            {NUMBER5,ndump},
+            {STRING3,sdump},
+            {STRING0,sdump},
+            {STRING1,sdump},
+            {'^%-%-%[%[.-%]%]',cdump},
+            {'^%-%-.-\n',cdump},
+            {'^%[%[.-%]%]',sdump_l},
+            {'^==',tdump},
+            {'^~=',tdump},
+            {'^<=',tdump},
+            {'^>=',tdump},
+            {'^%.%.%.',tdump},
+            {'^%.%.',tdump},
+            {'^.',tdump}
+        }
+    end
+    return lexer.scan(s,lua_matches,filter,options)
+end
+
+--- create a C/C++ token iterator from a string or file-like object.
+-- Will return the token type type and value.
+-- @param s the string
+-- @param filter a table of token types to exclude, by default {space=true,comments=true}
+-- @param options a table of options; by default, {number=true,string=true},
+-- which means convert numbers and strip string quotes.
+function lexer.cpp(s,filter,options)
+    filter = filter or {comments=true}
+    if not cpp_keyword then
+        cpp_keyword = {
+            ["class"] = true, ["break"] = true,  ["do"] = true, ["sizeof"] = true,
+            ["else"] = true, ["continue"] = true, ["struct"] = true,
+            ["false"] = true, ["for"] = true, ["public"] = true, ["void"] = true,
+            ["private"] = true, ["protected"] = true, ["goto"] = true,
+            ["if"] = true, ["static"] = true,  ["const"] = true, ["typedef"] = true,
+            ["enum"] = true, ["char"] = true, ["int"] = true, ["bool"] = true,
+            ["long"] = true, ["float"] = true, ["true"] = true, ["delete"] = true,
+            ["double"] = true,  ["while"] = true, ["new"] = true,
+            ["namespace"] = true, ["try"] = true, ["catch"] = true,
+            ["switch"] = true, ["case"] = true, ["extern"] = true,
+            ["return"] = true,["default"] = true,['unsigned']  = true,['signed'] = true,
+            ["union"] =  true, ["volatile"] = true, ["register"] = true,["short"] = true,
+        }
+    end
+    if not cpp_matches then
+        cpp_matches = {
+            {WSPACE,wsdump},
+            {PREPRO,pdump},
+            {NUMBER3,ndump},
+            {IDEN,cpp_vdump},
+            {NUMBER4,ndump},
+            {NUMBER5,ndump},
+            {STRING3,sdump},
+            {STRING1,chdump},
+            {'^//.-\n',cdump},
+            {'^/%*.-%*/',cdump},
+            {'^==',tdump},
+            {'^!=',tdump},
+            {'^<=',tdump},
+            {'^>=',tdump},
+            {'^->',tdump},
+            {'^&&',tdump},
+            {'^||',tdump},
+            {'^%+%+',tdump},
+            {'^%-%-',tdump},
+            {'^%+=',tdump},
+            {'^%-=',tdump},
+            {'^%*=',tdump},
+            {'^/=',tdump},
+            {'^|=',tdump},
+            {'^%^=',tdump},
+            {'^::',tdump},
+            {'^.',tdump}
+        }
+    end
+    return lexer.scan(s,cpp_matches,filter,options)
+end
+
+--- get a list of parameters separated by a delimiter from a stream.
+-- @param tok the token stream
+-- @param endtoken end of list (default ')'). Can be '\n'
+-- @param delim separator (default ',')
+-- @return a list of token lists.
+function lexer.get_separated_list(tok,endtoken,delim)
+    endtoken = endtoken or ')'
+    delim = delim or ','
+    local parm_values = {}
+    local level = 1 -- used to count ( and )
+    local tl = {}
+    local function tappend (tl,t,val)
+        val = val or t
+        append(tl,{t,val})
+    end
+    local is_end
+    if endtoken == '\n' then
+        is_end = function(t,val)
+            return t == 'space' and val:find '\n'
+        end
+    else
+        is_end = function (t)
+            return t == endtoken
+        end
+    end
+    local token,value
+    while true do
+        token,value=tok()
+        if not token then return nil,'EOS' end -- end of stream is an error!
+        if is_end(token,value) and level == 1 then
+            append(parm_values,tl)
+            break
+        elseif token == '(' then
+            level = level + 1
+            tappend(tl,'(')
+        elseif token == ')' then
+            level = level - 1
+            if level == 0 then -- finished with parm list
+                append(parm_values,tl)
+                break
+            else
+                tappend(tl,')')
+            end
+        elseif token == delim and level == 1 then
+            append(parm_values,tl) -- a new parm
+            tl = {}
+        else
+            tappend(tl,token,value)
+        end
+    end
+    return parm_values,{token,value}
+end
+
+--- get the next non-space token from the stream.
+-- @param tok the token stream.
+function lexer.skipws (tok)
+    local t,v = tok()
+    while t == 'space' do
+        t,v = tok()
+    end
+    return t,v
+end
+
+local skipws = lexer.skipws
+
+--- get the next token, which must be of the expected type.
+-- Throws an error if this type does not match!
+-- @param tok the token stream
+-- @param expected_type the token type
+-- @param no_skip_ws whether we should skip whitespace
+function lexer.expecting (tok,expected_type,no_skip_ws)
+    assert_arg(1,tok,'function')
+    assert_arg(2,expected_type,'string')
+    local t,v
+    if no_skip_ws then
+        t,v = tok()
+    else
+        t,v = skipws(tok)
+    end
+    if t ~= expected_type then error ("expecting "..expected_type,2) end
+    return v
+end
+
+return lexer

--- a/lib/ext/spec-support/pl/luabalanced.lua
+++ b/lib/ext/spec-support/pl/luabalanced.lua
@@ -1,0 +1,264 @@
+--- Extract delimited Lua sequences from strings.
+-- Inspired by Damian Conway's Text::Balanced in Perl. <br/>
+-- <ul>
+--   <li>[1] <a href="http://lua-users.org/wiki/LuaBalanced">Lua Wiki Page</a></li>
+--   <li>[2] http://search.cpan.org/dist/Text-Balanced/lib/Text/Balanced.pm</li>
+-- </ul> <br/>
+-- <pre class=example>
+-- local lb = require "pl.luabalanced"
+-- --Extract Lua expression starting at position 4.
+--  print(lb.match_expression("if x^2 + x > 5 then print(x) end", 4))
+--  --> x^2 + x > 5     16
+-- --Extract Lua string starting at (default) position 1.
+-- print(lb.match_string([["test\"123" .. "more"]]))
+-- --> "test\"123"     12
+-- </pre>
+-- (c) 2008, David Manura, Licensed under the same terms as Lua (MIT license).
+-- @class module
+-- @name pl.luabalanced
+
+local M = {}
+
+local assert = assert
+local table_concat = table.concat
+
+-- map opening brace <-> closing brace.
+local ends = { ['('] = ')', ['{'] = '}', ['['] = ']' }
+local begins = {}; for k,v in pairs(ends) do begins[v] = k end
+
+
+-- Match Lua string in string <s> starting at position <pos>.
+-- Returns <string>, <posnew>, where <string> is the matched
+-- string (or nil on no match) and <posnew> is the character
+-- following the match (or <pos> on no match).
+-- Supports all Lua string syntax: "...", '...', [[...]], [=[...]=], etc.
+local function match_string(s, pos)
+  pos = pos or 1
+  local posa = pos
+  local c = s:sub(pos,pos)
+  if c == '"' or c == "'" then
+    pos = pos + 1
+    while 1 do
+      pos = assert(s:find("[" .. c .. "\\]", pos), 'syntax error')
+      if s:sub(pos,pos) == c then
+        local part = s:sub(posa, pos)
+        return part, pos + 1
+      else
+        pos = pos + 2
+      end
+    end
+  else
+    local sc = s:match("^%[(=*)%[", pos)
+    if sc then
+      local _; _, pos = s:find("%]" .. sc .. "%]", pos)
+      assert(pos)
+      local part = s:sub(posa, pos)
+      return part, pos + 1
+    else
+      return nil, pos
+    end
+  end
+end
+M.match_string = match_string
+
+
+-- Match bracketed Lua expression, e.g. "(...)", "{...}", "[...]", "[[...]]",
+-- [=[...]=], etc.
+-- Function interface is similar to match_string.
+local function match_bracketed(s, pos)
+  pos = pos or 1
+  local posa = pos
+  local ca = s:sub(pos,pos)
+  if not ends[ca] then
+    return nil, pos
+  end
+  local stack = {}
+  while 1 do
+    pos = s:find('[%(%{%[%)%}%]\"\']', pos)
+    assert(pos, 'syntax error: unbalanced')
+    local c = s:sub(pos,pos)
+    if c == '"' or c == "'" then
+      local part; part, pos = match_string(s, pos)
+      assert(part)
+    elseif ends[c] then -- open
+      local mid, posb
+      if c == '[' then mid, posb = s:match('^%[(=*)%[()', pos) end
+      if mid then
+        pos = s:match('%]' .. mid .. '%]()', posb)
+        assert(pos, 'syntax error: long string not terminated')
+        if #stack == 0 then
+          local part = s:sub(posa, pos-1)
+          return part, pos
+        end
+      else
+        stack[#stack+1] = c
+        pos = pos + 1
+      end
+    else -- close
+      assert(stack[#stack] == assert(begins[c]), 'syntax error: unbalanced')
+      stack[#stack] = nil
+      if #stack == 0 then
+        local part = s:sub(posa, pos)
+        return part, pos+1
+      end
+      pos = pos + 1
+    end
+  end
+end
+M.match_bracketed = match_bracketed
+
+
+-- Match Lua comment, e.g. "--...\n", "--[[...]]", "--[=[...]=]", etc.
+-- Function interface is similar to match_string.
+local function match_comment(s, pos)
+  pos = pos or 1
+  if s:sub(pos, pos+1) ~= '--' then
+    return nil, pos
+  end
+  pos = pos + 2
+  local partt, post = match_string(s, pos)
+  if partt then
+    return '--' .. partt, post
+  end
+  local part; part, pos = s:match('^([^\n]*\n?)()', pos)
+  return '--' .. part, pos
+end
+
+
+-- Match Lua expression, e.g. "a + b * c[e]".
+-- Function interface is similar to match_string.
+local wordop = {['and']=true, ['or']=true, ['not']=true}
+local is_compare = {['>']=true, ['<']=true, ['~']=true}
+local function match_expression(s, pos)
+  pos = pos or 1
+  local posa = pos
+  local lastident
+  local poscs, posce
+  while pos do
+    local c = s:sub(pos,pos)
+    if c == '"' or c == "'" or c == '[' and s:find('^[=%[]', pos+1) then
+      local part; part, pos = match_string(s, pos)
+      assert(part, 'syntax error')
+    elseif c == '-' and s:sub(pos+1,pos+1) == '-' then
+      -- note: handle adjacent comments in loop to properly support
+      -- backtracing (poscs/posce).
+      poscs = pos
+      while s:sub(pos,pos+1) == '--' do
+        local part; part, pos = match_comment(s, pos)
+        assert(part)
+        pos = s:match('^%s*()', pos)
+        posce = pos
+      end
+    elseif c == '(' or c == '{' or c == '[' then
+      local part; part, pos = match_bracketed(s, pos)
+    elseif c == '=' and s:sub(pos+1,pos+1) == '=' then
+      pos = pos + 2  -- skip over two-char op containing '='
+    elseif c == '=' and is_compare[s:sub(pos-1,pos-1)] then
+      pos = pos + 1  -- skip over two-char op containing '='
+    elseif c:match'^[%)%}%];,=]' then
+      local part = s:sub(posa, pos-1)
+      return part, pos
+    elseif c:match'^[%w_]' then
+      local newident,newpos = s:match('^([%w_]+)()', pos)
+      if pos ~= posa and not wordop[newident] then -- non-first ident
+        local pose = ((posce == pos) and poscs or pos) - 1
+        while s:match('^%s', pose) do pose = pose - 1 end
+        local ce = s:sub(pose,pose)
+        if ce:match'[%)%}\'\"%]]' or
+           ce:match'[%w_]' and not wordop[lastident]
+        then
+          local part = s:sub(posa, pos-1)
+          return part, pos
+        end
+      end
+      lastident, pos = newident, newpos
+    else
+      pos = pos + 1
+    end
+    pos = s:find('[%(%{%[%)%}%]\"\';,=%w_%-]', pos)
+  end
+  local part = s:sub(posa, #s)
+  return part, #s+1
+end
+M.match_expression = match_expression
+
+
+-- Match name list (zero or more names).  E.g. "a,b,c"
+-- Function interface is similar to match_string,
+-- but returns array as match.
+local function match_namelist(s, pos)
+  pos = pos or 1
+  local list = {}
+  while 1 do
+    local c = #list == 0 and '^' or '^%s*,%s*'
+    local item, post = s:match(c .. '([%a_][%w_]*)%s*()', pos)
+    if item then pos = post else break end
+    list[#list+1] = item
+  end
+  return list, pos
+end
+M.match_namelist = match_namelist
+
+
+-- Match expression list (zero or more expressions).  E.g. "a+b,b*c".
+-- Function interface is similar to match_string,
+-- but returns array as match.
+local function match_explist(s, pos)
+  pos = pos or 1
+  local list = {}
+  while 1 do
+    if #list ~= 0 then
+      local post = s:match('^%s*,%s*()', pos)
+      if post then pos = post else break end
+    end
+    local item; item, pos = match_expression(s, pos)
+    assert(item, 'syntax error')
+    list[#list+1] = item
+  end
+  return list, pos
+end
+M.match_explist = match_explist
+
+
+-- Replace snippets of code in Lua code string <s>
+-- using replacement function f(u,sin) --> sout.
+-- <u> is the type of snippet ('c' = comment, 's' = string,
+-- 'e' = any other code).
+-- Snippet is replaced with <sout> (unless <sout> is nil or false, in
+-- which case the original snippet is kept)
+-- This is somewhat analogous to string.gsub .
+local function gsub(s, f)
+  local pos = 1
+  local posa = 1
+  local sret = ''
+  while 1 do
+    pos = s:find('[%-\'\"%[]', pos)
+    if not pos then break end
+    if s:match('^%-%-', pos) then
+      local exp = s:sub(posa, pos-1)
+      if #exp > 0 then sret = sret .. (f('e', exp) or exp) end
+      local comment; comment, pos = match_comment(s, pos)
+      sret = sret .. (f('c', assert(comment)) or comment)
+      posa = pos
+    else
+      local posb = s:find('^[\'\"%[]', pos)
+      local str
+      if posb then str, pos = match_string(s, posb) end
+      if str then
+        local exp = s:sub(posa, posb-1)
+        if #exp > 0 then sret = sret .. (f('e', exp) or exp) end
+        sret = sret .. (f('s', str) or str)
+        posa = pos
+      else
+        pos = pos + 1
+      end
+    end
+  end
+  local exp = s:sub(posa)
+  if #exp > 0 then sret = sret .. (f('e', exp) or exp) end
+  return sret
+end
+M.gsub = gsub
+
+
+return M

--- a/lib/ext/spec-support/pl/operator.lua
+++ b/lib/ext/spec-support/pl/operator.lua
@@ -1,0 +1,211 @@
+--- Lua operators available as functions.
+--
+-- (similar to the Python module of the same name)
+--
+-- There is a module field `optable` which maps the operator strings
+-- onto these functions, e.g. `operator.optable['()']==operator.call`
+--
+-- Operator strings like '>' and '{}' can be passed to most Penlight functions
+-- expecting a function argument.
+--
+-- Dependencies: `pl.utils`
+-- @module pl.operator
+
+local strfind = string.find
+local utils = require 'pl.utils'
+
+local operator = {}
+
+--- apply function to some arguments **()**
+-- @param fn a function or callable object
+-- @param ... arguments
+function operator.call(fn,...)
+    return fn(...)
+end
+
+--- get the indexed value from a table **[]**
+-- @param t a table or any indexable object
+-- @param k the key
+function  operator.index(t,k)
+    return t[k]
+end
+
+--- returns true if arguments are equal **==**
+-- @param a value
+-- @param b value
+function  operator.eq(a,b)
+    return a==b
+end
+
+--- returns true if arguments are not equal **~=**
+ -- @param a value
+-- @param b value
+function  operator.neq(a,b)
+    return a~=b
+end
+
+--- returns true if a is less than b **<**
+-- @param a value
+-- @param b value
+function  operator.lt(a,b)
+    return a < b
+end
+
+--- returns true if a is less or equal to b **<=**
+-- @param a value
+-- @param b value
+function  operator.le(a,b)
+    return a <= b
+end
+
+--- returns true if a is greater than b **>**
+-- @param a value
+-- @param b value
+function  operator.gt(a,b)
+    return a > b
+end
+
+--- returns true if a is greater or equal to b **>=**
+-- @param a value
+-- @param b value
+function  operator.ge(a,b)
+    return a >= b
+end
+
+--- returns length of string or table **#**
+-- @param a a string or a table
+function  operator.len(a)
+    return #a
+end
+
+--- add two values **+**
+-- @param a value
+-- @param b value
+function  operator.add(a,b)
+    return a+b
+end
+
+--- subtract b from a **-**
+-- @param a value
+-- @param b value
+function  operator.sub(a,b)
+    return a-b
+end
+
+--- multiply two values __*__
+-- @param a value
+-- @param b value
+function  operator.mul(a,b)
+    return a*b
+end
+
+--- divide first value by second **/**
+-- @param a value
+-- @param b value
+function  operator.div(a,b)
+    return a/b
+end
+
+--- raise first to the power of second **^**
+-- @param a value
+-- @param b value
+function  operator.pow(a,b)
+    return a^b
+end
+
+--- modulo; remainder of a divided by b **%**
+-- @param a value
+-- @param b value
+function  operator.mod(a,b)
+    return a%b
+end
+
+--- concatenate two values (either strings or `__concat` defined) **..**
+-- @param a value
+-- @param b value
+function  operator.concat(a,b)
+    return a..b
+end
+
+--- return the negative of a value **-**
+-- @param a value
+function  operator.unm(a)
+    return -a
+end
+
+--- false if value evaluates as true **not**
+-- @param a value
+function  operator.lnot(a)
+    return not a
+end
+
+--- true if both values evaluate as true **and**
+-- @param a value
+-- @param b value
+function  operator.land(a,b)
+    return a and b
+end
+
+--- true if either value evaluate as true **or**
+-- @param a value
+-- @param b value
+function  operator.lor(a,b)
+    return a or b
+end
+
+--- make a table from the arguments **{}**
+-- @param ... non-nil arguments
+-- @return a table
+function  operator.table (...)
+    return {...}
+end
+
+--- match two strings **~**.
+-- uses @{string.find}
+function  operator.match (a,b)
+    return strfind(a,b)~=nil
+end
+
+--- the null operation.
+-- @param ... arguments
+-- @return the arguments
+function  operator.nop (...)
+    return ...
+end
+
+---- Map from operator symbol to function.
+-- Most of these map directly from operators;
+-- But note these extras
+--
+--  * __'()'__  `call`
+--  * __'[]'__  `index`
+--  * __'{}'__ `table`
+--  * __'~'__   `match`
+--
+-- @table optable
+-- @field operator
+ operator.optable = {
+    ['+']=operator.add,
+    ['-']=operator.sub,
+    ['*']=operator.mul,
+    ['/']=operator.div,
+    ['%']=operator.mod,
+    ['^']=operator.pow,
+    ['..']=operator.concat,
+    ['()']=operator.call,
+    ['[]']=operator.index,
+    ['<']=operator.lt,
+    ['<=']=operator.le,
+    ['>']=operator.gt,
+    ['>=']=operator.ge,
+    ['==']=operator.eq,
+    ['~=']=operator.neq,
+    ['#']=operator.len,
+    ['and']=operator.land,
+    ['or']=operator.lor,
+    ['{}']=operator.table,
+    ['~']=operator.match,
+    ['']=operator.nop,
+}
+
+return operator

--- a/lib/ext/spec-support/pl/path.lua
+++ b/lib/ext/spec-support/pl/path.lua
@@ -1,0 +1,412 @@
+--- Path manipulation and file queries.
+--
+-- This is modelled after Python's os.path library (10.1); see @{04-paths.md|the Guide}.
+--
+-- Dependencies: `pl.utils`, `lfs`
+-- @module pl.path
+
+-- imports and locals
+local _G = _G
+local sub = string.sub
+local getenv = os.getenv
+local tmpnam = os.tmpname
+local attributes, currentdir, link_attrib
+local package = package
+local io = io
+local append = table.insert
+local ipairs = ipairs
+local utils = require 'pl.utils'
+local assert_arg,assert_string,raise = utils.assert_arg,utils.assert_string,utils.raise
+
+local attrib
+local path = {}
+
+local res,lfs = _G.pcall(_G.require,'lfs')
+if res then
+    attributes = lfs.attributes
+    currentdir = lfs.currentdir
+    link_attrib = lfs.symlinkattributes
+else
+    error("pl.path requires LuaFileSystem")
+end
+
+attrib = attributes
+path.attrib = attrib
+path.link_attrib = link_attrib
+
+--- Lua iterator over the entries of a given directory.
+-- Behaves like `lfs.dir`
+path.dir = lfs.dir
+
+--- Creates a directory.
+path.mkdir = lfs.mkdir
+
+--- Removes a directory.
+path.rmdir = lfs.rmdir
+
+---- Get the working directory.
+path.currentdir = currentdir
+
+--- Changes the working directory.
+path.chdir = lfs.chdir
+
+
+--- is this a directory?
+-- @param P A file path
+function path.isdir(P)
+	assert_string(1,P)
+    if P:match("\\$") then
+        P = P:sub(1,-2)
+    end
+    return attrib(P,'mode') == 'directory'
+end
+
+--- is this a file?.
+-- @param P A file path
+function path.isfile(P)
+	assert_string(1,P)
+    return attrib(P,'mode') == 'file'
+end
+
+-- is this a symbolic link?
+-- @param P A file path
+function path.islink(P)
+	assert_string(1,P)
+    if link_attrib then
+        return link_attrib(P,'mode')=='link'
+    else
+        return false
+    end
+end
+
+--- return size of a file.
+-- @param P A file path
+function path.getsize(P)
+	assert_string(1,P)
+    return attrib(P,'size')
+end
+
+--- does a path exist?.
+-- @param P A file path
+-- @return the file path if it exists, nil otherwise
+function path.exists(P)
+	assert_string(1,P)
+    return attrib(P,'mode') ~= nil and P
+end
+
+--- Return the time of last access as the number of seconds since the epoch.
+-- @param P A file path
+function path.getatime(P)
+	assert_string(1,P)
+    return attrib(P,'access')
+end
+
+--- Return the time of last modification
+-- @param P A file path
+function path.getmtime(P)
+    return attrib(P,'modification')
+end
+
+---Return the system's ctime.
+-- @param P A file path
+function path.getctime(P)
+	assert_string(1,P)
+    return path.attrib(P,'change')
+end
+
+
+local function at(s,i)
+    return sub(s,i,i)
+end
+
+path.is_windows = utils.dir_separator == '\\'
+
+local other_sep
+-- !constant sep is the directory separator for this platform.
+if path.is_windows then
+    path.sep = '\\'; other_sep = '/'
+    path.dirsep = ';'
+else
+    path.sep = '/'
+    path.dirsep = ':'
+end
+local sep,dirsep = path.sep,path.dirsep
+
+--- are we running Windows?
+-- @class field
+-- @name path.is_windows
+
+--- path separator for this platform.
+-- @class field
+-- @name path.sep
+
+--- separator for PATH for this platform
+-- @class field
+-- @name path.dirsep
+
+--- given a path, return the directory part and a file part.
+-- if there's no directory part, the first value will be empty
+-- @param P A file path
+function path.splitpath(P)
+    assert_string(1,P)
+    local i = #P
+    local ch = at(P,i)
+    while i > 0 and ch ~= sep and ch ~= other_sep do
+        i = i - 1
+        ch = at(P,i)
+    end
+    if i == 0 then
+        return '',P
+    else
+        return sub(P,1,i-1), sub(P,i+1)
+    end
+end
+
+--- return an absolute path.
+-- @param P A file path
+-- @param pwd optional start path to use (default is current dir)
+function path.abspath(P,pwd)
+    assert_string(1,P)
+	if pwd then assert_string(2,pwd) end
+    local use_pwd = pwd ~= nil
+    if not use_pwd and not currentdir then return P end
+    P = P:gsub('[\\/]$','')
+    pwd = pwd or currentdir()
+    if not path.isabs(P) then
+        P = path.join(pwd,P)
+    elseif path.is_windows and not use_pwd and at(P,2) ~= ':' and at(P,2) ~= '\\' then
+        P = pwd:sub(1,2)..P -- attach current drive to path like '\\fred.txt'
+    end
+    return path.normpath(P)
+end
+
+--- given a path, return the root part and the extension part.
+-- if there's no extension part, the second value will be empty
+-- @param P A file path
+function path.splitext(P)
+    assert_string(1,P)
+    local i = #P
+    local ch = at(P,i)
+    while i > 0 and ch ~= '.' do
+        if ch == sep or ch == other_sep then
+            return P,''
+        end
+        i = i - 1
+        ch = at(P,i)
+    end
+    if i == 0 then
+        return P,''
+    else
+        return sub(P,1,i-1),sub(P,i)
+    end
+end
+
+--- return the directory part of a path
+-- @param P A file path
+function path.dirname(P)
+    assert_string(1,P)
+    local p1,p2 = path.splitpath(P)
+    return p1
+end
+
+--- return the file part of a path
+-- @param P A file path
+function path.basename(P)
+    assert_string(1,P)
+    local p1,p2 = path.splitpath(P)
+    return p2
+end
+
+--- get the extension part of a path.
+-- @param P A file path
+function path.extension(P)
+    assert_string(1,P)
+    local p1,p2 = path.splitext(P)
+    return p2
+end
+
+--- is this an absolute path?.
+-- @param P A file path
+function path.isabs(P)
+    assert_string(1,P)
+    if path.is_windows then
+        return at(P,1) == '/' or at(P,1)=='\\' or at(P,2)==':'
+    else
+        return at(P,1) == '/'
+    end
+end
+
+--- return the path resulting from combining the individual paths.
+-- if the second (or later) path is absolute, we return the last absolute path (joined with any non-absolute paths following).
+-- empty elements (except the last) will be ignored.
+-- @param p1 A file path
+-- @param p2 A file path
+-- @param ... more file paths
+function path.join(p1,p2,...)
+    assert_string(1,p1)
+    assert_string(2,p2)
+    if select('#',...) > 0 then
+        local p = path.join(p1,p2)
+        local args = {...}
+        for i = 1,#args do
+            assert_string(i,args[i])
+            p = path.join(p,args[i])
+        end
+        return p
+    end
+    if path.isabs(p2) then return p2 end
+    local endc = at(p1,#p1)
+    if endc ~= path.sep and endc ~= other_sep and endc ~= "" then
+        p1 = p1..path.sep
+    end
+    return p1..p2
+end
+
+--- normalize the case of a pathname. On Unix, this returns the path unchanged;
+--  for Windows, it converts the path to lowercase, and it also converts forward slashes
+-- to backward slashes.
+-- @param P A file path
+function path.normcase(P)
+    assert_string(1,P)
+    if path.is_windows then
+        return (P:lower():gsub('/','\\'))
+    else
+        return P
+    end
+end
+
+local np_gen1,np_gen2 = '[^SEP]+SEP%.%.SEP?','SEP+%.?SEP'
+local np_pat1, np_pat2
+
+--- normalize a path name.
+--  A//B, A/./B and A/foo/../B all become A/B.
+-- @param P a file path
+function path.normpath(P)
+    assert_string(1,P)
+    if path.is_windows then
+        if P:match '^\\\\' then -- UNC
+            return '\\\\'..path.normpath(P:sub(3))
+        end
+        P = P:gsub('/','\\')
+    end
+    if not np_pat1 then
+        np_pat1 = np_gen1:gsub('SEP',sep)
+        np_pat2 = np_gen2:gsub('SEP',sep)
+    end
+    local k
+    repeat -- /./ -> /
+        P,k = P:gsub(np_pat2,sep)
+    until k == 0
+    repeat -- A/../ -> (empty)
+        P,k = P:gsub(np_pat1,'')
+    until k == 0
+    if P == '' then P = '.' end
+    return P
+end
+
+local function ATS (P)
+    if at(P,#P) ~= path.sep then
+        P = P..path.sep
+    end
+    return path.normcase(P)
+end
+
+--- relative path from current directory or optional start point
+-- @param P a path
+-- @param start optional start point (default current directory)
+function path.relpath (P,start)
+    assert_string(1,P)
+	if start then assert_string(2,start) end
+    local split,normcase,min,append = utils.split, path.normcase, math.min, table.insert
+    P = normcase(path.abspath(P,start))
+    start = start or currentdir()
+    start = normcase(start)
+    local startl, Pl = split(start,sep), split(P,sep)
+    local n = min(#startl,#Pl)
+    local k = n+1 -- default value if this loop doesn't bail out!
+    for i = 1,n do
+        if startl[i] ~= Pl[i] then
+            k = i
+            break
+        end
+    end
+    local rell = {}
+    for i = 1, #startl-k+1 do rell[i] = '..' end
+    if k <= #Pl then
+        for i = k,#Pl do append(rell,Pl[i]) end
+    end
+    return table.concat(rell,sep)
+end
+
+
+--- Replace a starting '~' with the user's home directory.
+-- In windows, if HOME isn't set, then USERPROFILE is used in preference to
+-- HOMEDRIVE HOMEPATH. This is guaranteed to be writeable on all versions of Windows.
+-- @param P A file path
+function path.expanduser(P)
+    assert_string(1,P)
+    if at(P,1) == '~' then
+        local home = getenv('HOME')
+        if not home then -- has to be Windows
+            home = getenv 'USERPROFILE' or (getenv 'HOMEDRIVE' .. getenv 'HOMEPATH')
+        end
+        return home..sub(P,2)
+    else
+        return P
+    end
+end
+
+
+---Return a suitable full path to a new temporary file name.
+-- unlike os.tmpnam(), it always gives you a writeable path (uses TEMP environment variable on Windows)
+function path.tmpname ()
+    local res = tmpnam()
+    if path.is_windows then res = getenv('TEMP')..res end
+    return res
+end
+
+--- return the largest common prefix path of two paths.
+-- @param path1 a file path
+-- @param path2 a file path
+function path.common_prefix (path1,path2)
+    assert_string(1,path1)
+    assert_string(2,path2)
+    path1, path2 = path.normcase(path1), path.normcase(path2)
+    -- get them in order!
+    if #path1 > #path2 then path2,path1 = path1,path2 end
+    for i = 1,#path1 do
+        local c1 = at(path1,i)
+        if c1 ~= at(path2,i) then
+            local cp = path1:sub(1,i-1)
+            if at(path1,i-1) ~= sep then
+                cp = path.dirname(cp)
+            end
+            return cp
+        end
+    end
+    if at(path2,#path1+1) ~= sep then path1 = path.dirname(path1) end
+    return path1
+    --return ''
+end
+
+
+--- return the full path where a particular Lua module would be found.
+-- Both package.path and package.cpath is searched, so the result may
+-- either be a Lua file or a shared library.
+-- @param mod name of the module
+-- @return on success: path of module, lua or binary
+-- @return on error: nil,error string
+function path.package_path(mod)
+    assert_string(1,mod)
+    local res
+    mod = mod:gsub('%.',sep)
+    res = package.searchpath(mod,package.path)
+    if res then return res,true end
+    res = package.searchpath(mod,package.cpath)
+    if res then return res,false end
+    return raise 'cannot find module on path'
+end
+
+
+---- finis -----
+return path

--- a/lib/ext/spec-support/pl/permute.lua
+++ b/lib/ext/spec-support/pl/permute.lua
@@ -1,0 +1,63 @@
+--- Permutation operations.
+--
+-- Dependencies: `pl.utils`, `pl.tablex`
+-- @module pl.permute
+local tablex = require 'pl.tablex'
+local utils = require 'pl.utils'
+local copy = tablex.deepcopy
+local append = table.insert
+local coroutine = coroutine
+local resume = coroutine.resume
+local assert_arg = utils.assert_arg
+
+
+local permute = {}
+
+-- PiL, 9.3
+
+local permgen
+permgen = function (a, n, fn)
+  if n == 0 then
+    fn(a)
+  else
+    for i=1,n do
+      -- put i-th element as the last one
+      a[n], a[i] = a[i], a[n]
+
+      -- generate all permutations of the other elements
+      permgen(a, n - 1, fn)
+
+      -- restore i-th element
+      a[n], a[i] = a[i], a[n]
+
+    end
+  end
+end
+
+--- an iterator over all permutations of the elements of a list.
+-- Please note that the same list is returned each time, so do not keep references!
+-- @param a list-like table
+-- @return an iterator which provides the next permutation as a list
+function permute.iter (a)
+    assert_arg(1,a,'table')
+    local n = #a
+    local co = coroutine.create(function () permgen(a, n, coroutine.yield) end)
+    return function ()   -- iterator
+        local code, res = resume(co)
+        return res
+    end
+end
+
+--- construct a table containing all the permutations of a list.
+-- @param a list-like table
+-- @return a table of tables
+-- @usage permute.table {1,2,3} --> {{2,3,1},{3,2,1},{3,1,2},{1,3,2},{2,1,3},{1,2,3}}
+function permute.table (a)
+    assert_arg(1,a,'table')
+    local res = {}
+    local n = #a
+    permgen(a,n,function(t) append(res,copy(t)) end)
+    return res
+end
+
+return permute

--- a/lib/ext/spec-support/pl/platf/luajava.lua
+++ b/lib/ext/spec-support/pl/platf/luajava.lua
@@ -1,0 +1,101 @@
+-- experimental support for LuaJava
+--
+local path = {}
+
+
+path.link_attrib = nil
+
+local File = luajava.bindClass("java.io.File")
+local Array = luajava.bindClass('java.lang.reflect.Array')
+
+local function file(s)
+    return luajava.new(File,s)
+end
+
+function path.dir(P)
+    local ls = file(P):list()
+    print(ls)
+    local idx,n = -1,Array:getLength(ls)
+    return function ()
+        idx = idx + 1
+        if idx == n then return nil
+        else
+            return Array:get(ls,idx)
+        end
+    end
+end
+
+function path.mkdir(P)
+    return file(P):mkdir()
+end
+
+function path.rmdir(P)
+    return file(P):delete()
+end
+
+--- is this a directory?
+-- @param P A file path
+function path.isdir(P)
+    if P:match("\\$") then
+        P = P:sub(1,-2)
+    end
+    return file(P):isDirectory()
+end
+
+--- is this a file?.
+-- @param P A file path
+function path.isfile(P)
+    return file(P):isFile()
+end
+
+-- is this a symbolic link?
+-- Direct support for symbolic links is not provided.
+-- see http://stackoverflow.com/questions/813710/java-1-6-determine-symbolic-links
+-- and the caveats therein.
+-- @param P A file path
+function path.islink(P)
+    local f = file(P)
+    local canon
+    local parent = f:getParent()
+    if not parent then
+        canon = f
+    else
+        parent = f.getParentFile():getCanonicalFile()
+        canon = luajava.new(File,parent,f:getName())
+    end
+    return canon:getCanonicalFile() ~= canon:getAbsoluteFile()
+end
+
+--- return size of a file.
+-- @param P A file path
+function path.getsize(P)
+    return file(P):length()
+end
+
+--- does a path exist?.
+-- @param P A file path
+-- @return the file path if it exists, nil otherwise
+function path.exists(P)
+    return file(P):exists() and P
+end
+
+--- Return the time of last access as the number of seconds since the epoch.
+-- @param P A file path
+function path.getatime(P)
+    return path.getmtime(P)
+end
+
+--- Return the time of last modification
+-- @param P A file path
+function path.getmtime(P)
+    -- Java time is no. of millisec since the epoch
+    return file(P):lastModified()/1000
+end
+
+---Return the system's ctime.
+-- @param P A file path
+function path.getctime(P)
+    return path.getmtime(P)
+end
+
+return path

--- a/lib/ext/spec-support/pl/pretty.lua
+++ b/lib/ext/spec-support/pl/pretty.lua
@@ -1,0 +1,286 @@
+--- Pretty-printing Lua tables.
+-- Also provides a sandboxed Lua table reader and
+-- a function to present large numbers in human-friendly format.
+--
+-- Dependencies: `pl.utils`, `pl.lexer`
+-- @module pl.pretty
+
+local append = table.insert
+local concat = table.concat
+local utils = require 'pl.utils'
+local lexer = require 'pl.lexer'
+local assert_arg = utils.assert_arg
+
+local pretty = {}
+
+local function save_string_index ()
+    local SMT = getmetatable ''
+    if SMT then
+        SMT.old__index = SMT.__index
+        SMT.__index = nil
+    end
+    return SMT
+end
+
+local function restore_string_index (SMT)
+    if SMT then
+        SMT.__index = SMT.old__index
+    end
+end
+
+--- read a string representation of a Lua table.
+-- Uses load(), but tries to be cautious about loading arbitrary code!
+-- It is expecting a string of the form '{...}', with perhaps some whitespace
+-- before or after the curly braces. A comment may occur beforehand.
+-- An empty environment is used, and
+-- any occurance of the keyword 'function' will be considered a problem.
+-- in the given environment - the return value may be `nil`.
+-- @param s {string} string of the form '{...}', with perhaps some whitespace
+-- before or after the curly braces.
+-- @return a table
+function pretty.read(s)
+    assert_arg(1,s,'string')
+    if s:find '^%s*%-%-' then -- may start with a comment..
+        s = s:gsub('%-%-.-\n','')
+    end
+    if not s:find '^%s*%b{}%s*$' then return nil,"not a Lua table" end
+    if s:find '[^\'"%w_]function[^\'"%w_]' then
+        local tok = lexer.lua(s)
+        for t,v in tok do
+            if t == 'keyword' then
+                return nil,"cannot have functions in table definition"
+            end
+        end
+    end
+    s = 'return '..s
+    local chunk,err = utils.load(s,'tbl','t',{})
+    if not chunk then return nil,err end
+    local SMT = save_string_index()
+    local ok,ret = pcall(chunk)
+    restore_string_index(SMT)
+    if ok then return ret
+    else
+        return nil,ret
+    end
+end
+
+--- read a Lua chunk.
+-- @param s Lua code
+-- @param env optional environment
+-- @param paranoid prevent any looping constructs and disable string methods
+-- @return the environment
+function pretty.load (s, env, paranoid)
+    env = env or {}
+    if paranoid then
+        local tok = lexer.lua(s)
+        for t,v in tok do
+            if t == 'keyword'
+                and (v == 'for' or v == 'repeat' or v == 'function' or v == 'goto')
+            then
+                return nil,"looping not allowed"
+            end
+        end
+    end
+    local chunk,err = utils.load(s,'tbl','t',env)
+    if not chunk then return nil,err end
+    local SMT = paranoid and save_string_index()
+    local ok,err = pcall(chunk)
+    restore_string_index(SMT)
+    if not ok then return nil,err end
+    return env
+end
+
+local function quote_if_necessary (v)
+    if not v then return ''
+    else
+        if v:find ' ' then v = '"'..v..'"' end
+    end
+    return v
+end
+
+local keywords
+
+local function is_identifier (s)
+    return type(s) == 'string' and s:find('^[%a_][%w_]*$') and not keywords[s]
+end
+
+local function quote (s)
+    if type(s) == 'table' then
+        return pretty.write(s,'')
+    else
+        return ('%q'):format(tostring(s))
+    end
+end
+
+local function index (numkey,key)
+    if not numkey then key = quote(key) end
+    return '['..key..']'
+end
+
+
+---	Create a string representation of a Lua table.
+--  This function never fails, but may complain by returning an
+--  extra value. Normally puts out one item per line, using
+--  the provided indent; set the second parameter to '' if
+--  you want output on one line.
+--	@param tbl {table} Table to serialize to a string.
+--	@param space {string} (optional) The indent to use.
+--	Defaults to two spaces; make it the empty string for no indentation
+--	@param not_clever {bool} (optional) Use for plain output, e.g {['key']=1}.
+--	Defaults to false.
+--  @return a string
+--  @return a possible error message
+function pretty.write (tbl,space,not_clever)
+    if type(tbl) ~= 'table' then
+        local res = tostring(tbl)
+        if type(tbl) == 'string' then return quote(tbl) end
+        return res, 'not a table'
+    end
+    if not keywords then
+        keywords = lexer.get_keywords()
+    end
+    local set = ' = '
+    if space == '' then set = '=' end
+    space = space or '  '
+    local lines = {}
+    local line = ''
+    local tables = {}
+
+
+    local function put(s)
+        if #s > 0 then
+            line = line..s
+        end
+    end
+
+    local function putln (s)
+        if #line > 0 then
+            line = line..s
+            append(lines,line)
+            line = ''
+        else
+            append(lines,s)
+        end
+    end
+
+    local function eat_last_comma ()
+        local n,lastch = #lines
+        local lastch = lines[n]:sub(-1,-1)
+        if lastch == ',' then
+            lines[n] = lines[n]:sub(1,-2)
+        end
+    end
+
+
+    local writeit
+    writeit = function (t,oldindent,indent)
+        local tp = type(t)
+        if tp ~= 'string' and  tp ~= 'table' then
+            putln(quote_if_necessary(tostring(t))..',')
+        elseif tp == 'string' then
+            if t:find('\n') then
+                putln('[[\n'..t..']],')
+            else
+                putln(quote(t)..',')
+            end
+        elseif tp == 'table' then
+            if tables[t] then
+                putln('<cycle>,')
+                return
+            end
+            tables[t] = true
+            local newindent = indent..space
+            putln('{')
+            local used = {}
+            if not not_clever then
+                for i,val in ipairs(t) do
+                    put(indent)
+                    writeit(val,indent,newindent)
+                    used[i] = true
+                end
+            end
+            for key,val in pairs(t) do
+                local numkey = type(key) == 'number'
+                if not_clever then
+                    key = tostring(key)
+                    put(indent..index(numkey,key)..set)
+                    writeit(val,indent,newindent)
+                else
+                    if not numkey or not used[key] then -- non-array indices
+                        if numkey or not is_identifier(key) then
+                            key = index(numkey,key)
+                        end
+                        put(indent..key..set)
+                        writeit(val,indent,newindent)
+                    end
+                end
+            end
+            tables[t] = nil
+            eat_last_comma()
+            putln(oldindent..'},')
+        else
+            putln(tostring(t)..',')
+        end
+    end
+    writeit(tbl,'',space)
+    eat_last_comma()
+    return concat(lines,#space > 0 and '\n' or '')
+end
+
+---	Dump a Lua table out to a file or stdout.
+--	@param t {table} The table to write to a file or stdout.
+--	@param ... {string} (optional) File name to write too. Defaults to writing
+--	to stdout.
+function pretty.dump (t,...)
+    if select('#',...)==0 then
+        print(pretty.write(t))
+        return true
+    else
+        return utils.writefile(...,pretty.write(t))
+    end
+end
+
+local memp,nump = {'B','KiB','MiB','GiB'},{'','K','M','B'}
+
+local comma
+function comma (val)
+    local thou = math.floor(val/1000)
+    if thou > 0 then return comma(thou)..','..(val % 1000)
+    else return tostring(val) end
+end
+
+--- format large numbers nicely for human consumption.
+-- @param num a number
+-- @param kind one of 'M' (memory in KiB etc), 'N' (postfixes are 'K','M' and 'B')
+-- and 'T' (use commas as thousands separator)
+-- @param prec number of digits to use for 'M' and 'N' (default 1)
+function pretty.number (num,kind,prec)
+    local fmt = '%.'..(prec or 1)..'f%s'
+    if kind == 'T' then
+        return comma(num)
+    else
+        local postfixes, fact
+        if kind == 'M' then
+            fact = 1024
+            postfixes = memp
+        else
+            fact = 1000
+            postfixes = nump
+        end
+        local div = fact
+        local k = 1
+        while num >= div and k <= #postfixes do
+            div = div * fact
+            k = k + 1
+        end
+        div = div / fact
+        if k > #postfixes then k = k - 1; div = div/fact end
+        if k > 1 then
+            return fmt:format(num/div,postfixes[k] or 'duh')
+        else
+            return num..postfixes[1]
+        end
+    end
+end
+
+return pretty

--- a/lib/ext/spec-support/pl/seq.lua
+++ b/lib/ext/spec-support/pl/seq.lua
@@ -1,0 +1,551 @@
+--- Manipulating iterators as sequences.
+-- See @{07-functional.md.Sequences|The Guide}
+--
+-- Dependencies: `pl.utils`, `pl.types`, `debug`
+-- @module pl.seq
+
+local next,assert,type,pairs,tonumber,type,setmetatable,getmetatable,_G = next,assert,type,pairs,tonumber,type,setmetatable,getmetatable,_G
+local strfind,strmatch,format = string.find,string.match,string.format
+local mrandom = math.random
+local remove,tsort,tappend = table.remove,table.sort,table.insert
+local io = io
+local utils = require 'pl.utils'
+local callable = require 'pl.types'.is_callable
+local function_arg = utils.function_arg
+local _List = utils.stdmt.List
+local _Map = utils.stdmt.Map
+local assert_arg = utils.assert_arg
+local debug = require 'debug'
+
+local seq = {}
+
+-- given a number, return a function(y) which returns true if y > x
+-- @param x a number
+function seq.greater_than(x)
+  return function(v)
+    return tonumber(v) > x
+  end
+end
+
+-- given a number, returns a function(y) which returns true if y < x
+-- @param x a number
+function seq.less_than(x)
+  return function(v)
+    return tonumber(v) < x
+  end
+end
+
+-- given any value, return a function(y) which returns true if y == x
+-- @param x a value
+function seq.equal_to(x)
+  if type(x) == "number" then
+    return function(v)
+      return tonumber(v) == x
+    end
+  else
+    return function(v)
+      return v == x
+    end
+  end
+end
+
+--- given a string, return a function(y) which matches y against the string.
+-- @param s a string
+function seq.matching(s)
+  return function(v)
+     return strfind(v,s)
+  end
+end
+
+local nexti
+
+--- sequence adaptor for a table.   Note that if any generic function is
+-- passed a table, it will automatically use seq.list()
+-- @param t a list-like table
+-- @usage sum(list(t)) is the sum of all elements of t
+-- @usage for x in list(t) do...end
+function seq.list(t)
+  assert_arg(1,t,'table')
+  if not nexti then
+    nexti = ipairs{}
+  end
+  local key,value = 0
+  return function()
+    key,value = nexti(t,key)
+    return value
+  end
+end
+
+--- return the keys of the table.
+-- @param t an arbitrary table
+-- @return iterator over keys
+function seq.keys(t)
+  assert_arg(1,t,'table')
+  local key,value
+  return function()
+    key,value = next(t,key)
+    return key
+  end
+end
+
+local list = seq.list
+local function default_iter(iter)
+  if type(iter) == 'table' then return list(iter)
+  else return iter end
+end
+
+seq.iter = default_iter
+
+--- create an iterator over a numerical range. Like the standard Python function xrange.
+-- @param start a number
+-- @param finish a number greater than start
+function seq.range(start,finish)
+  local i = start - 1
+  return function()
+      i = i + 1
+      if i > finish then return nil
+      else return i end
+  end
+end
+
+-- count the number of elements in the sequence which satisfy the predicate
+-- @param iter a sequence
+-- @param condn a predicate function (must return either true or false)
+-- @param optional argument to be passed to predicate as second argument.
+-- @return count
+function seq.count(iter,condn,arg)
+  local i = 0
+  seq.foreach(iter,function(val)
+        if condn(val,arg) then i = i + 1 end
+  end)
+  return i
+end
+
+--- return the minimum and the maximum value of the sequence.
+-- @param iter a sequence
+-- @return minimum value
+-- @return maximum value
+function seq.minmax(iter)
+  local vmin,vmax = 1e70,-1e70
+  for v in default_iter(iter) do
+    v = tonumber(v)
+    if v < vmin then vmin = v end
+    if v > vmax then vmax = v end
+  end
+  return vmin,vmax
+end
+
+--- return the sum and element count of the sequence.
+-- @param iter a sequence
+-- @param fn an optional function to apply to the values
+function seq.sum(iter,fn)
+  local s = 0
+  local i = 0
+  for v in default_iter(iter) do
+    if fn then v = fn(v) end
+    s = s + v
+    i = i + 1
+  end
+  return s,i
+end
+
+--- create a table from the sequence. (This will make the result a List.)
+-- @param iter a sequence
+-- @return a List
+-- @usage copy(list(ls)) is equal to ls
+-- @usage copy(list {1,2,3}) == List{1,2,3}
+function seq.copy(iter)
+    local res,k = {},1
+    for v in default_iter(iter) do
+        res[k] = v
+        k = k + 1
+    end
+    setmetatable(res,_List)
+    return res
+end
+
+--- create a table of pairs from the double-valued sequence.
+-- @param iter a double-valued sequence
+-- @param i1 used to capture extra iterator values
+-- @param i2 as with pairs & ipairs
+-- @usage copy2(ipairs{10,20,30}) == {{1,10},{2,20},{3,30}}
+-- @return a list-like table
+function seq.copy2 (iter,i1,i2)
+    local res,k = {},1
+    for v1,v2 in iter,i1,i2 do
+        res[k] = {v1,v2}
+        k = k + 1
+    end
+    return res
+end
+
+--- create a table of 'tuples' from a multi-valued sequence.
+-- A generalization of copy2 above
+-- @param iter a multiple-valued sequence
+-- @return a list-like table
+function seq.copy_tuples (iter)
+    iter = default_iter(iter)
+    local res = {}
+    local row = {iter()}
+    while #row > 0 do
+        tappend(res,row)
+        row = {iter()}
+    end
+    return res
+end
+
+--- return an iterator of random numbers.
+-- @param n the length of the sequence
+-- @param l same as the first optional argument to math.random
+-- @param u same as the second optional argument to math.random
+-- @return a sequnce
+function seq.random(n,l,u)
+  local rand
+  assert(type(n) == 'number')
+  if u then
+     rand = function() return mrandom(l,u) end
+  elseif l then
+     rand = function() return mrandom(l) end
+  else
+     rand = mrandom
+  end
+
+  return function()
+     if n == 0 then return nil
+     else
+       n = n - 1
+       return rand()
+     end
+  end
+end
+
+--- return an iterator to the sorted elements of a sequence.
+-- @param iter a sequence
+-- @param comp an optional comparison function (comp(x,y) is true if x < y)
+function seq.sort(iter,comp)
+    local t = seq.copy(iter)
+    tsort(t,comp)
+    return list(t)
+end
+
+--- return an iterator which returns elements of two sequences.
+-- @param iter1 a sequence
+-- @param iter2 a sequence
+-- @usage for x,y in seq.zip(ls1,ls2) do....end
+function seq.zip(iter1,iter2)
+    iter1 = default_iter(iter1)
+    iter2 = default_iter(iter2)
+    return function()
+        return iter1(),iter2()
+    end
+end
+
+--- Makes a table where the key/values are the values and value counts of the sequence.
+-- This version works with 'hashable' values like strings and numbers.
+-- `pl.tablex.count_map` is more general.
+-- @param iter a sequence
+-- @return a map-like table
+-- @return a table
+-- @see pl.tablex.count_map
+function seq.count_map(iter)
+    local t = {}
+    local v
+    for s in default_iter(iter) do
+        v = t[s]
+        if v then t[s] = v + 1
+        else t[s] = 1 end
+    end
+    return setmetatable(t,_Map)
+end
+
+-- given a sequence, return all the unique values in that sequence.
+-- @param iter a sequence
+-- @param returns_table true if we return a table, not a sequence
+-- @return a sequence or a table; defaults to a sequence.
+function seq.unique(iter,returns_table)
+    local t = seq.count_map(iter)
+    local res,k = {},1
+    for key in pairs(t) do res[k] = key; k = k + 1 end
+    table.sort(res)
+    if returns_table then
+        return res
+    else
+        return list(res)
+    end
+end
+
+--- print out a sequence iter with a separator.
+-- @param iter a sequence
+-- @param sep the separator (default space)
+-- @param nfields maximum number of values per line (default 7)
+-- @param fmt optional format function for each value
+function seq.printall(iter,sep,nfields,fmt)
+  local write = io.write
+  if not sep then sep = ' ' end
+  if not nfields then
+      if sep == '\n' then nfields = 1e30
+      else nfields = 7 end
+  end
+  if fmt then
+    local fstr = fmt
+    fmt = function(v) return format(fstr,v) end
+  end
+  local k = 1
+  for v in default_iter(iter) do
+     if fmt then v = fmt(v) end
+     if k < nfields then
+       write(v,sep)
+       k = k + 1
+    else
+       write(v,'\n')
+       k = 1
+    end
+  end
+  write '\n'
+end
+
+-- return an iterator running over every element of two sequences (concatenation).
+-- @param iter1 a sequence
+-- @param iter2 a sequence
+function seq.splice(iter1,iter2)
+  iter1 = default_iter(iter1)
+  iter2 = default_iter(iter2)
+  local iter = iter1
+  return function()
+    local ret = iter()
+    if ret == nil then
+      if iter == iter1 then
+        iter = iter2
+        return iter()
+      else return nil end
+   else
+       return  ret
+   end
+ end
+end
+
+--- return a sequence where every element of a sequence has been transformed
+-- by a function. If you don't supply an argument, then the function will
+-- receive both values of a double-valued sequence, otherwise behaves rather like
+-- tablex.map.
+-- @param fn a function to apply to elements; may take two arguments
+-- @param iter a sequence of one or two values
+-- @param arg optional argument to pass to function.
+function seq.map(fn,iter,arg)
+    fn = function_arg(1,fn)
+    iter = default_iter(iter)
+    return function()
+        local v1,v2 = iter()
+        if v1 == nil then return nil end
+        if arg then return fn(v1,arg) or false
+        else return fn(v1,v2) or false
+        end
+    end
+end
+
+--- filter a sequence using a predicate function.
+-- @param iter a sequence of one or two values
+-- @param pred a boolean function; may take two arguments
+-- @param arg optional argument to pass to function.
+function seq.filter (iter,pred,arg)
+    pred = function_arg(2,pred)
+    return function ()
+        local v1,v2
+        while true do
+            v1,v2 = iter()
+            if v1 == nil then return nil end
+            if arg then
+                if pred(v1,arg) then return v1,v2 end
+            else
+                if pred(v1,v2) then return v1,v2 end
+            end
+        end
+    end
+end
+
+--- 'reduce' a sequence using a binary function.
+-- @param fun a function of two arguments
+-- @param iter a sequence
+-- @param oldval optional initial value
+-- @usage seq.reduce(operator.add,seq.list{1,2,3,4}) == 10
+-- @usage seq.reduce('-',{1,2,3,4,5}) == -13
+function seq.reduce (fun,iter,oldval)
+   fun = function_arg(1,fun)
+   iter = default_iter(iter)
+   if not oldval then
+       oldval = iter()
+   end
+   local val = oldval
+   for v in iter do
+       val = fun(val,v)
+   end
+   return val
+end
+
+--- take the first n values from the sequence.
+-- @param iter a sequence of one or two values
+-- @param n number of items to take
+-- @return a sequence of at most n items
+function seq.take (iter,n)
+    local i = 1
+    iter = default_iter(iter)
+    return function()
+        if i > n then return end
+        local val1,val2 = iter()
+        if not val1 then return end
+        i = i + 1
+        return val1,val2
+    end
+end
+
+--- skip the first n values of a sequence
+-- @param iter a sequence of one or more values
+-- @param n number of items to skip
+function seq.skip (iter,n)
+    n = n or 1
+    for i = 1,n do iter() end
+    return iter
+end
+
+--- a sequence with a sequence count and the original value.
+-- enum(copy(ls)) is a roundabout way of saying ipairs(ls).
+-- @param iter a single or double valued sequence
+-- @return sequence of (i,v), i = 1..n and v is from iter.
+function seq.enum (iter)
+    local i = 0
+    iter = default_iter(iter)
+    return function  ()
+        local val1,val2 = iter()
+        if not val1 then return end
+        i = i + 1
+        return i,val1,val2
+    end
+end
+
+--- map using a named method over a sequence.
+-- @param iter a sequence
+-- @param name the method name
+-- @param arg1 optional first extra argument
+-- @param arg2 optional second extra argument
+function seq.mapmethod (iter,name,arg1,arg2)
+    iter = default_iter(iter)
+    return function()
+        local val = iter()
+        if not val then return end
+        local fn = val[name]
+        if not fn then error(type(val).." does not have method "..name) end
+        return fn(val,arg1,arg2)
+    end
+end
+
+--- a sequence of (last,current) values from another sequence.
+--  This will return S(i-1),S(i) if given S(i)
+-- @param iter a sequence
+function seq.last (iter)
+    iter = default_iter(iter)
+    local l = iter()
+    if l == nil then return nil end
+    return function ()
+        local val,ll
+        val = iter()
+        if val == nil then return nil end
+        ll = l
+        l = val
+        return val,ll
+    end
+end
+
+--- call the function on each element of the sequence.
+-- @param iter a sequence with up to 3 values
+-- @param fn a function
+function seq.foreach(iter,fn)
+    fn = function_arg(2,fn)
+    for i1,i2,i3 in default_iter(iter) do fn(i1,i2,i3) end
+end
+
+---------------------- Sequence Adapters ---------------------
+
+local SMT
+
+local function SW (iter,...)
+    if callable(iter) then
+        return setmetatable({iter=iter},SMT)
+    else
+        return iter,...
+    end
+end
+
+
+-- can't directly look these up in seq because of the wrong argument order...
+local map,reduce,mapmethod = seq.map, seq.reduce, seq.mapmethod
+local overrides = {
+    map = function(self,fun,arg)
+        return map(fun,self,arg)
+    end,
+    reduce = function(self,fun)
+        return reduce(fun,self)
+    end
+}
+
+SMT = {
+    __index = function (tbl,key)
+        local fn = overrides[key] or seq[key]
+        if fn then
+            return function(sw,...) return SW(fn(sw.iter,...)) end
+        else
+            return function(sw,...) return SW(mapmethod(sw.iter,key,...)) end
+        end
+    end,
+    __call = function (sw)
+        return sw.iter()
+    end,
+}
+
+setmetatable(seq,{
+    __call = function(tbl,iter)
+        if not callable(iter) then
+            if type(iter) == 'table' then iter = seq.list(iter)
+            else return iter
+            end
+        end
+        return setmetatable({iter=iter},SMT)
+    end
+})
+
+--- create a wrapped iterator over all lines in the file.
+-- @param f either a filename, file-like object, or 'STDIN' (for standard input)
+-- @param ... for Lua 5.2 only, optional format specifiers, as in `io.read`.
+-- @return a sequence wrapper
+function seq.lines (f,...)
+    local n = select('#',...)
+    local iter,obj
+    if f == 'STDIN' then
+        f = io.stdin
+    elseif type(f) == 'string' then
+        iter,obj = io.lines(f,...)
+    elseif not f.read then
+        error("Pass either a string or a file-like object",2)
+    end
+    if not iter then
+        iter,obj = f:lines(...)
+    end
+    if obj then -- LuaJIT version returns a function operating on a file
+        local lines,file = iter,obj
+        iter = function() return lines(file) end
+    end
+    return SW(iter)
+end
+
+function seq.import ()
+    _G.debug.setmetatable(function() end,{
+        __index = function(tbl,key)
+            local s = overrides[key] or seq[key]
+            if s then return s
+            else
+                return function(s,...) return seq.mapmethod(s,key,...) end
+            end
+        end
+    })
+end
+
+return seq

--- a/lib/ext/spec-support/pl/sip.lua
+++ b/lib/ext/spec-support/pl/sip.lua
@@ -1,0 +1,341 @@
+--- Simple Input Patterns (SIP).
+-- SIP patterns start with '$', then a
+-- one-letter type, and then an optional variable in curly braces.
+--
+--    sip.match('$v=$q','name="dolly"',res)
+--    ==> res=={'name','dolly'}
+--    sip.match('($q{first},$q{second})','("john","smith")',res)
+--    ==> res=={second='smith',first='john'}
+--
+-- ''Type names''
+--
+--    v    identifier
+--    i     integer
+--    f     floating-point
+--    q    quoted string
+--    ([{<  match up to closing bracket
+--
+-- See @{08-additional.md.Simple_Input_Patterns|the Guide}
+--
+-- @module pl.sip
+
+local loadstring = rawget(_G,'loadstring') or load
+local unpack = rawget(_G,'unpack') or rawget(table,'unpack')
+
+local append,concat = table.insert,table.concat
+local ipairs,loadstring,type,unpack = ipairs,loadstring,type,unpack
+local io,_G = io,_G
+local print,rawget = print,rawget
+
+local patterns = {
+    FLOAT = '[%+%-%d]%d*%.?%d*[eE]?[%+%-]?%d*',
+    INTEGER = '[+%-%d]%d*',
+    IDEN = '[%a_][%w_]*',
+    FILE = '[%a%.\\][:%][%w%._%-\\]*',
+    OPTION = '[%a_][%w_%-]*',
+}
+
+local function assert_arg(idx,val,tp)
+    if type(val) ~= tp then
+        error("argument "..idx.." must be "..tp, 2)
+    end
+end
+
+
+--[[
+module ('pl.sip',utils._module)
+]]
+
+local sip = {}
+
+local brackets = {['<'] = '>', ['('] = ')', ['{'] = '}', ['['] = ']' }
+local stdclasses = {a=1,c=0,d=1,l=1,p=0,u=1,w=1,x=1,s=0}
+
+local _patterns = {}
+
+
+local function group(s)
+    return '('..s..')'
+end
+
+-- escape all magic characters except $, which has special meaning
+-- Also, un-escape any characters after $, so $( passes through as is.
+local function escape (spec)
+    --_G.print('spec',spec)
+    local res = spec:gsub('[%-%.%+%[%]%(%)%^%%%?%*]','%%%1'):gsub('%$%%(%S)','$%1')
+    --_G.print('res',res)
+    return res
+end
+
+local function imcompressible (s)
+    return s:gsub('%s+','\001')
+end
+
+-- [handling of spaces in patterns]
+-- spaces may be 'compressed' (i.e will match zero or more spaces)
+-- unless this occurs within a number or an identifier. So we mark
+-- the four possible imcompressible patterns first and then replace.
+-- The possible alnum patterns are v,f,a,d,x,l and u.
+local function compress_spaces (s)
+    s = s:gsub('%$[vifadxlu]%s+%$[vfadxlu]',imcompressible)
+    s = s:gsub('[%w_]%s+[%w_]',imcompressible)
+    s = s:gsub('[%w_]%s+%$[vfadxlu]',imcompressible)
+    s = s:gsub('%$[vfadxlu]%s+[%w_]',imcompressible)
+    s = s:gsub('%s+','%%s*')
+    s = s:gsub('\001',' ')
+    return s
+end
+
+local pattern_map = {
+  v = group(patterns.IDEN),
+  i = group(patterns.INTEGER),
+  f = group(patterns.FLOAT),
+  o = group(patterns.OPTION),
+  r = '(%S.*)',
+  p = '([%a]?[:]?[\\/%.%w_]+)'
+}
+
+function sip.custom_pattern(flag,patt)
+    pattern_map[flag] = patt
+end
+
+--- convert a SIP pattern into the equivalent Lua string pattern.
+-- @param spec a SIP pattern
+-- @param options a table; only the <code>at_start</code> field is
+-- currently meaningful and esures that the pattern is anchored
+-- at the start of the string.
+-- @return a Lua string pattern.
+function sip.create_pattern (spec,options)
+    assert_arg(1,spec,'string')
+    local fieldnames,fieldtypes = {},{}
+
+    if type(spec) == 'string' then
+        spec = escape(spec)
+    else
+        local res = {}
+        for i,s in ipairs(spec) do
+            res[i] = escape(s)
+        end
+        spec = concat(res,'.-')
+    end
+
+    local kount = 1
+
+    local function addfield (name,type)
+        if not name then name = kount end
+        if fieldnames then append(fieldnames,name) end
+        if fieldtypes then fieldtypes[name] = type end
+        kount = kount + 1
+    end
+
+    local named_vars, pattern
+    named_vars = spec:find('{%a+}')
+    pattern = '%$%S'
+
+    if options and options.at_start then
+        spec = '^'..spec
+    end
+    if spec:sub(-1,-1) == '$' then
+        spec = spec:sub(1,-2)..'$r'
+        if named_vars then spec = spec..'{rest}' end
+    end
+
+
+    local names
+
+    if named_vars then
+        names = {}
+        spec = spec:gsub('{(%a+)}',function(name)
+            append(names,name)
+            return ''
+        end)
+    end
+    spec = compress_spaces(spec)
+
+    local k = 1
+    local err
+    local r = (spec:gsub(pattern,function(s)
+        local type,name
+        type = s:sub(2,2)
+        if names then name = names[k]; k=k+1 end
+        -- this kludge is necessary because %q generates two matches, and
+        -- we want to ignore the first. Not a problem for named captures.
+        if not names and type == 'q' then
+            addfield(nil,'Q')
+        else
+            addfield(name,type)
+        end
+        local res
+        if pattern_map[type] then
+            res = pattern_map[type]
+        elseif type == 'q' then
+            -- some Lua pattern matching voodoo; we want to match '...' as
+            -- well as "...", and can use the fact that %n will match a
+            -- previous capture. Adding the extra field above comes from needing
+            -- to accomodate the extra spurious match (which is either ' or ")
+            addfield(name,type)
+            res = '(["\'])(.-)%'..(kount-2)
+        else
+            local endbracket = brackets[type]
+            if endbracket then
+                res = '(%b'..type..endbracket..')'
+            elseif stdclasses[type] or stdclasses[type:lower()] then
+                res = '(%'..type..'+)'
+            else
+                err = "unknown format type or character class"
+            end
+        end
+        return res
+    end))
+    --print(r,err)
+    if err then
+        return nil,err
+    else
+        return r,fieldnames,fieldtypes
+    end
+end
+
+
+local function tnumber (s)
+    return s == 'd' or s == 'i' or s == 'f'
+end
+
+function sip.create_spec_fun(spec,options)
+    local fieldtypes,fieldnames
+    local ls = {}
+    spec,fieldnames,fieldtypes = sip.create_pattern(spec,options)
+    if not spec then return spec,fieldnames end
+    local named_vars = type(fieldnames[1]) == 'string'
+    for i = 1,#fieldnames do
+        append(ls,'mm'..i)
+    end
+    local fun = ('return (function(s,res)\n\tlocal %s = s:match(%q)\n'):format(concat(ls,','),spec)
+    fun = fun..'\tif not mm1 then return false end\n'
+    local k=1
+    for i,f in ipairs(fieldnames) do
+        if f ~= '_' then
+            local var = 'mm'..i
+            if tnumber(fieldtypes[f]) then
+                var = 'tonumber('..var..')'
+            elseif brackets[fieldtypes[f]] then
+                var = var..':sub(2,-2)'
+            end
+            if named_vars then
+                fun = ('%s\tres.%s = %s\n'):format(fun,f,var)
+            else
+                if fieldtypes[f] ~= 'Q' then -- we skip the string-delim capture
+                    fun = ('%s\tres[%d] = %s\n'):format(fun,k,var)
+                    k = k + 1
+                end
+            end
+        end
+    end
+    return fun..'\treturn true\nend)\n', named_vars
+end
+
+--- convert a SIP pattern into a matching function.
+-- The returned function takes two arguments, the line and an empty table.
+-- If the line matched the pattern, then this function return true
+-- and the table is filled with field-value pairs.
+-- @param spec a SIP pattern
+-- @param options optional table; {anywhere=true} will stop pattern anchoring at start
+-- @return a function if successful, or nil,<error>
+function sip.compile(spec,options)
+    assert_arg(1,spec,'string')
+    local fun,names = sip.create_spec_fun(spec,options)
+    if not fun then return nil,names end
+    if rawget(_G,'_DEBUG') then print(fun) end
+    local chunk,err = loadstring(fun,'tmp')
+    if err then return nil,err end
+    return chunk(),names
+end
+
+local cache = {}
+
+--- match a SIP pattern against a string.
+-- @param spec a SIP pattern
+-- @param line a string
+-- @param res a table to receive values
+-- @param options (optional) option table
+-- @return true or false
+function sip.match (spec,line,res,options)
+    assert_arg(1,spec,'string')
+    assert_arg(2,line,'string')
+    assert_arg(3,res,'table')
+    if not cache[spec] then
+        cache[spec] = sip.compile(spec,options)
+    end
+    return cache[spec](line,res)
+end
+
+--- match a SIP pattern against the start of a string.
+-- @param spec a SIP pattern
+-- @param line a string
+-- @param res a table to receive values
+-- @return true or false
+function sip.match_at_start (spec,line,res)
+    return sip.match(spec,line,res,{at_start=true})
+end
+
+--- given a pattern and a file object, return an iterator over the results
+-- @param spec a SIP pattern
+-- @param f a file - use standard input if not specified.
+function sip.fields (spec,f)
+    assert_arg(1,spec,'string')
+    f = f or io.stdin
+    local fun,err = sip.compile(spec)
+    if not fun then return nil,err end
+    local res = {}
+    return function()
+        while true do
+            local line = f:read()
+            if not line then return end
+            if fun(line,res) then
+                local values = res
+                res = {}
+                return unpack(values)
+            end
+        end
+    end
+end
+
+--- register a match which will be used in the read function.
+-- @param spec a SIP pattern
+-- @param fun a function to be called with the results of the match
+-- @see read
+function sip.pattern (spec,fun)
+    assert_arg(1,spec,'string')
+    local pat,named = sip.compile(spec)
+    append(_patterns,{pat=pat,named=named,callback=fun or false})
+end
+
+--- enter a loop which applies all registered matches to the input file.
+-- @param f a file object; if nil, then io.stdin is assumed.
+function sip.read (f)
+    local owned,err
+    f = f or io.stdin
+    if type(f) == 'string' then
+        f,err = io.open(f)
+        if not f then return nil,err end
+        owned = true
+    end
+    local res = {}
+    for line in f:lines() do
+        for _,item in ipairs(_patterns) do
+            if item.pat(line,res) then
+                if item.callback then
+                    if item.named then
+                        item.callback(res)
+                    else
+                        item.callback(unpack(res))
+                    end
+                end
+                res = {}
+                break
+            end
+        end
+    end
+    if owned then f:close() end
+end
+
+return sip

--- a/lib/ext/spec-support/pl/strict.lua
+++ b/lib/ext/spec-support/pl/strict.lua
@@ -1,0 +1,102 @@
+--- Checks uses of undeclared global variables.
+-- All global variables must be 'declared' through a regular assignment
+-- (even assigning `nil` will do) in a main chunk before being used
+-- anywhere or assigned to inside a function.  Existing metatables `__newindex` and `__index`
+-- metamethods are respected.
+--
+-- You can set any table to have strict behaviour using `strict.module`
+--
+-- @module pl.strict
+
+require 'debug' -- for Lua 5.2
+local getinfo, error, rawset, rawget = debug.getinfo, error, rawset, rawget
+local strict = {}
+
+local function what ()
+    local d = getinfo(3, "S")
+    return d and d.what or "C"
+end
+
+--- make an existing table strict.
+-- @param name name of table (optional)
+-- @param mod table - if `nil` then we'll return a new table
+-- @param predeclared - table of variables that are to be considered predeclared.
+-- @return the given table, or a new table
+function strict.module (name,mod,predeclared)
+    local mt, old_newindex, old_index, global, closed
+    if predeclared then
+        global = predeclared.__global
+        closed = predeclared.__closed
+    end
+    if type(mod) == 'table' then
+        mt = getmetatable(mod)
+        if mt and rawget(mt,'__declared') then return end -- already patched...
+    else
+        mod = {}
+    end
+    if mt == nil then
+        mt = {}
+        setmetatable(mod, mt)
+    else
+        old_newindex = mt.__newindex
+        old_index = mt.__index
+    end
+    mt.__declared = predeclared or {}
+    mt.__newindex = function(t, n, v)
+        if old_newindex then
+            old_newindex(t, n, v)
+            if rawget(t,n)~=nil then return end
+        end
+        if not mt.__declared[n] then
+            if global then
+                local w = what()
+                if w ~= "main" and w ~= "C" then
+                    error("assign to undeclared global '"..n.."'", 2)
+                end
+            end
+            mt.__declared[n] = true
+        end
+        rawset(t, n, v)
+    end
+    mt.__index = function(t,n)
+        if not mt.__declared[n] and what() ~= "C" then
+            if old_index then
+                local res = old_index(t, n)
+                if res then return res end
+            end
+            local msg = "variable '"..n.."' is not declared"
+            if name then
+                msg = msg .. " in '"..name.."'"
+            end
+            error(msg, 2)
+        end
+        return rawget(t, n)
+    end
+    return mod
+end
+
+function strict.make_all_strict (T)
+    for k,v in pairs(T) do
+        if type(v) == 'table' and v ~= T then
+            strict.module(k,v)
+        end
+    end
+end
+
+function strict.closed_module (mod,name)
+    local M = {}
+    local mt = getmetatable(mod)
+    if not mt then
+        mt = {}
+        setmetatable(mod,mt)
+    end
+    mt.__newindex = function(t,k,v)
+        M[k] = v
+    end
+    return strict.module(name,M)
+end
+
+strict.module(nil,_G,{_PROMPT=true,__global=true})
+
+return strict
+

--- a/lib/ext/spec-support/pl/stringio.lua
+++ b/lib/ext/spec-support/pl/stringio.lua
@@ -1,0 +1,155 @@
+--- Reading and writing strings using file-like objects. <br>
+--
+--    f = stringio.open(text)
+--    l1 = f:read()  -- read first line
+--    n,m = f:read ('*n','*n') -- read two numbers
+--    for line in f:lines() do print(line) end -- iterate over all lines
+--    f = stringio.create()
+--    f:write('hello')
+--    f:write('dolly')
+--    assert(f:value(),'hellodolly')
+--
+-- See  @{03-strings.md.File_style_I_O_on_Strings|the Guide}.
+-- @module pl.stringio
+
+local unpack = rawget(_G,'unpack') or rawget(table,'unpack')
+local getmetatable,tostring,tonumber = getmetatable,tostring,tonumber
+local concat,append = table.concat,table.insert
+
+local stringio = {}
+
+-- Writer class
+local SW = {}
+SW.__index = SW
+
+local function xwrite(self,...)
+    local args = {...} --arguments may not be nil!
+    for i = 1, #args do
+        append(self.tbl,args[i])
+    end
+end
+
+function SW:write(arg1,arg2,...)
+    if arg2 then
+        xwrite(self,arg1,arg2,...)
+    else
+        append(self.tbl,arg1)
+    end
+end
+
+function SW:writef(fmt,...)
+    self:write(fmt:format(...))
+end
+
+function SW:value()
+    return concat(self.tbl)
+end
+
+function SW:__tostring()
+    return self:value()
+end
+
+function SW:close() -- for compatibility only
+end
+
+function SW:seek()
+end
+
+-- Reader class
+local SR = {}
+SR.__index = SR
+
+function SR:_read(fmt)
+    local i,str = self.i,self.str
+    local sz = #str
+    if i > sz then return nil end
+    local res
+    if fmt == '*l' or fmt == '*L' then
+        local idx = str:find('\n',i) or (sz+1)
+        res = str:sub(i,fmt == '*l' and idx-1 or idx)
+        self.i = idx+1
+    elseif fmt == '*a' then
+        res = str:sub(i)
+        self.i = sz
+    elseif fmt == '*n' then
+        local _,i2,i2,idx
+        _,idx = str:find ('%s*%d+',i)
+        _,i2 = str:find ('^%.%d+',idx+1)
+        if i2 then idx = i2 end
+        _,i2 = str:find ('^[eE][%+%-]*%d+',idx+1)
+        if i2 then idx = i2 end
+        local val = str:sub(i,idx)
+        res = tonumber(val)
+        self.i = idx+1
+    elseif type(fmt) == 'number' then
+        res = str:sub(i,i+fmt-1)
+        self.i = i + fmt
+    else
+        error("bad read format",2)
+    end
+    return res
+end
+
+function SR:read(...)
+    if select('#',...) == 0 then
+        return self:_read('*l')
+    else
+        local res, fmts = {},{...}
+        for i = 1, #fmts do
+            res[i] = self:_read(fmts[i])
+        end
+        return unpack(res)
+    end
+end
+
+function SR:seek(whence,offset)
+    local base
+    whence = whence or 'cur'
+    offset = offset or 0
+    if whence == 'set' then
+        base = 1
+    elseif whence == 'cur' then
+        base = self.i
+    elseif whence == 'end' then
+        base = #self.str
+    end
+    self.i = base + offset
+    return self.i
+end
+
+function SR:lines(...)
+    local n, args = select('#',...)
+    if n > 0 then
+        args = {...}
+    end
+    return function()
+        if n == 0 then
+            return self:_read '*l'
+        else
+            return self:read(unpack(args))
+        end
+    end
+end
+
+function SR:close() -- for compatibility only
+end
+
+--- create a file-like object which can be used to construct a string.
+-- The resulting object has an extra <code>value()</code> method for
+-- retrieving the string value.
+-- @usage f = create(); f:write('hello, dolly\n'); print(f:value())
+function stringio.create()
+    return setmetatable({tbl={}},SW)
+end
+
+--- create a file-like object for reading from a given string.
+-- @param s The input string.
+function stringio.open(s)
+    return setmetatable({str=s,i=1},SR)
+end
+
+function stringio.lines(s,...)
+    return stringio.open(s):lines(...)
+end
+
+return stringio

--- a/lib/ext/spec-support/pl/stringx.lua
+++ b/lib/ext/spec-support/pl/stringx.lua
@@ -1,0 +1,462 @@
+--- Python-style extended string library.
+--
+-- see 3.6.1 of the Python reference.
+-- If you want to make these available as string methods, then say
+-- `stringx.import()` to bring them into the standard `string` table.
+--
+-- See @{03-strings.md|the Guide}
+--
+-- Dependencies: `pl.utils`
+-- @module pl.stringx
+local utils = require 'pl.utils'
+local string = string
+local find = string.find
+local type,setmetatable,getmetatable,ipairs,unpack = type,setmetatable,getmetatable,ipairs,utils.unpack
+local error,tostring = error,tostring
+local gsub = string.gsub
+local rep = string.rep
+local sub = string.sub
+local concat = table.concat
+local escape = utils.escape
+local ceil = math.ceil
+local _G = _G
+local assert_arg,usplit,list_MT = utils.assert_arg,utils.split,utils.stdmt.List
+local lstrip
+
+local function assert_string (n,s)
+    assert_arg(n,s,'string')
+end
+
+local function non_empty(s)
+    return #s > 0
+end
+
+local function assert_nonempty_string(n,s)
+    assert_arg(n,s,'string',non_empty,'must be a non-empty string')
+end
+
+local stringx = {}
+
+------------------
+-- String Predicates
+-- @section predicates
+
+--- does s only contain alphabetic characters?.
+-- @param s a string
+function stringx.isalpha(s)
+    assert_string(1,s)
+    return find(s,'^%a+$') == 1
+end
+
+--- does s only contain digits?.
+-- @param s a string
+function stringx.isdigit(s)
+    assert_string(1,s)
+    return find(s,'^%d+$') == 1
+end
+
+--- does s only contain alphanumeric characters?.
+-- @param s a string
+function stringx.isalnum(s)
+    assert_string(1,s)
+    return find(s,'^%w+$') == 1
+end
+
+--- does s only contain spaces?.
+-- @param s a string
+function stringx.isspace(s)
+    assert_string(1,s)
+    return find(s,'^%s+$') == 1
+end
+
+--- does s only contain lower case characters?.
+-- @param s a string
+function stringx.islower(s)
+    assert_string(1,s)
+    return find(s,'^[%l%s]+$') == 1
+end
+
+--- does s only contain upper case characters?.
+-- @param s a string
+function stringx.isupper(s)
+    assert_string(1,s)
+    return find(s,'^[%u%s]+$') == 1
+end
+
+--- does string start with the substring?.
+-- @param self the string
+-- @param s2 a string
+function stringx.startswith(self,s2)
+    assert_string(1,self)
+    assert_string(2,s2)
+    return find(self,s2,1,true) == 1
+end
+
+local function _find_all(s,sub,first,last)
+    if sub == '' then return #s+1,#s end
+    local i1,i2 = find(s,sub,first,true)
+    local res
+    local k = 0
+    while i1 do
+        res = i1
+        k = k + 1
+        i1,i2 = find(s,sub,i2+1,true)
+        if last and i1 > last then break end
+    end
+    return res,k
+end
+
+--- does string end with the given substring?.
+-- @param s a string
+-- @param send a substring or a table of suffixes
+function stringx.endswith(s,send)
+    assert_string(1,s)
+    if type(send) == 'string' then
+        return #s >= #send and s:find(send, #s-#send+1, true) and true or false
+    elseif type(send) == 'table' then
+        local endswith = stringx.endswith
+        for _,suffix in ipairs(send) do
+            if endswith(s,suffix) then return true end
+        end
+        return false
+    else
+        error('argument #2: either a substring or a table of suffixes expected')
+    end
+end
+
+--- Strings and Lists
+-- @section lists
+
+--- concatenate the strings using this string as a delimiter.
+-- @param self the string
+-- @param seq a table of strings or numbers
+-- @usage (' '):join {1,2,3} == '1 2 3'
+function stringx.join (self,seq)
+    assert_string(1,self)
+    return concat(seq,self)
+end
+
+--- break string into a list of lines
+-- @param self the string
+-- @param keepends (currently not used)
+function stringx.splitlines (self,keepends)
+    assert_string(1,self)
+    local res = usplit(self,'[\r\n]')
+    -- we are currently hacking around a problem with utils.split (see stringx.split)
+    if #res == 0 then res = {''} end
+    return setmetatable(res,list_MT)
+end
+
+--- split a string into a list of strings using a delimiter.
+-- @class function
+-- @name split
+-- @param self the string
+-- @param re a delimiter (defaults to whitespace)
+-- @param n maximum number of results
+-- @usage #(('one two'):split()) == 2
+-- @usage ('one,two,three'):split(',') == List{'one','two','three'}
+-- @usage ('one,two,three'):split(',',2) == List{'one','two,three'}
+function stringx.split(self,re,n)
+    local s = self
+    local plain = true
+    if not re then -- default spaces
+        s = lstrip(s)
+        plain = false
+    end
+    local res = usplit(s,re,plain,n)
+    if re and re ~= '' and find(s,re,-#re,true) then
+        res[#res+1] = ""
+    end
+	return setmetatable(res,list_MT)
+end
+
+local function tab_expand (self,n)
+    return (gsub(self,'([^\t]*)\t', function(s)
+            return s..(' '):rep(n - #s % n)
+    end))
+end
+
+--- replace all tabs in s with n spaces. If not specified, n defaults to 8.
+-- with 0.9.5 this now correctly expands to the next tab stop (if you really
+-- want to just replace tabs, use :gsub('\t','  ') etc)
+-- @param self the string
+-- @param n number of spaces to expand each tab, (default 8)
+function stringx.expandtabs(self,n)
+    assert_string(1,self)
+    n = n or 8
+    if not self:find '\n' then return tab_expand(self,n) end
+    local res,i = {},1
+    for line in stringx.lines(self) do
+        res[i] = tab_expand(line,n)
+        i = i + 1
+    end
+    return table.concat(res,'\n')
+end
+
+--- Finding and Replacing
+-- @section find
+
+--- find index of first instance of sub in s from the left.
+-- @param self the string
+-- @param sub substring
+-- @param  i1 start index
+function stringx.lfind(self,sub,i1)
+    assert_string(1,self)
+    assert_string(2,sub)
+    local idx = find(self,sub,i1,true)
+    if idx then return idx else return nil end
+end
+
+--- find index of first instance of sub in s from the right.
+-- @param self the string
+-- @param sub substring
+-- @param first first index
+-- @param last last index
+function stringx.rfind(self,sub,first,last)
+    assert_string(1,self)
+    assert_string(2,sub)
+    local idx = _find_all(self,sub,first,last)
+    if idx then return idx else return nil end
+end
+
+--- replace up to n instances of old by new in the string s.
+-- if n is not present, replace all instances.
+-- @param s the string
+-- @param old the target substring
+-- @param new the substitution
+-- @param n optional maximum number of substitutions
+-- @return result string
+-- @return the number of substitutions
+function stringx.replace(s,old,new,n)
+    assert_string(1,s)
+    assert_string(1,old)
+    return (gsub(s,escape(old),new:gsub('%%','%%%%'),n))
+end
+
+local function copy(self)
+    return self..''
+end
+
+--- count all instances of substring in string.
+-- @param self the string
+-- @param sub substring
+function stringx.count(self,sub)
+    assert_string(1,self)
+    local i,k = _find_all(self,sub,1)
+    return k
+end
+
+--- Stripping and Justifying
+-- @section strip
+
+local function _just(s,w,ch,left,right)
+    local n = #s
+    if w > n then
+        if not ch then ch = ' ' end
+        local f1,f2
+        if left and right then
+            local ln = ceil((w-n)/2)
+            local rn = w - n - ln
+            f1 = rep(ch,ln)
+            f2 = rep(ch,rn)
+        elseif right then
+            f1 = rep(ch,w-n)
+            f2 = ''
+        else
+            f2 = rep(ch,w-n)
+            f1 = ''
+        end
+        return f1..s..f2
+    else
+        return copy(s)
+    end
+end
+
+--- left-justify s with width w.
+-- @param self the string
+-- @param w width of justification
+-- @param ch padding character, default ' '
+function stringx.ljust(self,w,ch)
+    assert_string(1,self)
+    assert_arg(2,w,'number')
+    return _just(self,w,ch,true,false)
+end
+
+--- right-justify s with width w.
+-- @param s the string
+-- @param w width of justification
+-- @param ch padding character, default ' '
+function stringx.rjust(s,w,ch)
+    assert_string(1,s)
+    assert_arg(2,w,'number')
+    return _just(s,w,ch,false,true)
+end
+
+--- center-justify s with width w.
+-- @param s the string
+-- @param w width of justification
+-- @param ch padding character, default ' '
+function stringx.center(s,w,ch)
+    assert_string(1,s)
+    assert_arg(2,w,'number')
+    return _just(s,w,ch,true,true)
+end
+
+local function _strip(s,left,right,chrs)
+    if not chrs then
+        chrs = '%s'
+    else
+        chrs = '['..escape(chrs)..']'
+    end
+    if left then
+        local i1,i2 = find(s,'^'..chrs..'*')
+        if i2 >= i1 then
+            s = sub(s,i2+1)
+        end
+    end
+    if right then
+        local i1,i2 = find(s,chrs..'*$')
+        if i2 >= i1 then
+            s = sub(s,1,i1-1)
+        end
+    end
+    return s
+end
+
+--- trim any whitespace on the left of s.
+-- @param self the string
+-- @param chrs default any whitespace character (%s),
+--             can be a string of characters to be trimmed
+function stringx.lstrip(self,chrs)
+    assert_string(1,self)
+    return _strip(self,true,false,chrs)
+end
+lstrip = stringx.lstrip
+
+--- trim any whitespace on the right of s.
+-- @param s the string
+-- @param chrs default any whitespace character (%s),
+--             can be a string of characters to be trimmed
+function stringx.rstrip(s,chrs)
+    assert_string(1,s)
+    return _strip(s,false,true,chrs)
+end
+
+--- trim any whitespace on both left and right of s.
+-- @param self the string
+-- @param chrs default any whitespace character (%s),
+--             can be a string of characters to be trimmed
+function stringx.strip(self,chrs)
+    assert_string(1,self)
+    return _strip(self,true,true,chrs)
+end
+
+--- Partioning Strings
+-- @section partioning
+
+--- split a string using a pattern. Note that at least one value will be returned!
+-- @param self the string
+-- @param re a Lua string pattern (defaults to whitespace)
+-- @return the parts of the string
+-- @usage  a,b = line:splitv('=')
+function stringx.splitv (self,re)
+    assert_string(1,self)
+    return utils.splitv(self,re)
+end
+
+-- The partition functions split a string  using a delimiter into three parts:
+-- the part before, the delimiter itself, and the part afterwards
+local function _partition(p,delim,fn)
+    local i1,i2 = fn(p,delim)
+    if not i1 or i1 == -1 then
+        return p,'',''
+    else
+        if not i2 then i2 = i1 end
+        return sub(p,1,i1-1),sub(p,i1,i2),sub(p,i2+1)
+    end
+end
+
+--- partition the string using first occurance of a delimiter
+-- @param self the string
+-- @param ch delimiter
+-- @return part before ch
+-- @return ch
+-- @return part after ch
+function stringx.partition(self,ch)
+    assert_string(1,self)
+    assert_nonempty_string(2,ch)
+    return _partition(self,ch,stringx.lfind)
+end
+
+--- partition the string p using last occurance of a delimiter
+-- @param self the string
+-- @param ch delimiter
+-- @return part before ch
+-- @return ch
+-- @return part after ch
+function stringx.rpartition(self,ch)
+    assert_string(1,self)
+    assert_nonempty_string(2,ch)
+    return _partition(self,ch,stringx.rfind)
+end
+
+--- return the 'character' at the index.
+-- @param self the string
+-- @param idx an index (can be negative)
+-- @return a substring of length 1 if successful, empty string otherwise.
+function stringx.at(self,idx)
+    assert_string(1,self)
+    assert_arg(2,idx,'number')
+    return sub(self,idx,idx)
+end
+
+--- Miscelaneous
+-- @section misc
+
+--- return an interator over all lines in a string
+-- @param self the string
+-- @return an iterator
+function stringx.lines (self)
+    assert_string(1,self)
+    local s = self
+    if not s:find '\n$' then s = s..'\n' end
+    return s:gmatch('([^\n]*)\n')
+end
+
+--- iniital word letters uppercase ('title case').
+-- Here 'words' mean chunks of non-space characters.
+-- @param self the string
+-- @return a string with each word's first letter uppercase
+function stringx.title(self)
+    return (self:gsub('(%S)(%S*)',function(f,r)
+        return f:upper()..r:lower()
+    end))
+end
+
+stringx.capitalize = stringx.title
+
+local elipsis = '...'
+local n_elipsis = #elipsis
+
+--- return a shorted version of a string.
+-- @param self the string
+-- @param sz the maxinum size allowed
+-- @param tail true if we want to show the end of the string (head otherwise)
+function stringx.shorten(self,sz,tail)
+    if #self > sz then
+        if sz < n_elipsis then return elipsis:sub(1,sz) end
+        if tail then
+            local i = #self - sz + 1 + n_elipsis
+            return elipsis .. self:sub(i)
+        else
+            return self:sub(1,sz-n_elipsis) .. elipsis
+        end
+    end
+    return self
+end
+
+function stringx.import(dont_overload)
+    utils.import(stringx,string)
+end
+
+return stringx

--- a/lib/ext/spec-support/pl/tablex.lua
+++ b/lib/ext/spec-support/pl/tablex.lua
@@ -1,0 +1,859 @@
+--- Extended operations on Lua tables.
+--
+-- See @{02-arrays.md.Useful_Operations_on_Tables|the Guide}
+--
+-- Dependencies: `pl.utils`, `pl.types`
+-- @module pl.tablex
+local utils = require ('pl.utils')
+local types = require ('pl.types')
+local getmetatable,setmetatable,require = getmetatable,setmetatable,require
+local tsort,append,remove = table.sort,table.insert,table.remove
+local min,max = math.min,math.max
+local pairs,type,unpack,next,select,tostring = pairs,type,utils.unpack,next,select,tostring
+local function_arg = utils.function_arg
+local Set = utils.stdmt.Set
+local List = utils.stdmt.List
+local Map = utils.stdmt.Map
+local assert_arg = utils.assert_arg
+
+local tablex = {}
+
+-- generally, functions that make copies of tables try to preserve the metatable.
+-- However, when the source has no obvious type, then we attach appropriate metatables
+-- like List, Map, etc to the result.
+local function setmeta (res,tbl,def)
+    local mt = getmetatable(tbl) or def
+    return setmetatable(res, mt)
+end
+
+local function makelist (res)
+    return setmetatable(res,List)
+end
+
+local function complain (idx,msg)
+    error(('argument %d is not %s'):format(idx,msg),3)
+end
+
+local function assert_arg_indexable (idx,val)
+    if not types.is_indexable(val) then
+        complain(idx,"indexable")
+    end
+end
+
+local function assert_arg_iterable (idx,val)
+    if not types.is_iterable(val) then
+        complain(idx,"iterable")
+    end
+end
+
+local function assert_arg_writeable (idx,val)
+    if not types.is_writeable(val) then
+        complain(idx,"writeable")
+    end
+end
+
+--- copy a table into another, in-place.
+-- @param t1 destination table
+-- @param t2 source (any iterable object)
+-- @return first table
+function tablex.update (t1,t2)
+    assert_arg_writeable(1,t1)
+    assert_arg_iterable(2,t2)
+    for k,v in pairs(t2) do
+        t1[k] = v
+    end
+    return t1
+end
+
+--- total number of elements in this table.
+-- Note that this is distinct from `#t`, which is the number
+-- of values in the array part; this value will always
+-- be greater or equal. The difference gives the size of
+-- the hash part, for practical purposes. Works for any
+-- object with a __pairs metamethod.
+-- @param t a table
+-- @return the size
+function tablex.size (t)
+    assert_arg_iterable(1,t)
+    local i = 0
+    for k in pairs(t) do i = i + 1 end
+    return i
+end
+
+--- make a shallow copy of a table
+-- @param t an iterable source
+-- @return new table
+function tablex.copy (t)
+    assert_arg_iterable(1,t)
+    local res = {}
+    for k,v in pairs(t) do
+        res[k] = v
+    end
+    return res
+end
+
+--- make a deep copy of a table, recursively copying all the keys and fields.
+-- This will also set the copied table's metatable to that of the original.
+--  @param t A table
+-- @return new table
+function tablex.deepcopy(t)
+    if type(t) ~= 'table' then return t end
+    assert_arg_iterable(1,t)
+    local mt = getmetatable(t)
+    local res = {}
+    for k,v in pairs(t) do
+        if type(v) == 'table' then
+            v = tablex.deepcopy(v)
+        end
+        res[k] = v
+    end
+    setmetatable(res,mt)
+    return res
+end
+
+local abs, deepcompare = math.abs
+
+--- compare two values.
+-- if they are tables, then compare their keys and fields recursively.
+-- @param t1 A value
+-- @param t2 A value
+-- @param ignore_mt if true, ignore __eq metamethod (default false)
+-- @param eps if defined, then used for any number comparisons
+-- @return true or false
+function tablex.deepcompare(t1,t2,ignore_mt,eps)
+    local ty1 = type(t1)
+    local ty2 = type(t2)
+    if ty1 ~= ty2 then return false end
+    -- non-table types can be directly compared
+    if ty1 ~= 'table' then
+        if ty1 == 'number' and eps then return abs(t1-t2) < eps end
+        return t1 == t2
+    end
+    -- as well as tables which have the metamethod __eq
+    local mt = getmetatable(t1)
+    if not ignore_mt and mt and mt.__eq then return t1 == t2 end
+    for k1 in pairs(t1) do
+        if t2[k1]==nil then return false end
+    end
+    for k2 in pairs(t2) do
+        if t1[k2]==nil then return false end
+    end
+    for k1,v1 in pairs(t1) do
+        local v2 = t2[k1]
+        if not deepcompare(v1,v2,ignore_mt,eps) then return false end
+    end
+
+    return true
+end
+
+deepcompare = tablex.deepcompare
+
+--- compare two arrays using a predicate.
+-- @param t1 an array
+-- @param t2 an array
+-- @param cmp A comparison function
+function tablex.compare (t1,t2,cmp)
+    assert_arg_indexable(1,t1)
+    assert_arg_indexable(2,t2)
+    if #t1 ~= #t2 then return false end
+    cmp = function_arg(3,cmp)
+    for k = 1,#t1 do
+        if not cmp(t1[k],t2[k]) then return false end
+    end
+    return true
+end
+
+--- compare two list-like tables using an optional predicate, without regard for element order.
+-- @param t1 a list-like table
+-- @param t2 a list-like table
+-- @param cmp A comparison function (may be nil)
+function tablex.compare_no_order (t1,t2,cmp)
+    assert_arg_indexable(1,t1)
+    assert_arg_indexable(2,t2)
+    if cmp then cmp = function_arg(3,cmp) end
+    if #t1 ~= #t2 then return false end
+    local visited = {}
+    for i = 1,#t1 do
+        local val = t1[i]
+        local gotcha
+        for j = 1,#t2 do if not visited[j] then
+            local match
+            if cmp then match = cmp(val,t2[j]) else match = val == t2[j] end
+            if match then
+                gotcha = j
+                break
+            end
+        end end
+        if not gotcha then return false end
+        visited[gotcha] = true
+    end
+    return true
+end
+
+
+--- return the index of a value in a list.
+-- Like string.find, there is an optional index to start searching,
+-- which can be negative.
+-- @param t A list-like table (i.e. with numerical indices)
+-- @param val A value
+-- @param idx index to start; -1 means last element,etc (default 1)
+-- @return index of value or nil if not found
+-- @usage find({10,20,30},20) == 2
+-- @usage find({'a','b','a','c'},'a',2) == 3
+function tablex.find(t,val,idx)
+    assert_arg_indexable(1,t)
+    idx = idx or 1
+    if idx < 0 then idx = #t + idx + 1 end
+    for i = idx,#t do
+        if t[i] == val then return i end
+    end
+    return nil
+end
+
+--- return the index of a value in a list, searching from the end.
+-- Like string.find, there is an optional index to start searching,
+-- which can be negative.
+-- @param t A list-like table (i.e. with numerical indices)
+-- @param val A value
+-- @param idx index to start; -1 means last element,etc (default 1)
+-- @return index of value or nil if not found
+-- @usage rfind({10,10,10},10) == 3
+function tablex.rfind(t,val,idx)
+    assert_arg_indexable(1,t)
+    idx = idx or #t
+    if idx < 0 then idx = #t + idx + 1 end
+    for i = idx,1,-1 do
+        if t[i] == val then return i end
+    end
+    return nil
+end
+
+
+--- return the index (or key) of a value in a table using a comparison function.
+-- @param t A table
+-- @param cmp A comparison function
+-- @param arg an optional second argument to the function
+-- @return index of value, or nil if not found
+-- @return value returned by comparison function
+function tablex.find_if(t,cmp,arg)
+    assert_arg_iterable(1,t)
+    cmp = function_arg(2,cmp)
+    for k,v in pairs(t) do
+        local c = cmp(v,arg)
+        if c then return k,c end
+    end
+    return nil
+end
+
+--- return a list of all values in a table indexed by another list.
+-- @param tbl a table
+-- @param idx an index table (a list of keys)
+-- @return a list-like table
+-- @usage index_by({10,20,30,40},{2,4}) == {20,40}
+-- @usage index_by({one=1,two=2,three=3},{'one','three'}) == {1,3}
+function tablex.index_by(tbl,idx)
+    assert_arg_indexable(1,tbl)
+    assert_arg_indexable(2,idx)
+    local res = {}
+    for i = 1,#idx do
+        res[i] = tbl[idx[i]]
+    end
+    return setmeta(res,tbl,List)
+end
+
+--- apply a function to all values of a table.
+-- This returns a table of the results.
+-- Any extra arguments are passed to the function.
+-- @param fun A function that takes at least one argument
+-- @param t A table
+-- @param ... optional arguments
+-- @usage map(function(v) return v*v end, {10,20,30,fred=2}) is {100,400,900,fred=4}
+function tablex.map(fun,t,...)
+    assert_arg_iterable(1,t)
+    fun = function_arg(1,fun)
+    local res = {}
+    for k,v in pairs(t) do
+        res[k] = fun(v,...)
+    end
+    return setmeta(res,t)
+end
+
+--- apply a function to all values of a list.
+-- This returns a table of the results.
+-- Any extra arguments are passed to the function.
+-- @param fun A function that takes at least one argument
+-- @param t a table (applies to array part)
+-- @param ... optional arguments
+-- @return a list-like table
+-- @usage imap(function(v) return v*v end, {10,20,30,fred=2}) is {100,400,900}
+function tablex.imap(fun,t,...)
+    assert_arg_indexable(1,t)
+    fun = function_arg(1,fun)
+    local res = {}
+    for i = 1,#t do
+        res[i] = fun(t[i],...) or false
+    end
+    return setmeta(res,t,List)
+end
+
+--- apply a named method to values from a table.
+-- @param name the method name
+-- @param t a list-like table
+-- @param ... any extra arguments to the method
+function tablex.map_named_method (name,t,...)
+    utils.assert_string(1,name)
+    assert_arg_indexable(2,t)
+    local res = {}
+    for i = 1,#t do
+        local val = t[i]
+        local fun = val[name]
+        res[i] = fun(val,...)
+    end
+    return setmeta(res,t,List)
+end
+
+
+--- apply a function to all values of a table, in-place.
+-- Any extra arguments are passed to the function.
+-- @param fun A function that takes at least one argument
+-- @param t a table
+-- @param ... extra arguments
+function tablex.transform (fun,t,...)
+    assert_arg_iterable(1,t)
+    fun = function_arg(1,fun)
+    for k,v in pairs(t) do
+        t[k] = fun(v,...)
+    end
+end
+
+--- generate a table of all numbers in a range
+-- @param start  number
+-- @param finish number
+-- @param step optional increment (default 1 for increasing, -1 for decreasing)
+function tablex.range (start,finish,step)
+    if start == finish then return {start}
+    elseif start > finish then return {}
+    end
+    local res = {}
+    local k = 1
+    if not step then
+        if finish > start then step = finish > start and 1 or -1 end
+    end
+    for i=start,finish,step do res[k]=i; k=k+1 end
+    return res
+end
+
+--- apply a function to values from two tables.
+-- @param fun a function of at least two arguments
+-- @param t1 a table
+-- @param t2 a table
+-- @param ... extra arguments
+-- @return a table
+-- @usage map2('+',{1,2,3,m=4},{10,20,30,m=40}) is {11,22,23,m=44}
+function tablex.map2 (fun,t1,t2,...)
+    assert_arg_iterable(1,t1)
+    assert_arg_iterable(2,t2)
+    fun = function_arg(1,fun)
+    local res = {}
+    for k,v in pairs(t1) do
+        res[k] = fun(v,t2[k],...)
+    end
+    return setmeta(res,t1,List)
+end
+
+--- apply a function to values from two arrays.
+-- The result will be the length of the shortest array.
+-- @param fun a function of at least two arguments
+-- @param t1 a list-like table
+-- @param t2 a list-like table
+-- @param ... extra arguments
+-- @usage imap2('+',{1,2,3,m=4},{10,20,30,m=40}) is {11,22,23}
+function tablex.imap2 (fun,t1,t2,...)
+    assert_arg_indexable(2,t1)
+    assert_arg_indexable(3,t2)
+    fun = function_arg(1,fun)
+    local res,n = {},math.min(#t1,#t2)
+    for i = 1,n do
+        res[i] = fun(t1[i],t2[i],...)
+    end
+    return res
+end
+
+--- 'reduce' a list using a binary function.
+-- @param fun a function of two arguments
+-- @param t a list-like table
+-- @return the result of the function
+-- @usage reduce('+',{1,2,3,4}) == 10
+function tablex.reduce (fun,t)
+    assert_arg_indexable(2,t)
+    fun = function_arg(1,fun)
+    local n = #t
+    local res = t[1]
+    for i = 2,n do
+        res = fun(res,t[i])
+    end
+    return res
+end
+
+--- apply a function to all elements of a table.
+-- The arguments to the function will be the value,
+-- the key and <i>finally</i> any extra arguments passed to this function.
+-- Note that the Lua 5.0 function table.foreach passed the <i>key</i> first.
+-- @param t a table
+-- @param fun a function with at least one argument
+-- @param ... extra arguments
+function tablex.foreach(t,fun,...)
+    assert_arg_iterable(1,t)
+    fun = function_arg(2,fun)
+    for k,v in pairs(t) do
+        fun(v,k,...)
+    end
+end
+
+--- apply a function to all elements of a list-like table in order.
+-- The arguments to the function will be the value,
+-- the index and <i>finally</i> any extra arguments passed to this function
+-- @param t a table
+-- @param fun a function with at least one argument
+-- @param ... optional arguments
+function tablex.foreachi(t,fun,...)
+    assert_arg_indexable(1,t)
+    fun = function_arg(2,fun)
+    for i = 1,#t do
+        fun(t[i],i,...)
+    end
+end
+
+
+--- Apply a function to a number of tables.
+-- A more general version of map
+-- The result is a table containing the result of applying that function to the
+-- ith value of each table. Length of output list is the minimum length of all the lists
+-- @param fun a function of n arguments
+-- @param ... n tables
+-- @usage mapn(function(x,y,z) return x+y+z end, {1,2,3},{10,20,30},{100,200,300}) is {111,222,333}
+-- @usage mapn(math.max, {1,20,300},{10,2,3},{100,200,100}) is	{100,200,300}
+-- @param fun A function that takes as many arguments as there are tables
+function tablex.mapn(fun,...)
+    fun = function_arg(1,fun)
+    local res = {}
+    local lists = {...}
+    local minn = 1e40
+    for i = 1,#lists do
+        minn = min(minn,#(lists[i]))
+    end
+    for i = 1,minn do
+        local args,k = {},1
+        for j = 1,#lists do
+            args[k] = lists[j][i]
+            k = k + 1
+        end
+        res[#res+1] = fun(unpack(args))
+    end
+    return res
+end
+
+--- call the function with the key and value pairs from a table.
+-- The function can return a value and a key (note the order!). If both
+-- are not nil, then this pair is inserted into the result. If only value is not nil, then
+-- it is appended to the result.
+-- @param fun A function which will be passed each key and value as arguments, plus any extra arguments to pairmap.
+-- @param t A table
+-- @param ... optional arguments
+-- @usage pairmap(function(k,v) return v end,{fred=10,bonzo=20}) is {10,20} _or_ {20,10}
+-- @usage pairmap(function(k,v) return {k,v},k end,{one=1,two=2}) is {one={'one',1},two={'two',2}}
+function tablex.pairmap(fun,t,...)
+    assert_arg_iterable(1,t)
+    fun = function_arg(1,fun)
+    local res = {}
+    for k,v in pairs(t) do
+        local rv,rk = fun(k,v,...)
+        if rk then
+            res[rk] = rv
+        else
+            res[#res+1] = rv
+        end
+    end
+    return res
+end
+
+local function keys_op(i,v) return i end
+
+--- return all the keys of a table in arbitrary order.
+--  @param t A table
+function tablex.keys(t)
+    assert_arg_iterable(1,t)
+    return makelist(tablex.pairmap(keys_op,t))
+end
+
+local function values_op(i,v) return v end
+
+--- return all the values of the table in arbitrary order
+--  @param t A table
+function tablex.values(t)
+    assert_arg_iterable(1,t)
+    return makelist(tablex.pairmap(values_op,t))
+end
+
+local function index_map_op (i,v) return i,v end
+
+--- create an index map from a list-like table. The original values become keys,
+-- and the associated values are the indices into the original list.
+-- @param t a list-like table
+-- @return a map-like table
+function tablex.index_map (t)
+    assert_arg_indexable(1,t)
+    return setmetatable(tablex.pairmap(index_map_op,t),Map)
+end
+
+local function set_op(i,v) return true,v end
+
+--- create a set from a list-like table. A set is a table where the original values
+-- become keys, and the associated values are all true.
+-- @param t a list-like table
+-- @return a set (a map-like table)
+function tablex.makeset (t)
+    assert_arg_indexable(1,t)
+    return setmetatable(tablex.pairmap(set_op,t),Set)
+end
+
+
+--- combine two tables, either as union or intersection. Corresponds to
+-- set operations for sets () but more general. Not particularly
+-- useful for list-like tables.
+-- @param t1 a table
+-- @param t2 a table
+-- @param dup true for a union, false for an intersection.
+-- @usage merge({alice=23,fred=34},{bob=25,fred=34}) is {fred=34}
+-- @usage merge({alice=23,fred=34},{bob=25,fred=34},true) is {bob=25,fred=34,alice=23}
+-- @see tablex.index_map
+function tablex.merge (t1,t2,dup)
+    assert_arg_iterable(1,t1)
+    assert_arg_iterable(2,t2)
+    local res = {}
+    for k,v in pairs(t1) do
+        if dup or t2[k] then res[k] = v end
+    end
+    if dup then
+      for k,v in pairs(t2) do
+        res[k] = v
+      end
+    end
+    return setmeta(res,t1,Map)
+end
+
+--- a new table which is the difference of two tables.
+-- With sets (where the values are all true) this is set difference and
+-- symmetric difference depending on the third parameter.
+-- @param s1 a map-like table or set
+-- @param s2 a map-like table or set
+-- @param symm symmetric difference (default false)
+-- @return a map-like table or set
+function tablex.difference (s1,s2,symm)
+    assert_arg_iterable(1,s1)
+    assert_arg_iterable(2,s2)
+    local res = {}
+    for k,v in pairs(s1) do
+        if s2[k] == nil then res[k] = v end
+    end
+    if symm then
+        for k,v in pairs(s2) do
+            if s1[k] == nil then res[k] = v end
+        end
+    end
+    return setmeta(res,s1,Map)
+end
+
+--- A table where the key/values are the values and value counts of the table.
+-- @param t a list-like table
+-- @param cmp a function that defines equality (otherwise uses ==)
+-- @return a map-like table
+-- @see seq.count_map
+function tablex.count_map (t,cmp)
+    assert_arg_indexable(1,t)
+    local res,mask = {},{}
+    cmp = function_arg(2,cmp)
+    local n = #t
+    for i = 1,#t do
+        local v = t[i]
+        if not mask[v] then
+            mask[v] = true
+            -- check this value against all other values
+            res[v] = 1  -- there's at least one instance
+            for j = i+1,n do
+                local w = t[j]
+                if cmp and cmp(v,w) or v == w then
+                    res[v] = res[v] + 1
+                    mask[w] = true
+                end
+            end
+        end
+    end
+    return setmetatable(res,Map)
+end
+
+--- filter a table's values using a predicate function
+-- @param t a list-like table
+-- @param pred a boolean function
+-- @param arg optional argument to be passed as second argument of the predicate
+function tablex.filter (t,pred,arg)
+    assert_arg_indexable(1,t)
+    pred = function_arg(2,pred)
+    local res,k = {},1
+    for i = 1,#t do
+        local v = t[i]
+        if pred(v,arg) then
+            res[k] = v
+            k = k + 1
+        end
+    end
+    return setmeta(res,t,List)
+end
+
+--- return a table where each element is a table of the ith values of an arbitrary
+-- number of tables. It is equivalent to a matrix transpose.
+-- @usage zip({10,20,30},{100,200,300}) is {{10,100},{20,200},{30,300}}
+function tablex.zip(...)
+    return tablex.mapn(function(...) return {...} end,...)
+end
+
+local _copy
+function _copy (dest,src,idest,isrc,nsrc,clean_tail)
+    idest = idest or 1
+    isrc = isrc or 1
+    local iend
+    if not nsrc then
+        nsrc = #src
+        iend = #src
+    else
+        iend = isrc + min(nsrc-1,#src-isrc)
+    end
+    if dest == src then -- special case
+        if idest > isrc and iend >= idest then -- overlapping ranges
+            src = tablex.sub(src,isrc,nsrc)
+            isrc = 1; iend = #src
+        end
+    end
+    for i = isrc,iend do
+        dest[idest] = src[i]
+        idest = idest + 1
+    end
+    if clean_tail then
+        tablex.clear(dest,idest)
+    end
+    return dest
+end
+
+--- copy an array into another one, clearing dest after idest+nsrc, if necessary. <br>
+-- @param dest a list-like table
+-- @param src a list-like table
+-- @param idest where to start copying values into destination (default 1)
+-- @param isrc where to start copying values from source (default 1)
+-- @param nsrc number of elements to copy from source (default source size)
+function tablex.icopy (dest,src,idest,isrc,nsrc)
+    assert_arg_indexable(1,dest)
+    assert_arg_indexable(2,src)
+    return _copy(dest,src,idest,isrc,nsrc,true)
+end
+
+--- copy an array into another one. <br>
+-- @param dest a list-like table
+-- @param src a list-like table
+-- @param idest where to start copying values into destination (default 1)
+-- @param isrc where to start copying values from source (default 1)
+-- @param nsrc number of elements to copy from source (default source size)
+function tablex.move (dest,src,idest,isrc,nsrc)
+    assert_arg_indexable(1,dest)
+    assert_arg_indexable(2,src)
+    return _copy(dest,src,idest,isrc,nsrc,false)
+end
+
+function tablex._normalize_slice(self,first,last)
+  local sz = #self
+  if not first then first=1 end
+  if first<0 then first=sz+first+1 end
+  -- make the range _inclusive_!
+  if not last then last=sz end
+  if last < 0 then last=sz+1+last end
+  return first,last
+end
+
+--- Extract a range from a table, like  'string.sub'.
+-- If first or last are negative then they are relative to the end of the list
+-- eg. sub(t,-2) gives last 2 entries in a list, and
+-- sub(t,-4,-2) gives from -4th to -2nd
+-- @param t a list-like table
+-- @param first An index
+-- @param last An index
+-- @return a new List
+function tablex.sub(t,first,last)
+    assert_arg_indexable(1,t)
+    first,last = tablex._normalize_slice(t,first,last)
+    local res={}
+    for i=first,last do append(res,t[i]) end
+    return setmeta(res,t,List)
+end
+
+--- set an array range to a value. If it's a function we use the result
+-- of applying it to the indices.
+-- @param t a list-like table
+-- @param val a value
+-- @param i1 start range (default 1)
+-- @param i2 end range (default table size)
+function tablex.set (t,val,i1,i2)
+    assert_arg_indexable(1,t)
+    i1,i2 = i1 or 1,i2 or #t
+    if types.is_callable(val) then
+        for i = i1,i2 do
+            t[i] = val(i)
+        end
+    else
+        for i = i1,i2 do
+            t[i] = val
+        end
+    end
+end
+
+--- create a new array of specified size with initial value.
+-- @param n size
+-- @param val initial value (can be nil, but don't expect # to work!)
+-- @return the table
+function tablex.new (n,val)
+    local res = {}
+    tablex.set(res,val,1,n)
+    return res
+end
+
+--- clear out the contents of a table.
+-- @param t a table
+-- @param istart optional start position
+function tablex.clear(t,istart)
+    istart = istart or 1
+    for i = istart,#t do remove(t) end
+end
+
+--- insert values into a table. <br>
+-- insertvalues(t, [pos,] values) <br>
+-- similar to table.insert but inserts values from given table "values",
+-- not the object itself, into table "t" at position "pos".
+function tablex.insertvalues(t, ...)
+    assert_arg(1,t,'table')
+    local pos, values
+    if select('#', ...) == 1 then
+        pos,values = #t+1, ...
+    else
+        pos,values = ...
+    end
+    if #values > 0 then
+        for i=#t,pos,-1 do
+            t[i+#values] = t[i]
+        end
+        local offset = 1 - pos
+        for i=pos,pos+#values-1 do
+            t[i] = values[i + offset]
+        end
+    end
+    return t
+end
+
+--- remove a range of values from a table.
+-- @param t a list-like table
+-- @param i1 start index
+-- @param i2 end index
+-- @return the table
+function tablex.removevalues (t,i1,i2)
+    assert_arg(1,t,'table')
+    i1,i2 = tablex._normalize_slice(t,i1,i2)
+    for i = i1,i2 do
+        remove(t,i1)
+    end
+    return t
+end
+
+local _find
+_find = function (t,value,tables)
+    for k,v in pairs(t) do
+        if v == value then return k end
+    end
+    for k,v in pairs(t) do
+        if not tables[v] and type(v) == 'table' then
+            tables[v] = true
+            local res = _find(v,value,tables)
+            if res then
+                res = tostring(res)
+                if type(k) ~= 'string' then
+                    return '['..k..']'..res
+                else
+                    return k..'.'..res
+                end
+            end
+        end
+    end
+end
+
+--- find a value in a table by recursive search.
+-- @param t the table
+-- @param value the value
+-- @param exclude any tables to avoid searching
+-- @usage search(_G,math.sin,{package.path}) == 'math.sin'
+-- @return a fieldspec, e.g. 'a.b' or 'math.sin'
+function tablex.search (t,value,exclude)
+    assert_arg_iterable(1,t)
+    local tables = {[t]=true}
+    if exclude then
+        for _,v in pairs(exclude) do tables[v] = true end
+    end
+    return _find(t,value,tables)
+end
+
+--- return an iterator to a table sorted by its keys
+-- @param t the table
+-- @param f an optional comparison function (f(x,y) is true if x < y)
+-- @usage for k,v in tablex.sort(t) do print(k,v) end
+-- @return an iterator to traverse elements sorted by the keys
+function tablex.sort(t,f)
+   local keys = {}
+   for k in pairs(t) do keys[#keys + 1] = k end
+   tsort(keys,f)
+   local i = 0
+   return function()
+      i = i + 1
+      return keys[i], t[keys[i]]
+   end
+end
+
+--- return an iterator to a table sorted by its values
+-- @param t the table
+-- @param f an optional comparison function (f(x,y) is true if x < y)
+-- @usage for k,v in tablex.sortv(t) do print(k,v) end
+-- @return an iterator to traverse elements sorted by the values
+function tablex.sortv(t,f)
+   local rev = {}
+   for k,v in pairs(t) do rev[v] = k end
+   local next = tablex.sort(rev,f)
+   return function()
+      local value,key = next()
+      return key,value
+   end
+end
+
+--- modifies a table to be read only.
+-- This only offers weak protection. Tables can still be modified with
+-- table.insert and rawset.
+-- @param t the table
+-- @return the table read only.
+function tablex.readonly(t)
+    local mt = {
+        __index=t,
+        __newindex=function(t, k, v) error("Attempt to modify read-only table", 2) end,
+        __pairs=function() return pairs(t) end,
+        __ipairs=function() return ipairs(t) end,
+        __len=function() return #t end,
+        __metatable=false
+    }
+    return setmetatable({}, mt)
+end
+
+
+
+return tablex

--- a/lib/ext/spec-support/pl/template.lua
+++ b/lib/ext/spec-support/pl/template.lua
@@ -1,0 +1,103 @@
+--- A template preprocessor.
+-- Originally by [Ricki Lake](http://lua-users.org/wiki/SlightlyLessSimpleLuaPreprocessor)
+--
+-- There are two rules:
+--
+--  * lines starting with # are Lua
+--  * otherwise, `$(expr)` is the result of evaluating `expr`
+--
+-- Example:
+--
+--    #  for i = 1,3 do
+--       $(i) Hello, Word!
+--    #  end
+--    ===>
+--    1 Hello, Word!
+--    2 Hello, Word!
+--    3 Hello, Word!
+--
+-- Other escape characters can be used, when the defaults conflict
+-- with the output language.
+--
+--    > for _,n in pairs{'one','two','three'} do
+--    static int l_${n} (luaState *state);
+--    > end
+--
+-- See  @{03-strings.md.Another_Style_of_Template|the Guide}.
+--
+-- Dependencies: `pl.utils`
+-- @module pl.template
+
+local utils = require 'pl.utils'
+local append,format = table.insert,string.format
+
+local function parseHashLines(chunk,brackets,esc)
+    local exec_pat = "()$(%b"..brackets..")()"
+
+    local function parseDollarParen(pieces, chunk, s, e)
+        local s = 1
+        for term, executed, e in chunk:gmatch (exec_pat) do
+            executed = '('..executed:sub(2,-2)..')'
+            append(pieces,
+              format("%q..(%s or '')..",chunk:sub(s, term - 1), executed))
+            s = e
+        end
+        append(pieces, format("%q", chunk:sub(s)))
+    end
+
+    local esc_pat = esc.."+([^\n]*\n?)"
+    local esc_pat1, esc_pat2 = "^"..esc_pat, "\n"..esc_pat
+    local  pieces, s = {"return function(_put) ", n = 1}, 1
+    while true do
+        local ss, e, lua = chunk:find (esc_pat1, s)
+        if not e then
+            ss, e, lua = chunk:find(esc_pat2, s)
+            append(pieces, "_put(")
+            parseDollarParen(pieces, chunk:sub(s, ss))
+            append(pieces, ")")
+            if not e then break end
+        end
+        append(pieces, lua)
+        s = e + 1
+    end
+    append(pieces, " end")
+    return table.concat(pieces)
+end
+
+local template = {}
+
+--- expand the template using the specified environment.
+-- @param str the template string
+-- @param env the environment (by default empty). <br>
+-- There are three special fields in the environment table <ul>
+-- <li><code>_parent</code> continue looking up in this table</li>
+-- <li><code>_brackets</code>; default is '()', can be any suitable bracket pair</li>
+-- <li><code>_escape</code>; default is '#' </li>
+-- </ul>
+function template.substitute(str,env)
+    env = env or {}
+    if rawget(env,"_parent") then
+        setmetatable(env,{__index = env._parent})
+    end
+    local brackets = rawget(env,"_brackets") or '()'
+    local escape = rawget(env,"_escape") or '#'
+    local code = parseHashLines(str,brackets,escape)
+    local fn,err = utils.load(code,'TMP','t',env)
+    if not fn then return nil,err end
+    fn = fn()
+    local out = {}
+    local res,err = xpcall(function() fn(function(s)
+        out[#out+1] = s
+    end) end,debug.traceback)
+    if not res then
+        if env._debug then print(code) end
+        return nil,err
+    end
+    return table.concat(out)
+end
+
+return template
+
+
+
+

--- a/lib/ext/spec-support/pl/test.lua
+++ b/lib/ext/spec-support/pl/test.lua
@@ -1,0 +1,146 @@
+--- Useful test utilities.
+--
+--    test.asserteq({1,2},{1,2}) -- can compare tables
+--    test.asserteq(1.2,1.19,0.02) -- compare FP numbers within precision
+--    T = test.tuple -- used for comparing multiple results
+--    test.asserteq(T(string.find(" me","me")),T(2,3))
+--
+-- Dependencies: `pl.utils`, `pl.tablex`, `pl.pretty`, `pl.path`, `debug`
+-- @module pl.test
+
+local tablex = require 'pl.tablex'
+local utils = require 'pl.utils'
+local pretty = require 'pl.pretty'
+local path = require 'pl.path'
+local print,type,unpack = print,type,utils.pack
+local clock = os.clock
+local debug = require 'debug'
+local io,debug = io,debug
+
+local function dump(x)
+    if type(x) == 'table' and not (getmetatable(x) and getmetatable(x).__tostring) then
+        return pretty.write(x,' ',true)
+    elseif type(x) == 'string' then
+        return '"'..x..'"'
+    else
+        return tostring(x)
+    end
+end
+
+local test = {}
+
+local function complain (x,y,msg,where)
+    local i = debug.getinfo(3 + (where or 0))
+    local err = io.stderr
+    err:write(path.basename(i.short_src)..':'..i.currentline..': assertion failed\n')
+    err:write("got:\t",dump(x),'\n')
+    err:write("needed:\t",dump(y),'\n')
+    utils.quit(1,msg or "these values were not equal")
+end
+
+--- general test complain message.
+-- Useful for composing new test functions (see tests/tablex.lua for an example)
+-- @param x a value
+-- @param y value to compare first value against
+-- @param msg message
+-- @param where extra level offset for errors
+-- @function complain
+test.complain = complain
+
+--- like assert, except takes two arguments that must be equal and can be tables.
+-- If they are plain tables, it will use tablex.deepcompare.
+-- @param x any value
+-- @param y a value equal to x
+-- @param eps an optional tolerance for numerical comparisons
+-- @param where extra level offset
+function test.asserteq (x,y,eps,where)
+    local res = x == y
+    if not res then
+        res = tablex.deepcompare(x,y,true,eps)
+    end
+    if not res then
+        complain(x,y,nil,where)
+    end
+end
+
+--- assert that the first string matches the second.
+-- @param s1 a string
+-- @param s2 a string
+-- @param where extra level offset
+function test.assertmatch (s1,s2,where)
+    if not s1:match(s2) then
+        complain (s1,s2,"these strings did not match",where)
+    end
+end
+
+--- assert that the function raises a particular error.
+-- @param fn a function or a table of the form {function,arg1,...}
+-- @param e a string to match the error against
+-- @param where extra level offset
+function test.assertraise(fn,e,where)
+    local ok, err
+    if type(fn) == 'table' then
+        ok, err = pcall(unpack(fn))
+    else
+        ok, err = pcall(fn)
+    end
+    if not err or err:match(e)==nil then
+        complain (err,e,"these errors did not match",where)
+    end
+end
+
+--- a version of asserteq that takes two pairs of values.
+-- <code>x1==y1 and x2==y2</code> must be true. Useful for functions that naturally
+-- return two values.
+-- @param x1 any value
+-- @param x2 any value
+-- @param y1 any value
+-- @param y2 any value
+-- @param where extra level offset
+function test.asserteq2 (x1,x2,y1,y2,where)
+    if x1 ~= y1 then complain(x1,y1,nil,where) end
+    if x2 ~= y2 then complain(x2,y2,nil,where) end
+end
+
+-- tuple type --
+
+local tuple_mt = {}
+
+function tuple_mt.__tostring(self)
+    local ts = {}
+    for i=1, self.n do
+        local s = self[i]
+        ts[i] = type(s) == 'string' and ('%q'):format(s) or tostring(s)
+    end
+    return 'tuple(' .. table.concat(ts, ', ') .. ')'
+end
+
+function tuple_mt.__eq(a, b)
+    if a.n ~= b.n then return false end
+    for i=1, a.n do
+        if a[i] ~= b[i] then return false end
+    end
+    return true
+end
+
+--- encode an arbitrary argument list as a tuple.
+-- This can be used to compare to other argument lists, which is
+-- very useful for testing functions which return a number of values.
+-- @usage asserteq(tuple( ('ab'):find 'a'), tuple(1,1))
+function test.tuple(...)
+    return setmetatable(table.pack(...), tuple_mt)
+end
+
+--- Time a function. Call the function a given number of times, and report the number of seconds taken,
+-- together with a message.  Any extra arguments will be passed to the function.
+-- @param msg a descriptive message
+-- @param n number of times to call the function
+-- @param fun the function
+-- @param ... optional arguments to fun
+function test.timer(msg,n,fun,...)
+    local start = clock()
+    for i = 1,n do fun(...) end
+    utils.printf("%s: took %7.2f sec\n",msg,clock()-start)
+end
+
+return test

--- a/lib/ext/spec-support/pl/text.lua
+++ b/lib/ext/spec-support/pl/text.lua
@@ -1,0 +1,245 @@
+--- Text processing utilities.
+--
+-- This provides a Template class (modeled after the same from the Python
+-- libraries, see string.Template). It also provides similar functions to those
+-- found in the textwrap module.
+--
+-- See  @{03-strings.md.String_Templates|the Guide}.
+--
+-- Calling `text.format_operator()` overloads the % operator for strings to give Python/Ruby style formated output.
+-- This is extended to also do template-like substitution for map-like data.
+--
+--    > require 'pl.text'.format_operator()
+--    > = '%s = %5.3f' % {'PI',math.pi}
+--    PI = 3.142
+--    > = '$name = $value' % {name='dog',value='Pluto'}
+--    dog = Pluto
+--
+-- Dependencies: `pl.utils`, `pl.types`
+-- @module pl.text
+
+local gsub = string.gsub
+local concat,append = table.concat,table.insert
+local utils = require 'pl.utils'
+local bind1,usplit,assert_arg = utils.bind1,utils.split,utils.assert_arg
+local is_callable = require 'pl.types'.is_callable
+local unpack = utils.unpack
+
+local function lstrip(str)  return (str:gsub('^%s+',''))  end
+local function strip(str)  return (lstrip(str):gsub('%s+$','')) end
+local function make_list(l)  return setmetatable(l,utils.stdmt.List) end
+local function split(s,delim)  return make_list(usplit(s,delim)) end
+
+local function imap(f,t,...)
+    local res = {}
+    for i = 1,#t do res[i] = f(t[i],...) end
+    return res
+end
+
+--[[
+module ('pl.text',utils._module)
+]]
+
+local text = {}
+
+local function _indent (s,sp)
+    local sl = split(s,'\n')
+    return concat(imap(bind1('..',sp),sl),'\n')..'\n'
+end
+
+--- indent a multiline string.
+-- @param s the string
+-- @param n the size of the indent
+-- @param ch the character to use when indenting (default ' ')
+-- @return indented string
+function text.indent (s,n,ch)
+    assert_arg(1,s,'string')
+    assert_arg(2,n,'number')
+    return _indent(s,string.rep(ch or ' ',n))
+end
+
+--- dedent a multiline string by removing any initial indent.
+-- useful when working with [[..]] strings.
+-- @param s the string
+-- @return a string with initial indent zero.
+function text.dedent (s)
+    assert_arg(1,s,'string')
+    local sl = split(s,'\n')
+    local i1,i2 = sl[1]:find('^%s*')
+    sl = imap(string.sub,sl,i2+1)
+    return concat(sl,'\n')..'\n'
+end
+
+--- format a paragraph into lines so that they fit into a line width.
+-- It will not break long words, so lines can be over the length
+-- to that extent.
+-- @param s the string
+-- @param width the margin width, default 70
+-- @return a list of lines
+function text.wrap (s,width)
+    assert_arg(1,s,'string')
+    width = width or 70
+    s = s:gsub('\n',' ')
+    local i,nxt = 1
+    local lines,line = {}
+    while i < #s do
+        nxt = i+width
+        if s:find("[%w']",nxt) then -- inside a word
+            nxt = s:find('%W',nxt+1) -- so find word boundary
+        end
+        line = s:sub(i,nxt)
+        i = i + #line
+        append(lines,strip(line))
+    end
+    return make_list(lines)
+end
+
+--- format a paragraph so that it fits into a line width.
+-- @param s the string
+-- @param width the margin width, default 70
+-- @return a string
+-- @see wrap
+function text.fill (s,width)
+    return concat(text.wrap(s,width),'\n') .. '\n'
+end
+
+local Template = {}
+text.Template = Template
+Template.__index = Template
+setmetatable(Template, {
+    __call = function(obj,tmpl)
+        return Template.new(tmpl)
+    end})
+
+function Template.new(tmpl)
+    assert_arg(1,tmpl,'string')
+    local res = {}
+    res.tmpl = tmpl
+    setmetatable(res,Template)
+    return res
+end
+
+local function _substitute(s,tbl,safe)
+    local subst
+    if is_callable(tbl) then
+        subst = tbl
+    else
+        function subst(f)
+            local s = tbl[f]
+            if not s then
+                if safe then
+                    return f
+                else
+                    error("not present in table "..f)
+                end
+            else
+                return s
+            end
+        end
+    end
+    local res = gsub(s,'%${([%w_]+)}',subst)
+    return (gsub(res,'%$([%w_]+)',subst))
+end
+
+--- substitute values into a template, throwing an error.
+-- This will throw an error if no name is found.
+-- @param tbl a table of name-value pairs.
+function Template:substitute(tbl)
+    assert_arg(1,tbl,'table')
+    return _substitute(self.tmpl,tbl,false)
+end
+
+--- substitute values into a template.
+-- This version just passes unknown names through.
+-- @param tbl a table of name-value pairs.
+function Template:safe_substitute(tbl)
+    assert_arg(1,tbl,'table')
+    return _substitute(self.tmpl,tbl,true)
+end
+
+--- substitute values into a template, preserving indentation. <br>
+-- If the value is a multiline string _or_ a template, it will insert
+-- the lines at the correct indentation. <br>
+-- Furthermore, if a template, then that template will be subsituted
+-- using the same table.
+-- @param tbl a table of name-value pairs.
+function Template:indent_substitute(tbl)
+    assert_arg(1,tbl,'table')
+    if not self.strings then
+        self.strings = split(self.tmpl,'\n')
+    end
+    -- the idea is to substitute line by line, grabbing any spaces as
+    -- well as the $var. If the value to be substituted contains newlines,
+    -- then we split that into lines and adjust the indent before inserting.
+    local function subst(line)
+        return line:gsub('(%s*)%$([%w_]+)',function(sp,f)
+			local subtmpl
+            local s = tbl[f]
+            if not s then error("not present in table "..f) end
+			if getmetatable(s) == Template then
+				subtmpl = s
+				s = s.tmpl
+			else
+				s = tostring(s)
+			end
+            if s:find '\n' then
+                s = _indent(s,sp)
+            end
+			if subtmpl then return _substitute(s,tbl)
+			else return s
+			end
+        end)
+    end
+    local lines = imap(subst,self.strings)
+    return concat(lines,'\n')..'\n'
+end
+
+------- Python-style formatting operator ------
+-- (see <a href="http://lua-users.org/wiki/StringInterpolation">the lua-users wiki</a>) --
+
+function text.format_operator()
+
+    local format = string.format
+
+    -- a more forgiving version of string.format, which applies
+    -- tostring() to any value with a %s format.
+    local function formatx (fmt,...)
+        local args = {...}
+        local i = 1
+        for p in fmt:gmatch('%%.') do
+            if p == '%s' and type(args[i]) ~= 'string' then
+                args[i] = tostring(args[i])
+            end
+            i = i + 1
+        end
+        return format(fmt,unpack(args))
+    end
+
+    local function basic_subst(s,t)
+        return (s:gsub('%$([%w_]+)',t))
+    end
+
+    -- Note this goes further than the original, and will allow these cases:
+    -- 1. a single value
+    -- 2. a list of values
+    -- 3. a map of var=value pairs
+    -- 4. a function, as in gsub
+    -- For the second two cases, it uses $-variable substituion.
+    getmetatable("").__mod = function(a, b)
+        if b == nil then
+            return a
+        elseif type(b) == "table" and getmetatable(b) == nil then
+            if #b == 0 then -- assume a map-like table
+                return _substitute(a,b,true)
+            else
+                return formatx(a,unpack(b))
+            end
+        elseif type(b) == 'function' then
+            return basic_subst(a,b)
+        else
+            return formatx(a,b)
+        end
+    end
+end
+
+return text

--- a/lib/ext/spec-support/pl/types.lua
+++ b/lib/ext/spec-support/pl/types.lua
@@ -1,0 +1,143 @@
+---- Dealing with Detailed Type Information
+
+-- Dependencies `pl.utils`
+-- @module pl.types
+
+local utils = require 'pl.utils'
+local types = {}
+
+--- is the object either a function or a callable object?.
+-- @param obj Object to check.
+function types.is_callable (obj)
+    return type(obj) == 'function' or getmetatable(obj) and getmetatable(obj).__call
+end
+
+--- is the object of the specified type?.
+-- If the type is a string, then use type, otherwise compare with metatable
+-- @param obj An object to check
+-- @param tp String of what type it should be
+-- @function is_type
+types.is_type = utils.is_type
+
+local fileMT = getmetatable(io.stdout)
+
+--- a string representation of a type.
+-- For tables with metatables, we assume that the metatable has a `_name`
+-- field. Knows about Lua file objects.
+-- @param obj an object
+-- @return a string like 'number', 'table' or 'List'
+function types.type (obj)
+    local t = type(obj)
+    if t == 'table' or t == 'userdata' then
+        local mt = getmetatable(obj)
+        if mt == fileMT then
+            return 'file'
+        else
+            return mt._name or "unknown "..t
+        end
+    else
+        return t
+    end
+end
+
+--- is this number an integer?
+-- @param x a number
+-- @raise error if x is not a number
+function types.is_integer (x)
+    return math.ceil(x)==x
+end
+
+--- Check if the object is "empty".
+-- An object is considered empty if it is nil, a table with out any items (key,
+-- value pairs or indexes), or a string with no content ("").
+-- @param o The object to check if it is empty.
+-- @param ignore_spaces If the object is a string and this is true the string is
+-- considered empty is it only contains spaces.
+-- @return true if the object is empty, otherwise false.
+function types.is_empty(o, ignore_spaces)
+    if o == nil or (type(o) == "table" and not next(o)) or (type(o) == "string" and (o == "" or (ignore_spaces and o:match("^%s+$")))) then
+        return true
+    end
+    return false
+end
+
+local function check_meta (val)
+    if type(val) == 'table' then return true end
+    return getmetatable(val)
+end
+
+--- is an object 'array-like'?
+-- @param val any value.
+function types.is_indexable (val)
+    local mt = check_meta(val)
+    if mt == true then return true end
+    return not(mt and mt.__len and mt.__index)
+end
+
+--- can an object be iterated over with `ipairs`?
+-- @param val any value.
+function types.is_iterable (val)
+    local mt = check_meta(val)
+    if mt == true then return true end
+    return not(mt and mt.__pairs)
+end
+
+--- can an object accept new key/pair values?
+-- @param val any value.
+function types.is_writeable (val)
+    local mt = check_meta(val)
+    if mt == true then return true end
+    return not(mt and mt.__newindex)
+end
+
+-- Strings that should evaluate to true.
+local trues = { yes=true, y=true, ["true"]=true, t=true, ["1"]=true }
+-- Conditions types should evaluate to true.
+local true_types = {
+    boolean=function(o, true_strs, check_objs) return o end,
+    string=function(o, true_strs, check_objs)
+        if trues[o:lower()] then
+            return true
+        end
+        -- Check alternative user provided strings.
+        for _,v in ipairs(true_strs or {}) do
+            if type(v) == "string" and o == v:lower() then
+                return true
+            end
+        end
+        return false
+    end,
+    number=function(o, true_strs, check_objs) return o ~= 0 end,
+    table=function(o, true_strs, check_objs) if check_objs and next(o) ~= nil then return true end return false end
+}
+--- Convert to a boolean value.
+-- True values are:
+--
+-- * boolean: true.
+-- * string: 'yes', 'y', 'true', 't', '1' or additional strings specified by `true_strs`.
+-- * number: Any non-zero value.
+-- * table: Is not empty and `check_objs` is true.
+-- * object: Is not `nil` and `check_objs` is true.
+--
+-- @param o The object to evaluate.
+-- @param[opt] true_strs optional Additional strings that when matched should evaluate to true. Comparison is case insensitive.
+-- This should be a List of strings. E.g. "ja" to support German.
+-- @param[opt] check_objs True if objects should be evaluated. Default is to evaluate objects as true if not nil
+-- or if it is a table and it is not empty.
+-- @return true if the input evaluates to true, otherwise false.
+function types.to_bool(o, true_strs, check_objs)
+    local true_func
+    if true_strs then
+        utils.assert_arg(2, true_strs, "table")
+    end
+    true_func = true_types[type(o)]
+    if true_func then
+        return true_func(o, true_strs, check_objs)
+    elseif check_objs and o ~= nil then
+        return true
+    end
+    return false
+end
+
+
+return types

--- a/lib/ext/spec-support/pl/utils.lua
+++ b/lib/ext/spec-support/pl/utils.lua
@@ -1,0 +1,475 @@
+--- Generally useful routines.
+-- See  @{01-introduction.md.Generally_useful_functions|the Guide}.
+-- @module pl.utils
+local format,gsub,byte = string.format,string.gsub,string.byte
+local compat = require 'pl.compat'
+local clock = os.clock
+local stdout = io.stdout
+local append = table.insert
+local unpack = rawget(_G,'unpack') or rawget(table,'unpack')
+
+local collisions = {}
+
+local utils = {
+    _VERSION = "1.2.1",
+    lua51 = compat.lua51,
+    setfenv = compat.setfenv,
+    getfenv = compat.getfenv,
+    load = compat.load,
+    execute = compat.execute,
+    dir_separator = _G.package.config:sub(1,1),
+    unpack = unpack
+}
+
+--- end this program gracefully.
+-- @param code The exit code or a message to be printed
+-- @param ... extra arguments for message's format'
+-- @see utils.fprintf
+function utils.quit(code,...)
+    if type(code) == 'string' then
+        utils.fprintf(io.stderr,code,...)
+        code = -1
+    else
+        utils.fprintf(io.stderr,...)
+    end
+    io.stderr:write('\n')
+    os.exit(code)
+end
+
+--- print an arbitrary number of arguments using a format.
+-- @param fmt The format (see string.format)
+-- @param ... Extra arguments for format
+function utils.printf(fmt,...)
+    utils.assert_string(1,fmt)
+    utils.fprintf(stdout,fmt,...)
+end
+
+--- write an arbitrary number of arguments to a file using a format.
+-- @param f File handle to write to.
+-- @param fmt The format (see string.format).
+-- @param ... Extra arguments for format
+function utils.fprintf(f,fmt,...)
+    utils.assert_string(2,fmt)
+    f:write(format(fmt,...))
+end
+
+local function import_symbol(T,k,v,libname)
+    local key = rawget(T,k)
+    -- warn about collisions!
+    if key and k ~= '_M' and k ~= '_NAME' and k ~= '_PACKAGE' and k ~= '_VERSION' then
+        utils.printf("warning: '%s.%s' overrides existing symbol\n",libname,k)
+    end
+    rawset(T,k,v)
+end
+
+local function lookup_lib(T,t)
+    for k,v in pairs(T) do
+        if v == t then return k end
+    end
+    return '?'
+end
+
+local already_imported = {}
+
+--- take a table and 'inject' it into the local namespace.
+-- @param t The Table
+-- @param T An optional destination table (defaults to callers environment)
+function utils.import(t,T)
+    T = T or _G
+    t = t or utils
+    if type(t) == 'string' then
+        t = require (t)
+    end
+    local libname = lookup_lib(T,t)
+    if already_imported[t] then return end
+    already_imported[t] = libname
+    for k,v in pairs(t) do
+        import_symbol(T,k,v,libname)
+    end
+end
+
+utils.patterns = {
+    FLOAT = '[%+%-%d]%d*%.?%d*[eE]?[%+%-]?%d*',
+    INTEGER = '[+%-%d]%d*',
+    IDEN = '[%a_][%w_]*',
+    FILE = '[%a%.\\][:%][%w%._%-\\]*'
+}
+
+--- escape any 'magic' characters in a string
+-- @param s The input string
+function utils.escape(s)
+    utils.assert_string(1,s)
+    return (s:gsub('[%-%.%+%[%]%(%)%$%^%%%?%*]','%%%1'))
+end
+
+--- return either of two values, depending on a condition.
+-- @param cond A condition
+-- @param value1 Value returned if cond is true
+-- @param value2 Value returned if cond is false (can be optional)
+function utils.choose(cond,value1,value2)
+    if cond then return value1
+    else return value2
+    end
+end
+
+local raise
+
+--- return the contents of a file as a string
+-- @param filename The file path
+-- @param is_bin open in binary mode
+-- @return file contents
+function utils.readfile(filename,is_bin)
+    local mode = is_bin and 'b' or ''
+    utils.assert_string(1,filename)
+    local f,err = io.open(filename,'r'..mode)
+    if not f then return utils.raise (err) end
+    local res,err = f:read('*a')
+    f:close()
+    if not res then return raise (err) end
+    return res
+end
+
+--- write a string to a file
+-- @param filename The file path
+-- @param str The string
+-- @return true or nil
+-- @return error message
+-- @raise error if filename or str aren't strings
+function utils.writefile(filename,str)
+    utils.assert_string(1,filename)
+    utils.assert_string(2,str)
+    local f,err = io.open(filename,'w')
+    if not f then return raise(err) end
+    f:write(str)
+    f:close()
+    return true
+end
+
+--- return the contents of a file as a list of lines
+-- @param filename The file path
+-- @return file contents as a table
+-- @raise errror if filename is not a string
+function utils.readlines(filename)
+    utils.assert_string(1,filename)
+    local f,err = io.open(filename,'r')
+    if not f then return raise(err) end
+    local res = {}
+    for line in f:lines() do
+        append(res,line)
+    end
+    f:close()
+    return res
+end
+
+--- split a string into a list of strings separated by a delimiter.
+-- @param s The input string
+-- @param re A Lua string pattern; defaults to '%s+'
+-- @param plain don't use Lua patterns
+-- @param n optional maximum number of splits
+-- @return a list-like table
+-- @raise error if s is not a string
+function utils.split(s,re,plain,n)
+    utils.assert_string(1,s)
+    local find,sub,append = string.find, string.sub, table.insert
+    local i1,ls = 1,{}
+    if not re then re = '%s+' end
+    if re == '' then return {s} end
+    while true do
+        local i2,i3 = find(s,re,i1,plain)
+        if not i2 then
+            local last = sub(s,i1)
+            if last ~= '' then append(ls,last) end
+            if #ls == 1 and ls[1] == '' then
+                return {}
+            else
+                return ls
+            end
+        end
+        append(ls,sub(s,i1,i2-1))
+        if n and #ls == n then
+            ls[#ls] = sub(s,i1)
+            return ls
+        end
+        i1 = i3+1
+    end
+end
+
+--- split a string into a number of values.
+-- @param s the string
+-- @param re the delimiter, default space
+-- @return n values
+-- @usage first,next = splitv('jane:doe',':')
+-- @see split
+function utils.splitv (s,re)
+    return unpack(utils.split(s,re))
+end
+
+--- convert an array of values to strings.
+-- @param t a list-like table
+-- @param temp buffer to use, otherwise allocate
+-- @param tostr custom tostring function, called with (value,index).
+-- Otherwise use `tostring`
+-- @return the converted buffer
+function utils.array_tostring (t,temp,tostr)
+    temp, tostr = temp or {}, tostr or tostring
+    for i = 1,#t do
+        temp[i] = tostr(t[i],i)
+    end
+    return temp
+end
+
+--- execute a shell command and return the output.
+-- This function redirects the output to tempfiles and returns the content of those files.
+-- @param cmd a shell command
+-- @param bin boolean, if true, read output as binary file
+-- @return true if successful
+-- @return actual return code
+-- @return stdout output (string)
+-- @return errout output (string)
+function utils.executeex(cmd, bin)
+    local mode
+    local outfile = os.tmpname()
+    local errfile = os.tmpname()
+
+    if utils.dir_separator == '\\' then
+        outfile = os.getenv('TEMP')..outfile
+        errfile = os.getenv('TEMP')..errfile
+    end
+    cmd = cmd .. [[ >"]]..outfile..[[" 2>"]]..errfile..[["]]
+
+    local success, retcode = utils.execute(cmd)
+    local outcontent = utils.readfile(outfile, bin)
+    local errcontent = utils.readfile(errfile, bin)
+    os.remove(outfile)
+    os.remove(errfile)
+    return success, retcode, (outcontent or ""), (errcontent or "")
+end
+
+--- 'memoize' a function (cache returned value for next call).
+-- This is useful if you have a function which is relatively expensive,
+-- but you don't know in advance what values will be required, so
+-- building a table upfront is wasteful/impossible.
+-- @param func a function of at least one argument
+-- @return a function with at least one argument, which is used as the key.
+function utils.memoize(func)
+    return setmetatable({}, {
+        __index = function(self, k, ...)
+            local v = func(k,...)
+            self[k] = v
+            return v
+        end,
+        __call = function(self, k) return self[k] end
+    })
+end
+
+
+utils.stdmt = {
+    List = {_name='List'}, Map = {_name='Map'},
+    Set = {_name='Set'}, MultiMap = {_name='MultiMap'}
+}
+
+local _function_factories = {}
+
+--- associate a function factory with a type.
+-- A function factory takes an object of the given type and
+-- returns a function for evaluating it
+-- @param mt metatable
+-- @param fun a callable that returns a function
+function utils.add_function_factory (mt,fun)
+    _function_factories[mt] = fun
+end
+
+local function _string_lambda(f)
+    local raise = utils.raise
+    if f:find '^|' or f:find '_' then
+        local args,body = f:match '|([^|]*)|(.+)'
+        if f:find '_' then
+            args = '_'
+            body = f
+        else
+            if not args then return raise 'bad string lambda' end
+        end
+        local fstr = 'return function('..args..') return '..body..' end'
+        local fn,err = utils.load(fstr)
+        if not fn then return raise(err) end
+        fn = fn()
+        return fn
+    else return raise 'not a string lambda'
+    end
+end
+
+--- an anonymous function as a string. This string is either of the form
+-- '|args| expression' or is a function of one argument, '_'
+-- @param lf function as a string
+-- @return a function
+-- @usage string_lambda '|x|x+1' (2) == 3
+-- @usage string_lambda '_+1 (2) == 3
+-- @function utils.string_lambda
+utils.string_lambda = utils.memoize(_string_lambda)
+
+local ops
+
+--- process a function argument.
+-- This is used throughout Penlight and defines what is meant by a function:
+-- Something that is callable, or an operator string as defined by <code>pl.operator</code>,
+-- such as '>' or '#'. If a function factory has been registered for the type, it will
+-- be called to get the function.
+-- @param idx argument index
+-- @param f a function, operator string, or callable object
+-- @param msg optional error message
+-- @return a callable
+-- @raise if idx is not a number or if f is not callable
+function utils.function_arg (idx,f,msg)
+    utils.assert_arg(1,idx,'number')
+    local tp = type(f)
+    if tp == 'function' then return f end  -- no worries!
+    -- ok, a string can correspond to an operator (like '==')
+    if tp == 'string' then
+        if not ops then ops = require 'pl.operator'.optable end
+        local fn = ops[f]
+        if fn then return fn end
+        local fn, err = utils.string_lambda(f)
+        if not fn then error(err..': '..f) end
+        return fn
+    elseif tp == 'table' or tp == 'userdata' then
+        local mt = getmetatable(f)
+        if not mt then error('not a callable object',2) end
+        local ff = _function_factories[mt]
+        if not ff then
+            if not mt.__call then error('not a callable object',2) end
+            return f
+        else
+            return ff(f) -- we have a function factory for this type!
+        end
+    end
+    if not msg then msg = " must be callable" end
+    if idx > 0 then
+        error("argument "..idx..": "..msg,2)
+    else
+        error(msg,2)
+    end
+end
+
+--- bind the first argument of the function to a value.
+-- @param fn a function of at least two values (may be an operator string)
+-- @param p a value
+-- @return a function such that f(x) is fn(p,x)
+-- @raise same as @{function_arg}
+-- @see func.bind1
+function utils.bind1 (fn,p)
+    fn = utils.function_arg(1,fn)
+    return function(...) return fn(p,...) end
+end
+
+--- bind the second argument of the function to a value.
+-- @param fn a function of at least two values (may be an operator string)
+-- @param p a value
+-- @return a function such that f(x) is fn(x,p)
+-- @raise same as @{function_arg}
+function utils.bind2 (fn,p)
+    fn = utils.function_arg(1,fn)
+    return function(x,...) return fn(x,p,...) end
+end
+
+
+--- assert that the given argument is in fact of the correct type.
+-- @param n argument index
+-- @param val the value
+-- @param tp the type
+-- @param verify an optional verfication function
+-- @param msg an optional custom message
+-- @param lev optional stack position for trace, default 2
+-- @raise if the argument n is not the correct type
+-- @usage assert_arg(1,t,'table')
+-- @usage assert_arg(n,val,'string',path.isdir,'not a directory')
+function utils.assert_arg (n,val,tp,verify,msg,lev)
+    if type(val) ~= tp then
+        error(("argument %d expected a '%s', got a '%s'"):format(n,tp,type(val)),lev or 2)
+    end
+    if verify and not verify(val) then
+        error(("argument %d: '%s' %s"):format(n,val,msg),lev or 2)
+    end
+end
+
+--- assert the common case that the argument is a string.
+-- @param n argument index
+-- @param val a value that must be a string
+-- @raise val must be a string
+function utils.assert_string (n,val)
+    utils.assert_arg(n,val,'string',nil,nil,3)
+end
+
+local err_mode = 'default'
+
+--- control the error strategy used by Penlight.
+-- Controls how <code>utils.raise</code> works; the default is for it
+-- to return nil and the error string, but if the mode is 'error' then
+-- it will throw an error. If mode is 'quit' it will immediately terminate
+-- the program.
+-- @param mode - either 'default', 'quit'  or 'error'
+-- @see utils.raise
+function utils.on_error (mode)
+    if ({['default'] = 1, ['quit'] = 2, ['error'] = 3})[mode] then
+      err_mode = mode
+    else
+      -- fail loudly
+      if err_mode == 'default' then err_mode = 'error' end
+      utils.raise("Bad argument expected string; 'default', 'quit', or 'error'. Got '"..tostring(mode).."'")
+    end
+end
+
+--- used by Penlight functions to return errors.  Its global behaviour is controlled
+-- by <code>utils.on_error</code>
+-- @param err the error string.
+-- @see utils.on_error
+function utils.raise (err)
+    if err_mode == 'default' then return nil,err
+    elseif err_mode == 'quit' then utils.quit(err)
+    else error(err,2)
+    end
+end
+
+--- is the object of the specified type?.
+-- If the type is a string, then use type, otherwise compare with metatable
+-- @param obj An object to check
+-- @param tp String of what type it should be
+function utils.is_type (obj,tp)
+    if type(tp) == 'string' then return type(obj) == tp end
+    local mt = getmetatable(obj)
+    return tp == mt
+end
+
+raise = utils.raise
+
+--- load a code string or bytecode chunk.
+-- @param code Lua code as a string or bytecode
+-- @param name for source errors
+-- @param mode kind of chunk, 't' for text, 'b' for bytecode, 'bt' for all (default)
+-- @param env  the environment for the new chunk (default nil)
+-- @return compiled chunk
+-- @return error message (chunk is nil)
+-- @function utils.load
+
+---------------
+-- Get environment of a function.
+-- With Lua 5.2, may return nil for a function with no global references!
+-- Based on code by [Sergey Rozhenko](http://lua-users.org/lists/lua-l/2010-06/msg00313.html)
+-- @param f a function or a call stack reference
+-- @function utils.setfenv
+
+---------------
+-- Set environment of a function
+-- @param f a function or a call stack reference
+-- @param env a table that becomes the new environment of `f`
+-- @function utils.setfenv
+
+--- execute a shell command.
+-- This is a compatibility function that returns the same for Lua 5.1 and Lua 5.2
+-- @param cmd a shell command
+-- @return true if successful
+-- @return actual return code
+-- @function utils.execute
+
+return utils
+
+

--- a/lib/ext/spec-support/pl/xml.lua
+++ b/lib/ext/spec-support/pl/xml.lua
@@ -1,0 +1,775 @@
+--- XML LOM Utilities.
+--
+-- This implements some useful things on [LOM](http://matthewwild.co.uk/projects/luaexpat/lom.html) documents, such as returned by `lxp.lom.parse`.
+-- In particular, it can convert LOM back into XML text, with optional pretty-printing control.
+-- It is s based on stanza.lua from [Prosody](http://hg.prosody.im/trunk/file/4621c92d2368/util/stanza.lua)
+--
+--     > d = xml.parse "<nodes><node id='1'>alice</node></nodes>"
+--     > = d
+--     <nodes><node id='1'>alice</node></nodes>
+--     > = xml.tostring(d,'','  ')
+--     <nodes>
+--        <node id='1'>alice</node>
+--     </nodes>
+--
+-- Can be used as a lightweight one-stop-shop for simple XML processing; a simple XML parser is included
+-- but the default is to use `lxp.lom` if it can be found.
+-- <pre>
+-- Prosody IM
+-- Copyright (C) 2008-2010 Matthew Wild
+-- Copyright (C) 2008-2010 Waqas Hussain--
+-- classic Lua XML parser by Roberto Ierusalimschy.
+-- modified to output LOM format.
+-- http://lua-users.org/wiki/LuaXml
+-- </pre>
+-- See @{06-data.md.XML|the Guide}
+--
+-- Dependencies: `pl.utils`
+--
+-- Soft Dependencies: `lxp.lom` (fallback is to use basic Lua parser)
+-- @module pl.xml
+
+local utils = require 'pl.utils'
+local split         =   utils.split;
+local t_insert      =  table.insert;
+local t_concat      =  table.concat;
+local t_remove      =  table.remove;
+local s_format      = string.format;
+local s_match       =  string.match;
+local tostring      =      tostring;
+local setmetatable  =  setmetatable;
+local getmetatable  =  getmetatable;
+local pairs         =         pairs;
+local ipairs        =        ipairs;
+local type          =          type;
+local next          =          next;
+local print         =         print;
+local unpack        =  utils.unpack;
+local s_gsub        =   string.gsub;
+local s_char        =   string.char;
+local s_find        =   string.find;
+local os            =            os;
+local pcall,require,io     =   pcall,require,io
+
+local _M = {}
+local Doc = { __type = "doc" };
+Doc.__index = Doc;
+
+--- create a new document node.
+-- @param tag the tag name
+-- @param attr optional attributes (table of name-value pairs)
+function _M.new(tag, attr)
+    local doc = { tag = tag, attr = attr or {}, last_add = {}};
+    return setmetatable(doc, Doc);
+end
+
+--- parse an XML document.  By default, this uses lxp.lom.parse, but
+-- falls back to basic_parse, or if use_basic is true
+-- @param text_or_file  file or string representation
+-- @param is_file whether text_or_file is a file name or not
+-- @param use_basic do a basic parse
+-- @return a parsed LOM document with the document metatatables set
+-- @return nil, error the error can either be a file error or a parse error
+function _M.parse(text_or_file, is_file, use_basic)
+    local parser,status,lom
+    if use_basic then parser = _M.basic_parse
+    else
+        status,lom = pcall(require,'lxp.lom')
+        if not status then parser = _M.basic_parse else parser = lom.parse end
+    end
+    if is_file then
+        local f,err = io.open(text_or_file)
+        if not f then return nil,err end
+        text_or_file = f:read '*a'
+        f:close()
+    end
+    local doc,err = parser(text_or_file)
+    if not doc then return nil,err end
+    if lom then
+        _M.walk(doc,false,function(_,d)
+            setmetatable(d,Doc)
+        end)
+    end
+    return doc
+end
+
+---- convenient function to add a document node, This updates the last inserted position.
+-- @param tag a tag name
+-- @param attrs optional set of attributes (name-string pairs)
+function Doc:addtag(tag, attrs)
+    local s = _M.new(tag, attrs);
+    (self.last_add[#self.last_add] or self):add_direct_child(s);
+    t_insert(self.last_add, s);
+    return self;
+end
+
+--- convenient function to add a text node.  This updates the last inserted position.
+-- @param text a string
+function Doc:text(text)
+    (self.last_add[#self.last_add] or self):add_direct_child(text);
+    return self;
+end
+
+---- go up one level in a document
+function Doc:up()
+    t_remove(self.last_add);
+    return self;
+end
+
+function Doc:reset()
+    local last_add = self.last_add;
+    for i = 1,#last_add do
+        last_add[i] = nil;
+    end
+    return self;
+end
+
+--- append a child to a document directly.
+-- @param child a child node (either text or a document)
+function Doc:add_direct_child(child)
+    t_insert(self, child);
+end
+
+--- append a child to a document at the last element added
+-- @param child a child node (either text or a document)
+function Doc:add_child(child)
+    (self.last_add[#self.last_add] or self):add_direct_child(child);
+    return self;
+end
+
+--accessing attributes: useful not to have to expose implementation (attr)
+--but also can allow attr to be nil in any future optimizations
+
+--- set attributes of a document node.
+-- @param t a table containing attribute/value pairs
+function Doc:set_attribs (t)
+    for k,v in pairs(t) do
+        self.attr[k] = v
+    end
+end
+
+--- set a single attribute of a document node.
+-- @param a attribute
+-- @param v its value
+function Doc:set_attrib(a,v)
+    self.attr[a] = v
+end
+
+--- access the attributes of a document node.
+function Doc:get_attribs()
+    return self.attr
+end
+
+local function is_text(s) return type(s) == 'string' end
+
+--- function to create an element with a given tag name and a set of children.
+-- @param tag a tag name
+-- @param items either text or a table where the hash part is the attributes and the list part is the children.
+function _M.elem(tag,items)
+    local s = _M.new(tag)
+    if is_text(items) then items = {items} end
+    if _M.is_tag(items) then
+       t_insert(s,items)
+    elseif type(items) == 'table' then
+       for k,v in pairs(items) do
+           if is_text(k) then
+               s.attr[k] = v
+               t_insert(s.attr,k)
+           else
+               s[k] = v
+           end
+       end
+    end
+    return s
+end
+
+--- given a list of names, return a number of element constructors.
+-- @param list  a list of names, or a comma-separated string.
+-- @usage local parent,children = doc.tags 'parent,children' <br>
+--  doc = parent {child 'one', child 'two'}
+function _M.tags(list)
+    local ctors = {}
+    local elem = _M.elem
+    if is_text(list) then list = split(list,'%s*,%s*') end
+    for _,tag in ipairs(list) do
+        local ctor = function(items) return _M.elem(tag,items) end
+        t_insert(ctors,ctor)
+    end
+    return unpack(ctors)
+end
+
+local templ_cache = {}
+
+local function template_cache (templ)
+    if is_text(templ) then
+        if templ_cache[templ] then
+            templ = templ_cache[templ]
+        else
+            local str,err = templ
+            templ,err = _M.parse(str,false,true)
+            if not templ then return nil,err end
+            templ_cache[str] = templ
+        end
+    elseif not _M.is_tag(templ) then
+        return nil, "template is not a document"
+    end
+    return templ
+end
+
+local function is_data(data)
+    return #data == 0 or type(data[1]) ~= 'table'
+end
+
+local function prepare_data(data)
+    -- a hack for ensuring that $1 maps to first element of data, etc.
+    -- Either this or could change the gsub call just below.
+    for i,v in ipairs(data) do
+        data[tostring(i)] = v
+    end
+end
+
+--- create a substituted copy of a document,
+-- @param templ  may be a document or a string representation which will be parsed and cached
+-- @param data  a table of name-value pairs or a list of such tables
+-- @return an XML document
+function Doc.subst(templ, data)
+    local err
+    if type(data) ~= 'table' or not next(data) then return nil, "data must be a non-empty table" end
+    if is_data(data) then
+        prepare_data(data)
+    end
+    templ,err = template_cache(templ)
+    if err then return nil, err end
+    local function _subst(item)
+        return _M.clone(templ,function(s)
+            return s:gsub('%$(%w+)',item)
+        end)
+    end
+    if is_data(data) then return _subst(data) end
+    local list = {}
+    for _,item in ipairs(data) do
+        prepare_data(item)
+        t_insert(list,_subst(item))
+    end
+    if data.tag then
+        list = _M.elem(data.tag,list)
+    end
+    return list
+end
+
+
+--- get the first child with a given tag name.
+-- @param tag the tag name
+function Doc:child_with_name(tag)
+    for _, child in ipairs(self) do
+        if child.tag == tag then return child; end
+    end
+end
+
+local _children_with_name
+function _children_with_name(self,tag,list,recurse)
+    for _, child in ipairs(self) do if type(child) == 'table' then
+        if child.tag == tag then t_insert(list,child) end
+        if recurse then _children_with_name(child,tag,list,recurse) end
+    end end
+end
+
+--- get all elements in a document that have a given tag.
+-- @param tag a tag name
+-- @param dont_recurse optionally only return the immediate children with this tag name
+-- @return a list of elements
+function Doc:get_elements_with_name(tag,dont_recurse)
+    local res = {}
+    _children_with_name(self,tag,res,not dont_recurse)
+    return res
+end
+
+-- iterate over all children of a document node, including text nodes.
+function Doc:children()
+    local i = 0;
+    return function (a)
+            i = i + 1
+            return a[i];
+    end, self, i;
+end
+
+-- return the first child element of a node, if it exists.
+function Doc:first_childtag()
+    if #self == 0 then return end
+    for _,t in ipairs(self) do
+        if type(t) == 'table' then return t end
+    end
+end
+
+function Doc:matching_tags(tag, xmlns)
+    xmlns = xmlns or self.attr.xmlns;
+    local tags = self;
+    local start_i, max_i, v = 1, #tags;
+    return function ()
+            for i=start_i,max_i do
+                v = tags[i];
+                if (not tag or v.tag == tag)
+                and (not xmlns or xmlns == v.attr.xmlns) then
+                    start_i = i+1;
+                    return v;
+                end
+            end
+        end, tags, start_i;
+end
+
+--- iterate over all child elements of a document node.
+function Doc:childtags()
+    local i = 0;
+    return function (a)
+        local v
+            repeat
+                i = i + 1
+                v = self[i]
+                if v and type(v) == 'table' then return v; end
+            until not v
+        end, self[1], i;
+end
+
+--- visit child element  of a node and call a function, possibility modifying the document.
+-- @param callback  a function passed the node (text or element). If it returns nil, that node will be removed.
+-- If it returns a value, that will replace the current node.
+function Doc:maptags(callback)
+    local is_tag = _M.is_tag
+    local i = 1;
+    while i <= #self do
+        if is_tag(self[i]) then
+            local ret = callback(self[i]);
+            if ret == nil then
+                t_remove(self, i);
+            else
+                self[i] = ret;
+                i = i + 1;
+            end
+        end
+    end
+    return self;
+end
+
+local xml_escape
+do
+    local escape_table = { ["'"] = "&apos;", ["\""] = "&quot;", ["<"] = "&lt;", [">"] = "&gt;", ["&"] = "&amp;" };
+    function xml_escape(str) return (s_gsub(str, "['&<>\"]", escape_table)); end
+    _M.xml_escape = xml_escape;
+end
+
+-- pretty printing
+-- if indent, then put each new tag on its own line
+-- if attr_indent, put each new attribute on its own line
+local function _dostring(t, buf, self, xml_escape, parentns, idn, indent, attr_indent)
+    local nsid = 0;
+    local tag = t.tag
+    local lf,alf = ""," "
+    if indent then lf = '\n'..idn end
+    if attr_indent then alf = '\n'..idn..attr_indent end
+    t_insert(buf, lf.."<"..tag);
+    local function write_attr(k,v)
+        if s_find(k, "\1", 1, true) then
+            local ns, attrk = s_match(k, "^([^\1]*)\1?(.*)$");
+            nsid = nsid + 1;
+            t_insert(buf, " xmlns:ns"..nsid.."='"..xml_escape(ns).."' ".."ns"..nsid..":"..attrk.."='"..xml_escape(v).."'");
+        elseif not(k == "xmlns" and v == parentns) then
+            t_insert(buf, alf..k.."='"..xml_escape(v).."'");
+        end
+    end
+    -- it's useful for testing to have predictable attribute ordering, if available
+    if #t.attr > 0 then
+        for _,k in ipairs(t.attr) do
+            write_attr(k,t.attr[k])
+        end
+    else
+        for k, v in pairs(t.attr) do
+            write_attr(k,v)
+        end
+    end
+    local len,has_children = #t;
+    if len == 0 then
+    local out = "/>"
+    if attr_indent then out = '\n'..idn..out end
+        t_insert(buf, out);
+    else
+        t_insert(buf, ">");
+        for n=1,len do
+            local child = t[n];
+            if child.tag then
+                self(child, buf, self, xml_escape, t.attr.xmlns,idn and idn..indent, indent, attr_indent );
+                has_children = true
+            else -- text element
+                t_insert(buf, xml_escape(child));
+            end
+        end
+        t_insert(buf, (has_children and lf or '').."</"..tag..">");
+    end
+end
+
+---- pretty-print an XML document
+--- @param t an XML document
+--- @param idn an initial indent (indents are all strings)
+--- @param indent an indent for each level
+--- @param attr_indent if given, indent each attribute pair and put on a separate line
+--- @param xml force prefacing with <?xml...>
+--- @return a string representation
+function _M.tostring(t,idn,indent, attr_indent, xml)
+    local buf = {};
+    if xml then buf[1] = "<?xml version='1.0'?>" end
+    _dostring(t, buf, _dostring, xml_escape, nil,idn,indent, attr_indent);
+    return t_concat(buf);
+end
+
+Doc.__tostring = _M.tostring
+
+--- get the full text value of an element
+function Doc:get_text()
+    local res = {}
+    for i,el in ipairs(self) do
+        if is_text(el) then t_insert(res,el) end
+    end
+    return t_concat(res);
+end
+
+--- make a copy of a document
+-- @param doc the original document
+-- @param strsubst an optional function for handling string copying which could do substitution, etc.
+function _M.clone(doc, strsubst)
+    local lookup_table = {};
+    local function _copy(object,kind,parent)
+        if type(object) ~= "table" then
+            if strsubst and is_text(object) then return strsubst(object,kind,parent)
+            else return object
+            end
+        elseif lookup_table[object] then
+            return lookup_table[object]
+        end
+        local new_table = {};
+        lookup_table[object] = new_table
+        local tag = object.tag
+        new_table.tag = _copy(tag,'*TAG',parent)
+        if object.attr then
+            local res = {}
+            for attr,value in pairs(object.attr) do
+                res[attr] = _copy(value,attr,object)
+            end
+            new_table.attr = res
+        end
+        for index = 1,#object do
+            local v = _copy(object[index],'*TEXT',object)
+            t_insert(new_table,v)
+        end
+        return setmetatable(new_table, getmetatable(object))
+    end
+
+    return _copy(doc)
+end
+
+Doc.filter = _M.clone -- also available as method
+
+--- compare two documents.
+-- @param t1 any value
+-- @param t2 any value
+function _M.compare(t1,t2)
+    local ty1 = type(t1)
+    local ty2 = type(t2)
+    if ty1 ~= ty2 then return false, 'type mismatch' end
+    if ty1 == 'string' then
+        return t1 == t2 and true or 'text '..t1..' ~= text '..t2
+    end
+    if ty1 ~= 'table' or ty2 ~= 'table' then return false, 'not a document' end
+    if t1.tag ~= t2.tag then return false, 'tag  '..t1.tag..' ~= tag '..t2.tag end
+    if #t1 ~= #t2 then return false, 'size '..#t1..' ~= size '..#t2..' for tag '..t1.tag end
+    -- compare attributes
+    for k,v in pairs(t1.attr) do
+        if t2.attr[k] ~= v then return false, 'mismatch attrib' end
+    end
+    for k,v in pairs(t2.attr) do
+        if t1.attr[k] ~= v then return false, 'mismatch attrib' end
+    end
+    -- compare children
+    for i = 1,#t1 do
+        local yes,err = _M.compare(t1[i],t2[i])
+        if not yes then return err end
+    end
+    return true
+end
+
+--- is this value a document element?
+-- @param d any value
+function _M.is_tag(d)
+    return type(d) == 'table' and is_text(d.tag)
+end
+
+--- call the desired function recursively over the document.
+-- @param doc the document
+-- @param depth_first  visit child notes first, then the current node
+-- @param operation a function which will receive the current tag name and current node.
+function _M.walk (doc, depth_first, operation)
+    if not depth_first then operation(doc.tag,doc) end
+    for _,d in ipairs(doc) do
+        if _M.is_tag(d) then
+            _M.walk(d,depth_first,operation)
+        end
+    end
+    if depth_first then operation(doc.tag,doc) end
+end
+
+local html_empty_elements = { --lists all HTML empty (void) elements
+	br      = true,
+	img     = true,
+	meta    = true,
+	frame   = true,
+	area    = true,
+	hr      = true,
+	base    = true,
+	col     = true,
+	link    = true,
+	input   = true,
+	option  = true,
+	param   = true,
+    isindex = true,
+    embed = true,
+}
+
+local escapes = { quot = "\"", apos = "'", lt = "<", gt = ">", amp = "&" }
+local function unescape(str) return (str:gsub( "&(%a+);", escapes)); end
+
+--- Parse a well-formed HTML file as a string.
+-- Tags are case-insenstive, DOCTYPE is ignored, and empty elements can be .. empty.
+-- @param s the HTML
+function _M.parsehtml (s)
+    return _M.basic_parse(s,false,true)
+end
+
+--- Parse a simple XML document using a pure Lua parser based on Robero Ierusalimschy's original version.
+-- @param s the XML document to be parsed.
+-- @param all_text  if true, preserves all whitespace. Otherwise only text containing non-whitespace is included.
+-- @param html if true, uses relaxed HTML rules for parsing
+function _M.basic_parse(s,all_text,html)
+    local t_insert,t_remove = table.insert,table.remove
+    local s_find,s_sub = string.find,string.sub
+    local stack = {}
+    local top = {}
+
+    local function parseargs(s)
+      local arg = {}
+      s:gsub("([%w:]+)%s*=%s*([\"'])(.-)%2", function (w, _, a)
+        if html then w = w:lower() end
+        arg[w] = unescape(a)
+      end)
+      if html then
+        s:gsub("([%w:]+)%s*=%s*([^\"']+)%s*", function (w, a)
+          w = w:lower()
+          arg[w] = unescape(a)
+        end)
+      end
+      return arg
+    end
+
+    t_insert(stack, top)
+    local ni,c,label,xarg, empty, _, istart
+    local i, j = 1, 1
+    if not html then -- we're not interested in <?xml version="1.0"?>
+        _,istart = s_find(s,'^%s*<%?[^%?]+%?>%s*')
+    else -- or <!DOCTYPE ...>
+        _,istart = s_find(s,'^%s*<!DOCTYPE.->%s*')
+    end
+    if istart then i = istart+1 end
+    while true do
+        ni,j,c,label,xarg, empty = s_find(s, "<([%/!]?)([%w:%-_]+)(.-)(%/?)>", i)
+        if not ni then break end
+        if c == "!" then -- comment
+            -- case where there's no space inside comment
+            if not (label:match '%-%-$' and xarg == '') then
+                if xarg:match '%-%-$' then -- we've grabbed it all
+                    j = j - 2
+                end
+                -- match end of comment
+                _,j = s_find(s, "-->", j, true)
+            end
+        else
+            local text = s_sub(s, i, ni-1)
+            if html then
+                label = label:lower()
+                if html_empty_elements[label] then empty = "/" end
+                if label == 'script' then
+                end
+            end
+            if all_text or not s_find(text, "^%s*$") then
+                t_insert(top, unescape(text))
+            end
+            if empty == "/" then  -- empty element tag
+                t_insert(top, setmetatable({tag=label, attr=parseargs(xarg), empty=1},Doc))
+            elseif c == "" then   -- start tag
+                top = setmetatable({tag=label, attr=parseargs(xarg)},Doc)
+                t_insert(stack, top)   -- new level
+            else  -- end tag
+                local toclose = t_remove(stack)  -- remove top
+                top = stack[#stack]
+                if #stack < 1 then
+                    error("nothing to close with "..label..':'..text)
+                end
+                if toclose.tag ~= label then
+                    error("trying to close "..toclose.tag.." with "..label.." "..text)
+                end
+                t_insert(top, toclose)
+            end
+        end
+    i = j+1
+    end
+    local text = s_sub(s, i)
+    if all_text or  not s_find(text, "^%s*$") then
+        t_insert(stack[#stack], unescape(text))
+    end
+    if #stack > 1 then
+        error("unclosed "..stack[#stack].tag)
+    end
+    local res = stack[1]
+    return is_text(res[1]) and res[2] or res[1]
+end
+
+local function empty(attr) return not attr or not next(attr) end
+local function is_element(d) return type(d) == 'table' and d.tag ~= nil end
+
+-- returns the key,value pair from a table if it has exactly one entry
+local function has_one_element(t)
+    local key,value = next(t)
+    if next(t,key) ~= nil then return false end
+    return key,value
+end
+
+local function append_capture(res,tbl)
+    if not empty(tbl) then -- no point in capturing empty tables...
+        local key
+        if tbl._ then  -- if $_ was set then it is meant as the top-level key for the captured table
+            key = tbl._
+            tbl._ = nil
+            if empty(tbl) then return end
+        end
+        -- a table with only one pair {[0]=value} shall be reduced to that value
+        local numkey,val = has_one_element(tbl)
+        if numkey == 0 then tbl = val end
+        if key then
+            res[key] = tbl
+        else -- otherwise, we append the captured table
+            t_insert(res,tbl)
+        end
+    end
+end
+
+local function make_number(pat)
+    if pat:find '^%d+$' then -- $1 etc means use this as an array location
+        pat = tonumber(pat)
+    end
+    return pat
+end
+
+local function capture_attrib(res,pat,value)
+    pat = make_number(pat:sub(2))
+    res[pat] = value
+    return true
+end
+
+local match
+function match(d,pat,res,keep_going)
+    local ret = true
+    if d == nil then d = '' end --return false end
+    -- attribute string matching is straight equality, except if the pattern is a $ capture,
+    -- which always succeeds.
+    if is_text(d) then
+        if not is_text(pat) then return false end
+        if _M.debug then print(d,pat) end
+        if pat:find '^%$' then
+            return capture_attrib(res,pat,d)
+        else
+            return d == pat
+        end
+    else
+    if _M.debug then print(d.tag,pat.tag) end
+        -- this is an element node. For a match to succeed, the attributes must
+        -- match as well.
+        -- a tagname in the pattern ending with '-' is a wildcard and matches like an attribute
+        local tagpat = pat.tag:match '^(.-)%-$'
+        if tagpat then
+            tagpat = make_number(tagpat)
+            res[tagpat] = d.tag
+        end
+        if d.tag == pat.tag or tagpat then
+
+            if not empty(pat.attr) then
+                if empty(d.attr) then ret =  false
+                else
+                    for prop,pval in pairs(pat.attr) do
+                        local dval = d.attr[prop]
+                        if not match(dval,pval,res) then ret = false;  break end
+                    end
+                end
+            end
+            -- the pattern may have child nodes. We match partially, so that {P1,P2} shall match {X,P1,X,X,P2,..}
+            if ret and #pat > 0 then
+                local i,j = 1,1
+                local function next_elem()
+                    j = j + 1  -- next child element of data
+                    if is_text(d[j]) then j = j + 1 end
+                    return j <= #d
+                end
+                repeat
+                    local p = pat[i]
+                    -- repeated {{<...>}} patterns  shall match one or more elements
+                    -- so e.g. {P+} will match {X,X,P,P,X,P,X,X,X}
+                    if is_element(p) and p.repeated then
+                        local found
+                        repeat
+                            local tbl = {}
+                            ret = match(d[j],p,tbl,false)
+                            if ret then
+                                found = false --true
+                                append_capture(res,tbl)
+                            end
+                        until not next_elem() or (found and not ret)
+                        i = i + 1
+                    else
+                        ret = match(d[j],p,res,false)
+                        if ret then i = i + 1 end
+                    end
+                until not next_elem() or i > #pat -- run out of elements or patterns to match
+                -- if every element in our pattern matched ok, then it's been a successful match
+                if i > #pat then return true end
+            end
+            if ret then return true end
+        else
+            ret = false
+        end
+        -- keep going anyway - look at the children!
+        if keep_going then
+            for child in d:childtags() do
+                ret = match(child,pat,res,keep_going)
+                if ret then break end
+            end
+        end
+    end
+    return ret
+end
+
+function Doc:match(pat)
+    local err
+    pat,err = template_cache(pat)
+    if not pat then return nil, err end
+    _M.walk(pat,false,function(_,d)
+        if is_text(d[1]) and is_element(d[2]) and is_text(d[3]) and
+           d[1]:find '%s*{{' and d[3]:find '}}%s*' then
+           t_remove(d,1)
+           t_remove(d,2)
+           d[1].repeated = true
+        end
+    end)
+
+    local res = {}
+    local ret = match(self,pat,res,true)
+    return res,ret
+end
+
+
+return _M
+

--- a/lib/ext/spec-support/say/LICENSE
+++ b/lib/ext/spec-support/say/LICENSE
@@ -1,0 +1,22 @@
+MIT License Terms
+=================
+
+Copyright (c) 2012 Olivine Labs, LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.

--- a/lib/ext/spec-support/say/init.lua
+++ b/lib/ext/spec-support/say/init.lua
@@ -1,0 +1,61 @@
+local registry = { }
+local current_namespace
+local fallback_namespace
+
+local s = {
+
+  _COPYRIGHT   = "Copyright (c) 2012 Olivine Labs, LLC.",
+  _DESCRIPTION = "A simple string key/value store for i18n or any other case where you want namespaced strings.",
+  _VERSION     = "Say 1.2",
+
+  set_namespace = function(self, namespace)
+    current_namespace = namespace
+    if not registry[current_namespace] then
+      registry[current_namespace] = {}
+    end
+  end,
+
+  set_fallback = function(self, namespace)
+    fallback_namespace = namespace
+    if not registry[fallback_namespace] then
+      registry[fallback_namespace] = {}
+    end
+  end,
+
+  set = function(self, key, value)
+    registry[current_namespace][key] = value
+  end
+}
+
+local __meta = {
+  __call = function(self, key, vars)
+    vars = vars or {}
+
+    local str = registry[current_namespace][key] or registry[fallback_namespace][key]
+
+    if str == nil then
+      return nil
+    end
+    str = tostring(str)
+    local strings = {}
+
+    for i,v in ipairs(vars) do
+      table.insert(strings, tostring(v))
+    end
+
+    return #strings > 0 and str:format(unpack(strings)) or str
+  end,
+
+  __index = function(self, key)
+    return registry[key]
+  end
+}
+
+s:set_fallback('en')
+s:set_namespace('en')
+
+if _TEST then
+  s._registry = registry -- force different name to make sure with _TEST behaves exactly as without _TEST
+end
+
+return setmetatable(s, __meta)

--- a/lib/howl/init.lua
+++ b/lib/howl/init.lua
@@ -14,6 +14,7 @@ Where options can be any of:
   --lint        Lints the given files
   --run         Loads and runs the specified file from within Howl
   --no-profile  Starts Howl without loading any user profile (settings, etc)
+  --spec        Runs the specified Howl spec file(s)
   -h, --help    This help
 ]=]
 
@@ -27,6 +28,7 @@ local function parse_args(argv)
     ['--compile'] = 'compile',
     ['--lint'] = 'lint',
     ['--no-profile'] = 'no_profile',
+    ['--spec'] = 'spec',
     ['--run'] = 'run',
   }
   local args = {}
@@ -40,7 +42,7 @@ local function parse_args(argv)
     end
   end
 
-  if args.help then
+  if args.help and not args.spec then
     print(help)
     os.exit(0)
   end
@@ -182,8 +184,10 @@ local function main(args)
     howl.app = howl.Application(howl.io.File(app_root), args)
     assert(jit.status(), "JIT is inadvertently switched off")
 
-    if os.getenv('BUSTED') then
-      local busted = assert(loadfile(argv[2]))
+    if args.spec then
+      set_package_path('lib/ext/spec-support')
+      package.loaded.lfs = loadfile(app_root .. '/lib/ext/spec-support/howl-lfs-shim.moon')()
+      local busted = assert(loadfile(app_root .. '/lib/ext/spec-support/busted/busted_bootstrap'))
       arg = {table.unpack(argv, 3, #argv)}
       local support = assert(loadfile(app_root .. '/spec/support/spec_helper.moon'))
       support()

--- a/lib/howl/log.moon
+++ b/lib/howl/log.moon
@@ -35,8 +35,8 @@ dispatch = (level, message) ->
     essentials = essentials_of message
     status[level] status, essentials
     command_line\notify essentials, level if command_line.showing
-  else
-    print message if not _G.os.getenv('BUSTED')
+  elseif not _G.howl.app.args.spec
+    _G.print message
 
   while #entries > config.max_log_entries and #entries > 0
     table.remove entries, 1


### PR DESCRIPTION
This vendors all the required dependencies for running `howl-spec`. With this it's not longer necessary to have a luarocks install in order to run specs, which should it make it a lot easier to get up and running with the specs, especially since we require a specific rock setup with certain versions.

This is actually a continuation of work I did previously. At that point the work was put aside since the spec dependencies themselves had a dependency on `lfs`, which contains C code. This PR now uses an extremely crude and lacking implementation of `lfs`, but on which happen to fulfil the few requirements.