### PR TITLE
Add a buffer-next command mapped to Ctrl+Tab

### DIFF
--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -46,6 +46,17 @@ command.register
   handler: (buf) -> app.editor.buffer = buf
 
 command.register
+  name: 'buffer-next',
+  description: 'Jump to the next buffer'
+  handler: ->
+    buffers = moon.copy app.buffers
+    table.sort buffers, (a, b) -> a.title < b.title
+    for i, buffer in ipairs buffers
+      if buffer.title == app.editor.buffer.title
+        app.editor.buffer = buffers[i % #buffers + 1]
+        break
+
+command.register
   name: 'buffer-reload',
   description: 'Reload the current buffer from file'
   handler: ->

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -39,6 +39,7 @@
     ctrl_shift_end:   'cursor-eof-extend'
 
     ctrl_b:           'switch-buffer'
+    ctrl_tab:         'buffer-next'
     ctrl_c:           'editor-copy'
     ctrl_d:           'editor-duplicate-current'
     ctrl_shift_e:     'cursor-goto-inspection'
@@ -65,7 +66,7 @@
     ctrl_q:           'show-doc-at-cursor'
     ctrl_space:       'editor-complete'
     ctrl_slash:       'editor-toggle-comment'
-    ctrl_tab:         'view-next'
+    ctrl_shift_tab:   'view-next'
 
     shift_insert:     'editor-paste'
     ctrl_insert:      'editor-copy'
@@ -121,6 +122,7 @@
       editor: {
         meta_shift_a:     'editor-select-all'
         meta_b:           'switch-buffer'
+        meta_tab:         'buffer-next'
         meta_c:           'editor-copy'
         meta_d:           'editor-duplicate-current'
         meta_f:           'buffer-search-forward'


### PR DESCRIPTION
Hello ! Sorry for my bad English ;-)

I'm new to howl, and I found that switching between buffers was quite long (you need to press Ctrl+B, then to select the buffer, and then to press Enter). So I tried to create a very fast-to-use buffer-next command, mapped to Ctrl+Tab (the view-next command being remapped to Ctrl+Shift+Tab, I use it less often because using the mouse to change active view is often faster). Note that I have never programmed in MoonScript before, so I guess that my code is very dirty.

This PR proposes this change to merge.

Note: I love howl, because it is simple but powerful !
