### PR TITLE
Ruby inspection

### DIFF
--- a/bundles/ruby/init.moon
+++ b/bundles/ruby/init.moon
@@ -23,8 +23,15 @@ mode_reg =
   create: -> bundle_load('ruby_mode')
 
 howl.mode.register mode_reg
+howl.inspection.register {
+  name: 'ruby',
+  factory: (buffer) ->
+    bundle_load('ruby_inspector') buffer
+}
 
-unload = -> howl.mode.unregister 'ruby'
+unload = ->
+  howl.mode.unregister 'ruby'
+  howl.inspection.unregister 'ruby'
 
 return {
   info:

--- a/bundles/ruby/init.moon
+++ b/bundles/ruby/init.moon
@@ -32,4 +32,6 @@ return {
     description: 'Ruby bundle',
     license: 'MIT',
   :unload
+
+  util: bundle_load('util')
 }

--- a/bundles/ruby/ruby_inspector.moon
+++ b/bundles/ruby/ruby_inspector.moon
@@ -1,0 +1,19 @@
+-- Copyright 2016 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+util = bundle_load 'util'
+
+(buffer) ->
+  path = buffer.file or buffer.directory
+  ruby_cmd = util.ruby_command_for path
+
+  {
+    cmd: "#{ruby_cmd} -w -c"
+
+    post_parse: (inspections) ->
+      for i in *inspections
+        unless i.search
+          search = i.message\match 'variable %- (.+)$'
+          search or= i.message\match "`([^']+)'"
+          i.search = search
+  }

--- a/bundles/ruby/ruby_mode.moon
+++ b/bundles/ruby/ruby_mode.moon
@@ -39,6 +39,7 @@ continuation_indent = (line, indent_level) ->
 
   default_config:
     word_pattern: r'\\b\\w[\\w\\d_]+[?!=]?\\b'
+    inspectors: { 'ruby' }
 
   indentation: {
     more_after: {

--- a/bundles/ruby/spec/util_spec.moon
+++ b/bundles/ruby/spec/util_spec.moon
@@ -1,0 +1,55 @@
+-- Copyright 2016 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+{:bundle} = howl
+{:File} = howl.io
+{:env} = howl.sys
+
+describe 'bundle.ruby.util', ->
+  local util
+
+  setup ->
+    bundle.load_by_name 'ruby'
+    util = _G.bundles.ruby.util
+
+  teardown -> bundle.unload 'ruby'
+
+  describe 'ruby_version_for(path)', ->
+    it 'supports .ruby-version files', ->
+      with_tmpdir (dir) ->
+        ruby_version = dir / '.ruby-version'
+        ruby_version.contents = '2.3\n'
+        root_file = dir / 'root.rb'
+        root_file\touch!
+        sub_file = dir\join('sub/below.rb')
+        sub_file\mkdir_p!
+        for path in *{root_file, sub_file, dir}
+          assert.equal '2.3', util.ruby_version_for path
+
+    it 'returns nil if no particular version is found', ->
+      with_tmpdir (dir) ->
+        assert.is_nil util.ruby_version_for dir\join('sub.rb')
+        assert.is_nil util.ruby_version_for dir
+
+  describe 'ruby_command_for(path)', ->
+    REAL_HOME = env.HOME
+
+    describe 'with a .ruby-version file present', ->
+      local dir
+
+      before_each ->
+        dir = File.tmpdir!
+        ruby_version = dir / '.ruby-version'
+        ruby_version.contents = '2.3\n'
+        env.HOME = dir.path
+
+      after_each ->
+        env.HOME = REAL_HOME
+        dir\delete_all! if dir.exists
+
+      it 'returns a matching executable from the rvm rubies if possible', ->
+        exec = with dir\join('.rvm/wrappers/ruby-2.3.0/ruby')
+          \mkdir_p!
+          \touch!
+
+        assert.equals exec.path, util.ruby_command_for dir

--- a/bundles/ruby/util.moon
+++ b/bundles/ruby/util.moon
@@ -1,0 +1,38 @@
+{:File} = howl.io
+sys = howl.sys
+
+version_file_for = (file) ->
+  dir = file.is_directory and file or file.parent
+  while dir
+    version_file = dir\join('.ruby-version')
+
+    return version_file if version_file.exists
+    dir = dir.parent
+
+rvm_ruby = (version) ->
+  for rvm_dir in *{
+    File(sys.env.HOME)\join('.rvm'),
+    File('/usr/local/rvm'),
+  }
+    wrappers = rvm_dir\join('wrappers')
+    if wrappers.exists
+      for c in *wrappers.children
+        if c.basename\find version
+          return c\join('ruby').path
+
+ruby_version_for = (file) ->
+  version_file = version_file_for file
+  return nil unless version_file
+
+  version_file.contents.stripped
+
+ruby_command_for = (path) ->
+  version = path and ruby_version_for(path)
+  if version
+    cmd = rvm_ruby(version)
+    return cmd if cmd
+
+  cmd = sys.find_executable 'ruby'
+  cmd or rvm_ruby('default')
+
+:ruby_version_for, :ruby_command_for


### PR DESCRIPTION
This adds command-based inspection support for Ruby. It supports project-specific ruby versions (via `.ruby-version`) and RVM where detected.