### PR TITLE
Major config implementation refactor

### DIFF
--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -10,7 +10,7 @@ ffi = require 'ffi'
 append = table.insert
 min = math.min
 
-buffer_id = 1
+buffer_id = 0
 
 next_id = ->
   buffer_id += 1

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -12,7 +12,7 @@ min = math.min
 
 buffer_id = 1
 
-_next_id = ->
+next_id = ->
   buffer_id += 1
   return buffer_id
 
@@ -20,7 +20,7 @@ class Buffer extends PropertyObject
   new: (b_mode = {}) =>
     super!
 
-    @id = _next_id!
+    @id = next_id!
     @_buffer = aullar.Buffer!
     @markers = BufferMarkers @_buffer
     @completers = {}

--- a/lib/howl/config.moon
+++ b/lib/howl/config.moon
@@ -175,18 +175,15 @@ proxy = (scope, write_layer='default', read_layer=write_layer) ->
   }
   setmetatable proxy, proxy_mt
 
-
 copy = (scope, new_scope) ->
-  scopes[new_scope] = scopes[scope]
+  scopes[new_scope] = {}
+  if scopes[scope]
+    for k, v in pairs scopes[scope]
+      scopes[new_scope][k] = moon.copy v
 
 delete = (scope) ->
   error 'Cannot delete global scope' if scope == ''
   scopes[scope] = nil
-
-move = (scope, new_scope) ->
-  error 'Cannot move global scope' if scope == ''
-  copy(scope, new_scope)
-  delete(scope)
 
 config = {
   :definitions

--- a/lib/howl/config.moon
+++ b/lib/howl/config.moon
@@ -196,7 +196,6 @@ config = {
   :proxy
   :copy
   :delete
-  :move
 }
 
 return setmetatable config, {

--- a/site/source/doc/api/config.md
+++ b/site/source/doc/api/config.md
@@ -21,7 +21,7 @@ Values for configuration variables can be specified at multiple levels, called
 ### Scopes
 
 The *scope* is a path within a hierarchical namespace. An example of a scope is
-`'file/home/user/my_dir'` with represents the file path  `/home/user/my_dir`.
+`'file/home/user/my_dir'` which represents the file path  `/home/user/my_dir`.
 Some common scopes are:
 
 - **Global scope**
@@ -67,7 +67,7 @@ The `set-for-mode` command sets the mode specific layer at the global scope.
 The evaluation of a configuration value works as follows:
 
   - scopes are inspected most specific to least specific
-  - withn each scope the specified layer is checked before falling back to the `default` layer.
+  - within each scope the specified layer is checked before falling back to the `default` layer.
 
 Consider an example - evaluation of the configuration variable, say `font_size`,
 for the file `/home/user/my_file.moon` in `moonscript` mode. The following
@@ -130,9 +130,12 @@ Defines a new config variable. Options can contain the following fields:
 
 - `description`: A description of the configuration variable (_required_)
 
-- `scope`: An optional value specifying the scope of the variable. One of
-  `local` and `global`. Local variables can be set at any scope, whereas
-  global variables can only be set directly at the global scope.
+- `scope`: An optional value that specifies what scopes are valid for this
+  config variable. Note that this parameter does not specify a scope directly,
+  but instead specifies one of the following values:
+
+  - `"local"` - variable can be set for any scope
+  - `"global"` - variable can be set for the global scope only
 
 - `validate`: A function that will be used for validating any values set
   for this variable. Whenever a value is set for the variable, this function

--- a/site/source/doc/api/config.md
+++ b/site/source/doc/api/config.md
@@ -7,45 +7,107 @@ title: howl.config
 ## Overview
 
 Things that are meant to be configurable in Howl are exposed as "configuration
-variables". Configuration variables can be set either interactively from within
-Howl, using the `set` command, or programmatically from code. To get an overview
-of currently available variables, type `set` and press `space` at the readline
-to view a list.
+variables". An example configuration variable is `font_size`, which sets the
+size of the main font.
 
-Configuration variables can be specified at three different levels in Howl,
-in ascending order of priority:
+Configuration variables are set either interactively from within Howl, using the
+`set` command, or programmatically from code. To get an overview of currently
+available variables, open the command line, type `set` and press `space` - this
+shows a list of all variables.
 
-- *Globally*
+Values for configuration variables can be specified at multiple levels, called
+*scopes*, and at multiple *layers* within each scope. These are described below.
 
-The value set for the variable is used unless overridden by a mode or buffer
-specific setting (the `set` command always sets variables globally).
+### Scopes
 
-- *Per mode*
+The *scope* is a path within a hierarchical namespace. An example of a scope is
+`'file/home/user/my_dir'` with represents the file path  `/home/user/my_dir`.
+Some common scopes are:
 
-The value is set for a particular mode (e.g. "Lua" or "Ruby"), and is applied
-whenever a buffer with that particular mode is active. The value is used unless
-overridden by a buffer specific setting, and overrides any global setting.
+- **Global scope**
 
-- *Per buffer*
+  The global scope is represented as the empty string `''` and the value is used
+  if no specific value is found at any nested scope. The `set` command always
+  sets variables at the global scope.
 
-The value is set for a particular buffer, and is applied whenever that buffer is
-active. The value overrides any mode specific or global setting.
+- **File path scope**
 
-As described above, variables can be set on three different levels. No matter
-the on what level they're set, they're always set (and accessed) using `config`
-objects. For global accesses, you would use `howl.config` (this module). For
-mode variables you access variables using the config object on a particular mode
-instance, and similarly for buffer variables you use the config object for a
-particular buffer.
+  File path scopes are used to specify configuration for specific files
+  directories. A file path scope starts with `'file/'`, e.g.
+  `'file/home/user/folder'`, and the value applies to all files at or below the
+  specified path.
 
-The following code snippet illustrates the idiomatic ways of setting variables
-on different levels:
+  This value overrides any value set by a parent scope.
+
+- **Unsaved file scope (buffer scope)**
+
+  Unsaved file scopes are used to specify configuraiton for buffers that are not
+  associated with any file. These scopes start with `'buffer'`, e.g.
+  `'buffer/1234'`, and the value applies to the specific buffer only.
+
+  The `set-for-buffer` command sets variables at the file or buffer scope.
+
+### Layers
+
+Within each scope, multiple layers are available for configuration. By default,
+when a value is specified for a scope, it is set for the `default` layer within
+that scope. However, a value may also be set for another layer in the same
+scope, for instance it may be set for the `'mode:moonscript'` layer. This is
+used to define values for specific a buffer [mode]. Layer names are not abitrary
+tags but are a predefined set of string tags and the same set of layers is
+available at *all* scopes.
+
+Within each scope, the layer specific value applies. If the requested layer
+value does not exist, the `default` layer value applies.
+
+The `set-for-mode` command sets the mode specific layer at the global scope.
+
+### Evaluation
+
+The evaluation of a configuration value works as follows:
+
+  - scopes are inspected most specific to least specific
+  - withn each scope the specified layer is checked before falling back to the `default` layer.
+
+Consider an example - evaluation of the configuration variable, say `font_size`,
+for the file `/home/user/my_file.moon` in `moonscript` mode. The following
+configuration values are checked, in order, and the first value found is
+returned:
+
+```
+ 1. scope='file/home/user/my_file.moon', layer='mode:moonscript'
+ 2. scope='file/home/user/my_file.moon', layer='default'
+
+ 3. scope='file/home/user', layer='mode:moonscript'
+ 4. scope='file/home/user', layer='default'
+
+ 5. scope='file/home', layer='mode:moonscript'
+ 6. scope='file/home', layer='default'
+
+ 7. scope='file', layer='mode:moonscript'
+ 8. scope='file', layer='default'
+
+ 9. scope='', layer='mode:moonscript'
+10. scope='', layer='default'
+```
+
+
+### API
+
+The primitive API consists of [`get()`](#get) and [`set`](#set) calls which
+accept scope and layer as additional parameters. However, the following code
+snippet illustrates the idiomatic ways of setting variables globally, globally
+for a mode, and for a specific buffer only:
 
 ```lua
 howl.config.my_var = 'foo'
 howl.mode.by_name('ruby').config.my_var = 'foo'
 howl.app:new_buffer().config.my_var = 'foo'
 ```
+
+Note that internally the values are organized within scopes and layers, but this
+convinient API is available on [buffer] and [mode] objects. [Proxy](#proxy)
+objects, described below are used to build the convinience API.
 
 _See also_:
 
@@ -69,9 +131,8 @@ Defines a new config variable. Options can contain the following fields:
 - `description`: A description of the configuration variable (_required_)
 
 - `scope`: An optional value specifying the scope of the variable. One of
-  `local` and `global`. Local variables are only allowed to be set for a
-  [Buffer] or a [mode], whereas a global variable can only be directly on
-  the global config.
+  `local` and `global`. Local variables can be set at any scope, whereas
+  global variables can only be directly at the global scope.
 
 - `validate`: A function that will be used for validating any values set
   for this variable. Whenever a value is set for the variable, this function
@@ -105,59 +166,57 @@ into a native representation.
   - string
   - string_list
 
-### get (name)
+### get (name, scope, layer)
 
-Gets the global value of the variable named `name`. While getting the value of a
-variable using `get` is perfectly fine, note that the idiomatic way of getting
-variables values globally is to just to index the config module, like so:
+Gets the global value of the variable named `name` for the scope `scope` and
+layer `layer`. While getting the value of a variable using `get` is perfectly
+fine, note that the idiomatic way of getting variables values globally is to
+just to index the config module, like so:
 
 ```lua
 local val = howl.config.my_variable
 ```
 
-### local_proxy ()
+The [Evaluation](#Evaluation) section above describes how the value is computed.
 
-Returns a new configuration proxy object. A proxy object offers access to all
-configuration variables defined in Howl, using simple indexing:
+### proxy (scope, write_layer='default', read_layer)
+
+Returns a new configuration proxy object, which offers a convinient API to get
+and set values for a specific scope and layer. A proxy object offers access to
+all configuration variables, using simple indexing:
 
 ```lua
-proxy = howl.config.local_proxy()
+proxy = howl.config.proxy('file/path/to/my_file')
 proxy.indent -- => 2
 ```
 
-Assigning to a proxy object only sets the value locally however:
+Assigning to a proxy object only sets the value for the specified scope:
 
 ```lua
-proxy = howl.config.local_proxy()
+proxy = howl.config.proxy('file/path/to/my_file')
 proxy.indent = 5
 howl.config.indent -- => 2
 proxy.indent -- => 5
 ```
 
-Proxy objects offers one additional feature in addition to the above; the
-possibility of chaining to a different configuration object other than the
-global howl.config module. Using the `chain_to` method, it's possible to create
-hierarchies of configuration objects (as is done in Howl for modes and buffers):
+Getting and setting values use the default layer, when neither `write_layer` nor
+`read_layer` are specified. When `write_layer` is specified, that layer is used
+when getting and setting values. When `read_layer` is also specified, that layer
+is used when getting values only.
 
-```lua
-proxy = howl.config.local_proxy()
-next_proxy = howl.config.local_proxy()
-next_proxy.chain_to(proxy)
-```
+Note that `proxy` objects are used to provide the convinient config API for
+[buffer] and [mode] objects, as described in [API](#API) above.
 
-In the above example, `proxy` would defer any lookups not set locally to the
-global howl.config module, and `next_proxy` would defer any lookups to `proxy`.
-Proxies work against the global configuration variable definitions, and respects
-any validations, conversions, etc., specified.
+### set (name, value, scope='', layer='default')
 
-### set (name, value)
-
-Globally sets the value of the configuration variable with name `name` to be
-`value`. An error is raised for any of the following scenarios:
+Sets the value of the configuration variable with name `name`, for scope `scope`
+and layer `layer` to be `value`. An error is raised for any of the following
+scenarios:
 
 - There exists no known variable with name `name`
 - `value` is not a valid value for the parameter
-- The parameter was defined with the scope "local"
+- The scope is `''` (i.e. global) but the parameter is defined as 'local'
+- The scope is not global, but the parameter is defained as 'global'
 
 Upon a successful change, any listeners are notified. To remove any previously
 set value, pass `nil` as `value`. While setting a variable using `set` is
@@ -178,5 +237,5 @@ callable, will be invoked whenever the specified variable has a new value set.
 *value* - The new value of the parameter
 *is_local* - A boolean indicating whether the value was set locally or globally.
 
-[Buffer]: buffer.html
+[buffer]: buffer.html
 [mode]: mode.html

--- a/site/source/doc/api/config.md
+++ b/site/source/doc/api/config.md
@@ -96,8 +96,8 @@ returned:
 
 The primitive API consists of [`get()`](#get) and [`set`](#set) calls which
 accept scope and layer as additional parameters. However, the following code
-snippet illustrates the idiomatic ways of setting variables globally, globally
-for a mode, and for a specific buffer only:
+snippet illustrates the idiomatic ways of setting variables globally, for a
+mode, and for a specific buffer only:
 
 ```lua
 howl.config.my_var = 'foo'
@@ -107,7 +107,7 @@ howl.app:new_buffer().config.my_var = 'foo'
 
 Note that internally the values are organized within scopes and layers, but this
 convenient API is available on [buffer] and [mode] objects. [Proxy](#proxy)
-objects, described below are used to build the convinience API.
+objects, described below are used to build the convenience API.
 
 _See also_:
 

--- a/site/source/doc/api/config.md
+++ b/site/source/doc/api/config.md
@@ -106,7 +106,7 @@ howl.app:new_buffer().config.my_var = 'foo'
 ```
 
 Note that internally the values are organized within scopes and layers, but this
-convinient API is available on [buffer] and [mode] objects. [Proxy](#proxy)
+convenient API is available on [buffer] and [mode] objects. [Proxy](#proxy)
 objects, described below are used to build the convinience API.
 
 _See also_:
@@ -132,7 +132,7 @@ Defines a new config variable. Options can contain the following fields:
 
 - `scope`: An optional value specifying the scope of the variable. One of
   `local` and `global`. Local variables can be set at any scope, whereas
-  global variables can only be directly at the global scope.
+  global variables can only be set directly at the global scope.
 
 - `validate`: A function that will be used for validating any values set
   for this variable. Whenever a value is set for the variable, this function
@@ -171,7 +171,7 @@ into a native representation.
 Gets the global value of the variable named `name` for the scope `scope` and
 layer `layer`. While getting the value of a variable using `get` is perfectly
 fine, note that the idiomatic way of getting variables values globally is to
-just to index the config module, like so:
+just index the config module, like so:
 
 ```lua
 local val = howl.config.my_variable
@@ -181,7 +181,7 @@ The [Evaluation](#Evaluation) section above describes how the value is computed.
 
 ### proxy (scope, write_layer='default', read_layer)
 
-Returns a new configuration proxy object, which offers a convinient API to get
+Returns a new configuration proxy object, which offers a convenient API to get
 and set values for a specific scope and layer. A proxy object offers access to
 all configuration variables, using simple indexing:
 
@@ -204,7 +204,7 @@ Getting and setting values use the default layer, when neither `write_layer` nor
 when getting and setting values. When `read_layer` is also specified, that layer
 is used when getting values only.
 
-Note that `proxy` objects are used to provide the convinient config API for
+Note that `proxy` objects are used to provide the convenient config API for
 [buffer] and [mode] objects, as described in [API](#API) above.
 
 ### set (name, value, scope='', layer='default')
@@ -216,7 +216,7 @@ scenarios:
 - There exists no known variable with name `name`
 - `value` is not a valid value for the parameter
 - The scope is `''` (i.e. global) but the parameter is defined as 'local'
-- The scope is not global, but the parameter is defained as 'global'
+- The scope is not global, but the parameter is defined as 'global'
 
 Upon a successful change, any listeners are notified. To remove any previously
 set value, pass `nil` as `value`. While setting a variable using `set` is

--- a/spec/config_spec.moon
+++ b/spec/config_spec.moon
@@ -364,7 +364,6 @@ describe 'config', ->
           proxy_inner_mixed = config.proxy '/outer/inner', 'default', 'layer:one'
           proxy_inner_sub = config.proxy '/outer/inner', 'layer:sub'
 
-
         it 'layer is checked before default values at each scope', ->
           proxy_inner_layered.my_var = 4
           proxy_inner.my_var = 3


### PR DESCRIPTION
While buffer.config, mode.config and the set* commands can still be
used the same way, the underlying implementation has been changed.

The config is now organized along two dimensions - a primary dimension
called scope which is a hierarchial namespace, and a secondary
dimension called layer which can be any string. When defined, a layer
may be associated with another layer as the parent. For each scope,
multiple layers may exist and for each layer within the scope multiple
name/value pairs may exist.

Values are looked up in a scope, and if not found, the parent scopes
are checked, all the way from the immedidate parent to the global
scope, represented by the emtpy string ''. For each scope, value
resolution may check multiple layers.

Proxy config objects on buffer and mode hide most of this machinery by
exposing config values as attributes.