### PR TITLE
Popup fixes

### DIFF
--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -459,8 +459,8 @@ View = {
         rect =  layout\index_to_pos index
         bottom = y + ((rect.y + rect.height) / Pango.SCALE) + @config.view_line_padding
         return {
-          x: x + (rect.x / Pango.SCALE)
-          x2: x + ((rect.x + rect.width) / Pango.SCALE)
+          x: x + (rect.x / Pango.SCALE) - @base_x
+          x2: x + ((rect.x + rect.width) / Pango.SCALE) - @base_x
           y: y + (rect.y / Pango.SCALE)
           y2: bottom
         }

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -311,6 +311,7 @@ View = {
           @horizontal_scrollbar\show!
 
     @_updating_scrolling = false
+    notify @, 'on_scroll', opts
 
   insert: (text) =>
     if @selection.is_empty


### PR DESCRIPTION
This PR does two things:

1. Currently, if a completion popup appears while the text is scrolled to the right, it will appear *outside* the Howl window. https://github.com/howl-editor/howl/commit/4b63690bbc12f7bcd603d5ff53e526ccb5247ff7 fixes that.

2. Even with that fixed, when the text scrolled, the popup would stay stationary. https://github.com/howl-editor/howl/commit/d0ea33bbdedc9a5886d1afc742bb0b8d688b3280 fixes that.