### PR TITLE
Always log non-info to the terminal

### DIFF
--- a/lib/howl/log.moon
+++ b/lib/howl/log.moon
@@ -29,13 +29,18 @@ dispatch = (level, message) ->
   entry = :message, :level
   append entries, entry
   window = _G.howl.app.window
+  showed_message = false
+
   if window and window.visible
     status = window.status
     command_line = window.command_line
     essentials = essentials_of message
     status[level] status, essentials
     command_line\notify essentials, level if command_line.showing
-  elseif not _G.howl.app.args.spec
+    showed_message = true
+
+  -- Avoid print all sorts of random info to the terminal if it's already on the window
+  if not _G.howl.app.args.spec and (not showed_message or level != 'info')
     _G.print message
 
   while #entries > config.max_log_entries and #entries > 0


### PR DESCRIPTION
Previously, if an error occurred, Howl would always try to show it on the window. The problem is that that  makes it very hard to open bug reports, since you have to try and re-type the error message word-for-word, and it can also make it difficult when one error overshadows another.