### PR TITLE
Support process based inspections

### DIFF
--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -182,7 +182,18 @@ update_buffer = (buffer, editor) ->
   if data.last_inspect and data.last_inspect >= buffer.last_changed
     return
 
-  criticize buffer
+  -- we mark this automatic inspection run with a serial
+  update_serial = (data.inspections_update or 0) + 1
+  data.inspections_update = update_serial
+
+  criticisms = inspect buffer
+  -- check serial to avoid applying out-of-date criticisms
+  unless data.inspections_update == update_serial
+    log.warn "Ignoring stale inspection update - slow inspection processes?"
+    return
+
+  criticize buffer, criticisms
+
   editor or= app\editor_for_buffer buffer
   if editor
     update_inspections_display editor

--- a/lib/howl/io/process_output.moon
+++ b/lib/howl/io/process_output.moon
@@ -1,0 +1,41 @@
+-- Copyright 2016 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+glib = require 'ljglibs.glib'
+{:File} = howl.io
+
+append = table.insert
+
+line_p = r'(\\d+):(?:(\\d+):)?\\s+(.+)'
+
+parse = (output, opts = {}) ->
+  locations = {}
+  base_dir = opts.directory or File glib.get_current_dir!
+  lines = [l for l in output\gmatch('[^\n]+') ]
+  for i = 1, #lines
+    line = lines[i]
+    nr, column, message = line\umatch line_p
+
+    continue unless nr
+
+    file = line\match '^([^:]+):%d+'
+    if file
+      if file == '-' or file\match('^%d+$')
+        file = nil
+      else
+        file = File.is_absolute(file) and File(file) or base_dir\join(file)
+
+    tokens = [t for t in message\gmatch "[`'‘]([^'`‘]+)[`'‘]"]
+    tokens = nil if #tokens == 0
+
+    append locations, {
+      :file,
+      line: tonumber(nr),
+      column: tonumber(column),
+      :message
+      :tokens
+    }
+
+  locations
+
+:parse

--- a/spec/inspect_spec.moon
+++ b/spec/inspect_spec.moon
@@ -2,6 +2,7 @@
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 import inspect, inspection, Buffer, mode from howl
+File = howl.io.File
 
 describe 'inspect', ->
   local buffer, inspector
@@ -85,6 +86,28 @@ describe 'inspect', ->
               { message: 'some warning', search: 'zed' },
             }
            }, res
+          done!
+
+    context 'when an inspector command contains a <file> placeholder', ->
+      it "is skipped if the buffer has no associated file", (done) ->
+        inspector = 'echo "foo:1: <file> urk"'
+        howl_async ->
+          buffer.mode.config.inspectors = {'test-inspector'}
+          assert.same {}, inspect.inspect(buffer)
+          done!
+
+      it "is expanded with the buffer's file's path", (done) ->
+        file = File '/foo/bar'
+        buffer.file = file
+        inspector = cmd: 'echo "foo:1: <file>"'
+        howl_async ->
+          buffer.mode.config.inspectors = {'test-inspector'}
+          res = inspect.inspect(buffer)
+          assert.same {
+            [1]: {
+              { message: '/foo/bar' },
+            }
+          }, res
           done!
 
     it 'merges inspection results into one scathing result', ->

--- a/spec/inspect_spec.moon
+++ b/spec/inspect_spec.moon
@@ -27,6 +27,66 @@ describe 'inspect', ->
       inspect.inspect(buffer)
       assert.spy(inspector).was_called_with(buffer)
 
+    context 'when the returned inspector is a string', ->
+      it 'is run as an external command, translating default output parsing', (done) ->
+        inspector = 'echo "foo:1: warning: foo\nline 2: wrong val \\`foo\\`"'
+        howl_async ->
+          buffer.mode.config.inspectors = {'test-inspector'}
+          res = inspect.inspect(buffer)
+          assert.same {
+            [1]: {
+              { message: 'warning: foo', type: 'warning' },
+            }
+            [2]: {
+              { message: 'wrong val `foo`', search: 'foo' }
+            }
+           }, res
+          done!
+
+    context 'when the returned inspector is a table', ->
+      it 'uses the `cmd` key as the external command to run', (done) ->
+        inspector = cmd: 'echo "foo:1: some warning"'
+        howl_async ->
+          buffer.mode.config.inspectors = {'test-inspector'}
+          res = inspect.inspect(buffer)
+          assert.same {
+            [1]: {
+              { message: 'some warning' },
+            }
+           }, res
+          done!
+
+      it 'allows for custom parsing via the `parse` key', (done) ->
+        inspector = {
+          cmd: 'echo "output"'
+          parse: spy.new -> { {line: 1, message: 'foo' } }
+        }
+        howl_async ->
+          buffer.mode.config.inspectors = {'test-inspector'}
+          res = inspect.inspect(buffer)
+          assert.spy(inspector.parse).was_called_with('output\n')
+          assert.same {
+            [1]: {
+              { message: 'foo' },
+            }
+           }, res
+          done!
+
+      it 'allows for custom post processing via the `post_parse` key', (done) ->
+        inspector = {
+          cmd: 'echo "foo:1: some warning"'
+          post_parse: (inspections) -> inspections[1].search = 'zed'
+        }
+        howl_async ->
+          buffer.mode.config.inspectors = {'test-inspector'}
+          res = inspect.inspect(buffer)
+          assert.same {
+            [1]: {
+              { message: 'some warning', search: 'zed' },
+            }
+           }, res
+          done!
+
     it 'merges inspection results into one scathing result', ->
       inspection.register name: 'inspector1', factory: ->
         -> { { line: 1, type: 'error', message: 'foo' } }

--- a/spec/io/process_output_spec.moon
+++ b/spec/io/process_output_spec.moon
@@ -1,0 +1,50 @@
+-- Copyright 2016 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+{:parse} = howl.io.process_output
+{:File} = howl.io
+
+describe 'process_output', ->
+  describe 'parse(output, opts = {})', ->
+    it 'parses out line numbers and messages', ->
+      assert.same {
+        { line: 2, message: 'foo' }
+      }, parse "2: foo"
+
+    it 'parses out relevant tokens', ->
+      assert.same {
+        {
+          line: 3,
+          message: "unused: `foo`, 'bar', ‘zed’",
+          tokens: {'foo', 'bar', 'zed'}
+        }
+      }, parse "3: unused: `foo`, 'bar', ‘zed’"
+
+    it 'parses out columns where available', ->
+      assert.same {
+        { line: 2, column: 12, message: 'foo' }
+      }, parse "2:12: foo"
+
+    context 'file references', ->
+      it 'parses out and resolves file references according to the directory option', ->
+        with_tmpdir (dir) ->
+          assert.same {
+            { file: dir\join('zed.moon'), line: 3, message: 'msg' }
+          }, parse "zed.moon:3: msg", directory: dir
+
+      it 'defaults to the current working directory if the directory option is missing', ->
+        glib = require 'ljglibs.glib'
+        cwd = File glib.get_current_dir!
+        assert.same {
+          { file: cwd\join('zed.moon'), line: 3, message: 'msg' }
+        }, parse "zed.moon:3: msg"
+
+      it 'leaves absolute paths alone', ->
+        assert.same {
+          { file: File('/tmp/zed.moon'), line: 3, message: 'msg' }
+        }, parse "/tmp/zed.moon:3: msg"
+
+      it 'leaves "-" paths alone', ->
+        assert.same {
+          { line: 3, message: 'msg' }
+        }, parse "-:3: msg"


### PR DESCRIPTION
As part two of the new inspections framework introduced earlier comes this support for process based inspections. This makes it easy to just provide a command that should be run, with its output parsed for inspections.

Along with this comes a new module as well, `howl.io.process_output`, intended to provide one place for keeping the parsing smarts for parsing process output for various file references / messages.
