### PR TITLE
Upgrade LPeg to version 1.0.0.

### DIFF
--- a/lib/howl/util/lpeg_lexer.moon
+++ b/lib/howl/util/lpeg_lexer.moon
@@ -178,7 +178,7 @@ export *
 -- helper patterns
 eol = eol_p
 blank = blank_p
-line_start = -B(1) + B(eol)
+line_start = B'\n' + B'\r\n' + B'\r' + -B(1)
 float = digit^0 * P'.' * digit^1 * (S'eE' * P('-')^0 * digit^1)^0
 hexadecimal = P'0' * S'xX' * xdigit^1 * -#(digit + alpha)
 hexadecimal_float =  P'0' * S'xX' * xdigit^1 * (P'.' * xdigit^1)^0 * (S'pP' * S'-+'^0 * xdigit^1)^0 * -#(digit + alpha)
@@ -204,11 +204,11 @@ sequence = (...) ->
 
 word = (...) ->
   word_char = alpha + '_' + digit
-  (-B(1) + B(-word_char)) * any(...) * -word_char
+  (-B(1) + -B(word_char)) * any(...) * -word_char
 
 separate = (p) ->
   word_char = alpha + '_' + digit
-  (-B(1) + B(-word_char)) * p * (-word_char + -#P(1))
+  (-B(1) + -B(word_char)) * p * (-word_char + -#P(1))
 
 scan_until = (stop_p, escape_p) ->
   stop_p = P(stop_p)

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,11 +13,12 @@ LUAJIT_CFLAGS = -I$(LUAJIT_SRC_DIR)
 LUAJIT_ARCHIVE = $(LUAJIT)/src/libluajit.a
 LUAJIT_URL = http://nordman.org/mirror/luajit/$(LUAJIT_VER).tar.gz
 
-LPEG_VER = lpeg-0.10.2
-LPEG_CHECKSUM = 1402433f02e37ddadff04a3d4118b026
+LPEG_VER = lpeg-1.0.0
+LPEG_CHECKSUM = 0aec64ccd13996202ad0c099e2877ece
 LPEG = deps/$(LPEG_VER)
-LPEG_OBJECT = $(LPEG)/lpeg.o
-LPEG_URL = http://nordman.org/mirror/lpeg/$(LPEG_VER).tar.gz
+LPEG_OBJECTS = $(LPEG)/lpcap.o $(LPEG)/lpcode.o $(LPEG)/lpprint.o $(LPEG)/lptree.o $(LPEG)/lpvm.o
+#LPEG_URL = http://nordman.org/mirror/lpeg/$(LPEG_VER).tar.gz
+LPEG_URL = http://www.inf.puc-rio.br/~roberto/lpeg/$(LPEG_VER).tar.gz
 
 CFLAGS = -Wall -O2 -g $(LUAJIT_CFLAGS) $(GTK_CFLAGS) -DHOWL_PREFIX=$(PREFIX)
 ARCHIVES = $(LUAJIT_ARCHIVE)
@@ -31,7 +32,7 @@ else
 	LD_FLAGS = -Wl,-E
 endif
 OBJECTS = main.o process_helpers.o
-DEP_OBJECTS = $(LPEG_OBJECT)
+DEP_OBJECTS = $(LPEG_OBJECTS)
 
 all: howl bytecode
 
@@ -44,8 +45,8 @@ ${OBJECTS}: %.o : %.c main.h $(LUAJIT)
 $(LPEG):
 	@tools/download $(LPEG_URL) $(LPEG_CHECKSUM) tar xzf {file} -C deps
 
-$(LPEG_OBJECT): $(LPEG) $(LUAJIT)
-	cd ${LPEG} && $(MAKE) lpeg.o LUADIR=../../$(LUAJIT)/src
+$(LPEG_OBJECTS): $(LPEG) $(LUAJIT)
+	$(MAKE) -C $(LPEG) $(notdir $@) LUADIR=../../$(LUAJIT)/src
 
 $(LUAJIT):
 	@tools/download $(LUAJIT_URL) $(LUAJIT_CHECKSUM) tar xzf {file} -C deps
@@ -60,8 +61,8 @@ deps-purge:
 	rm -rf $(LUAJIT) $(LPEG)
 
 deps-clean:
-	@rm $(LPEG_OBJECT) || true
-	@cd $(LUAJIT) && $(MAKE) clean
+	@make -C $(LPEG) clean
+	@make -C $(LUAJIT) clean
 
 clean:
 	-rm -f ${OBJECTS}


### PR DESCRIPTION
LPeg 1.0.0 was released in Sep 2015, and Textadept is also using it since Oct 2015, so it might be a good idea to upgrade.

There are currently 2 test-suite failures which may indicate bugs in the grammars.

Please try it and give it some review.