### PR TITLE
Add temporary file backups during saving

### DIFF
--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -205,8 +205,8 @@ class Buffer extends PropertyObject
       local backup
       if @config.backup_files and @file.exists
         file_stem = "#{@file.basename}::#{ffi.C.getpid!}::#{@file.etag}"
-        backup_directory = @config.backup_directory or howl.app.backupdir
-        backup = File(@config.backup_directory) / file_stem
+        backup_directory = File @config.backup_directory or howl.app.settings.backupdir
+        backup = backup_directory / file_stem
         status, err = pcall @file\copy, backup, {'COPY_OVERWRITE', 'COPY_ALL_METADATA'}
         if not status
           log.error "Failed to write backup file #{backup} for #{@file}: #{err}"

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -202,7 +202,7 @@ class Buffer extends PropertyObject
         @append @eol
 
       local backup
-      if config.backup_files and @file.exists
+      if @config.backup_files and @file.exists
         backup = howl.app.settings.backupdir / ("#{@file.basename}::#{ffi.C.getpid!}::#{@file.etag}")
         status, err = pcall @file\copy, backup, {'COPY_OVERWRITE', 'COPY_ALL_METADATA'}
         if not status

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -204,7 +204,7 @@ class Buffer extends PropertyObject
       local backup
       if config.backup_files and @file.exists
         backup = howl.app.settings.backupdir / ("#{@file.basename}::#{ffi.C.getpid!}::#{@file.etag}")
-        status, err = pcall @file\copy, backup, {'OVERWRITE', 'ALL_METADATA'}
+        status, err = pcall @file\copy, backup, {'COPY_OVERWRITE', 'COPY_ALL_METADATA'}
         if not status
           log.error "Failed to write backup file #{backup} for #{@file}: #{err}"
           backup = nil

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -3,6 +3,7 @@
 
 import BufferContext, BufferLines, BufferMarkers, Chunk, config, mode, signal, sys from howl
 import PropertyObject from howl.util.moon
+import File from howl.io
 aullar = require 'aullar'
 
 ffi = require 'ffi'
@@ -203,7 +204,9 @@ class Buffer extends PropertyObject
 
       local backup
       if @config.backup_files and @file.exists
-        backup = howl.app.settings.backupdir / ("#{@file.basename}::#{ffi.C.getpid!}::#{@file.etag}")
+        file_stem = "#{@file.basename}::#{ffi.C.getpid!}::#{@file.etag}"
+        backup_directory = @config.backup_directory or howl.app.backupdir
+        backup = File(@config.backup_directory) / file_stem
         status, err = pcall @file\copy, backup, {'COPY_OVERWRITE', 'COPY_ALL_METADATA'}
         if not status
           log.error "Failed to write backup file #{backup} for #{@file}: #{err}"
@@ -376,6 +379,12 @@ with config
     description: 'Whether or not to make temporary backups of files while saving'
     default: false
     type_of: 'boolean'
+
+  .define
+    name: 'backup_directory'
+    description: 'The directory to backup files while saving (defaults to ~/.howl/backups)'
+    default: nil
+    type_of: 'string'
 
 -- Signals
 

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -204,7 +204,7 @@ class Buffer extends PropertyObject
       local backup
       if config.backup_files and @file.exists
         backup = howl.app.settings.backupdir / ("#{@file.basename}::#{ffi.C.getpid!}::#{@file.etag}")
-        status, err = pcall @file\copy, backup, {'overwrite', 'all_metadata'}
+        status, err = pcall @file\copy, backup, {'OVERWRITE', 'ALL_METADATA'}
         if not status
           log.error "Failed to write backup file #{backup} for #{@file}: #{err}"
           backup = nil

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -374,7 +374,7 @@ with config
   .define
     name: 'backup_files'
     description: 'Whether or not to make temporary backups of files while saving'
-    default: true
+    default: false
     type_of: 'boolean'
 
 -- Signals

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -203,8 +203,8 @@ class Buffer extends PropertyObject
 
       local backup
       if config.backup_files and @file.exists
-        backup = howl.app.settings.backupdir / ("#{@file.basename}::#{ffi.C.getpid!}")
-        status, err = pcall -> backup.contents = @file.contents
+        backup = howl.app.settings.backupdir / ("#{@file.basename}::#{ffi.C.getpid!}::#{@file.etag}")
+        status, err = pcall @file\copy, backup, {'overwrite', 'all_metadata'}
         if not status
           log.error "Failed to write backup file #{backup} for #{@file}: #{err}"
           backup = nil

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -202,7 +202,7 @@ class Buffer extends PropertyObject
         @append @eol
 
       local backup
-      if config.backup_files
+      if config.backup_files and @file.exists
         backup = howl.app.settings.backupdir / ("#{@file.basename}::#{ffi.C.getpid!}")
         status, err = pcall -> backup.contents = @file.contents
         if not status

--- a/lib/howl/cdefs/init.moon
+++ b/lib/howl/cdefs/init.moon
@@ -11,6 +11,7 @@ int strncmp(const char *s1, const char *s2, size_t n);
 
 typedef int pid_t;
 int kill(pid_t pid, int sig);
+pid_t getpid();
 
 /* process helpers */
 int process_exited_normally(int status);

--- a/lib/howl/io/file.moon
+++ b/lib/howl/io/file.moon
@@ -1,7 +1,6 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-core = require 'ljglibs.core'
 GFile = require 'ljglibs.gio.file'
 GFileInfo = require 'ljglibs.gio.file_info'
 glib = require 'ljglibs.glib'

--- a/lib/howl/io/file.moon
+++ b/lib/howl/io/file.moon
@@ -6,6 +6,7 @@ GFileInfo = require 'ljglibs.gio.file_info'
 glib = require 'ljglibs.glib'
 import PropertyObject from howl.util.moon
 append = table.insert
+bit = require 'bit'
 
 file_types = {
   [tonumber GFileInfo.TYPE_DIRECTORY]: 'directory',
@@ -200,6 +201,17 @@ class File extends PropertyObject
 
 
     files, false
+
+  copy: (dest, flags, progress) =>
+    bitflags = 0
+    flags or= {}
+
+    for flag in *flags
+      bitflag = GFile["COPY_#{flag\upper!}"]
+      error "invalid copy flag '#{flag}'" if not bitflag
+      bitflags = bit.bor bitflags, bitflag
+
+    @gfile\copy File(dest).gfile, bitflags, nil, progress
 
   tostring: => tostring @path or @uri
 

--- a/lib/howl/io/file.moon
+++ b/lib/howl/io/file.moon
@@ -1,12 +1,12 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
+core = require 'ljglibs.core'
 GFile = require 'ljglibs.gio.file'
 GFileInfo = require 'ljglibs.gio.file_info'
 glib = require 'ljglibs.glib'
 import PropertyObject from howl.util.moon
 append = table.insert
-bit = require 'bit'
 
 file_types = {
   [tonumber GFileInfo.TYPE_DIRECTORY]: 'directory',
@@ -202,16 +202,9 @@ class File extends PropertyObject
 
     files, false
 
-  copy: (dest, flags, progress) =>
-    bitflags = 0
-    flags or= {}
-
-    for flag in *flags
-      bitflag = GFile["COPY_#{flag\upper!}"]
-      error "invalid copy flag '#{flag}'" if not bitflag
-      bitflags = bit.bor bitflags, bitflag
-
-    @gfile\copy File(dest).gfile, bitflags, nil, progress
+  copy: (dest, flags) =>
+    bitflags = core.parse_flags 'G_FILE_', flags
+    @gfile\copy File(dest).gfile, bitflags, nil, nil
 
   tostring: => tostring @path or @uri
 

--- a/lib/howl/io/file.moon
+++ b/lib/howl/io/file.moon
@@ -203,8 +203,7 @@ class File extends PropertyObject
     files, false
 
   copy: (dest, flags) =>
-    bitflags = core.parse_flags 'G_FILE_', flags
-    @gfile\copy File(dest).gfile, bitflags, nil, nil
+    @gfile\copy File(dest).gfile, flags, nil, nil
 
   tostring: => tostring @path or @uri
 

--- a/lib/howl/settings.moon
+++ b/lib/howl/settings.moon
@@ -49,8 +49,12 @@ class Settings
         return
 
     @dir = dir
+
     @sysdir = @dir / 'system'
     @sysdir\mkdir! unless @sysdir.exists
+
+    @backupdir = @dir / 'backups'
+    @backupdir\mkdir! unless @backupdir.exists
 
   load_user: =>
     return unless @dir

--- a/lib/ljglibs/cdefs/gio.moon
+++ b/lib/ljglibs/cdefs/gio.moon
@@ -162,6 +162,20 @@ ffi.cdef [[
     G_FILE_CREATE_REPLACE_DESTINATION = (1 << 1)
   } GFileCreateFlags;
 
+  typedef enum {
+    G_FILE_COPY_NONE                 = 0,          /*< nick=none >*/
+    G_FILE_COPY_OVERWRITE            = (1 << 0),
+    G_FILE_COPY_BACKUP               = (1 << 1),
+    G_FILE_COPY_NOFOLLOW_SYMLINKS    = (1 << 2),
+    G_FILE_COPY_ALL_METADATA         = (1 << 3),
+    G_FILE_COPY_NO_FALLBACK_FOR_MOVE = (1 << 4),
+    G_FILE_COPY_TARGET_DEFAULT_PERMS = (1 << 5)
+  } GFileCopyFlags;
+
+  typedef void (*GFileProgressCallback)(goffset current_num_bytes,
+                                        goffset total_num_bytes,
+                                        gpointer user_data);
+
   GFile * g_file_new_for_path (const char *path);
   GFile * g_file_new_for_commandline_arg_and_cwd (const gchar *arg,
                                                   const gchar *cwd);
@@ -192,6 +206,12 @@ ffi.cdef [[
                                                GFileQueryInfoFlags flags,
                                                GCancellable *cancellable,
                                                GError **error);
+
+  gboolean g_file_copy (GFile *source, GFile *destination,
+                        GFileCopyFlags flags, GCancellable *cancellable,
+                        GFileProgressCallback progress_callback,
+                        gpointer progress_callback_data,
+                        GError **error);
 
   GFile * g_file_get_child (GFile *file, const char *name);
 

--- a/lib/ljglibs/gio/file.moon
+++ b/lib/ljglibs/gio/file.moon
@@ -70,10 +70,12 @@ core.define 'GFile', {
     self = @
     local handler, cb_handle, cb_cast, cb_data
 
-    copy_flags = core.parse_flags 'G_FILE_COPY_', flags
+    copy_flags = core.parse_flags 'G_FILE_', flags
 
     if progress_callback
       handler = (current_bytes, total_bytes) ->
+        current_bytes = tonumber ffi.cast 'goffset', current_bytes
+        total_bytes = tonumber ffi.cast 'goffset', total_bytes
         progress_callback self, current_bytes, total_bytes
 
       cb_handle = callbacks.register handler, 'file-progress'

--- a/lib/ljglibs/gio/file.moon
+++ b/lib/ljglibs/gio/file.moon
@@ -8,6 +8,7 @@ require 'ljglibs.gio.file_input_stream'
 require 'ljglibs.gio.file_output_stream'
 core = require 'ljglibs.core'
 glib = require 'ljglibs.glib'
+callbacks = require 'ljglibs.callbacks'
 import gc_ptr from require 'ljglibs.gobject'
 import g_string, catch_error from glib
 
@@ -23,7 +24,15 @@ core.define 'GFile', {
     prefix: 'G_FILE_'
 
     'QUERY_INFO_NONE',
-    'QUERY_INFO_NOFOLLOW_SYMLINKS'
+    'QUERY_INFO_NOFOLLOW_SYMLINKS',
+
+    'COPY_NONE',
+    'COPY_OVERWRITE',
+    'COPY_BACKUP',
+    'COPY_NOFOLLOW_SYMLINKS',
+    'COPY_ALL_METADATA',
+    'COPY_NO_FALLBACK_FOR_MOVE',
+    'COPY_TARGET_DEFAULT_PERMS',
   }
 
   new_for_path: (p) -> gc_ptr C.g_file_new_for_path p
@@ -56,6 +65,17 @@ core.define 'GFile', {
 
   enumerate_children: (attributes, flags = @QUERY_INFO_NONE) =>
     gc_ptr catch_error C.g_file_enumerate_children, @, attributes, flags, nil
+
+  copy: (dest, flags, cancellable, callback) =>
+    self = @
+    local cb_handle
+
+    handler = (current_bytes, total_bytes) ->
+      callback self, current_bytes, total_bytes
+
+    cb_handle = callbacks.register handler, 'file-progress'
+    cb_cast = ffi.cast('GFileProgressCallback', callbacks.void3)
+    catch_error(C.g_file_copy, @, dest, flags, cancellable, cb_cast, callbacks.cast_arg(cb_handle.id)) != 0
 
   make_directory: => catch_error(C.g_file_make_directory, @, nil) != 0
   make_directory_with_parents: => catch_error(C.g_file_make_directory_with_parents, @, nil) != 0

--- a/lib/ljglibs/gio/file.moon
+++ b/lib/ljglibs/gio/file.moon
@@ -70,6 +70,8 @@ core.define 'GFile', {
     self = @
     local handler, cb_handle, cb_cast, cb_data
 
+    copy_flags = core.parse_flags 'G_FILE_COPY_', flags
+
     if progress_callback
       handler = (current_bytes, total_bytes) ->
         progress_callback self, current_bytes, total_bytes
@@ -78,7 +80,7 @@ core.define 'GFile', {
       cb_cast = ffi.cast('GFileProgressCallback', callbacks.void3)
       cb_data = callbacks.cast_arg(cb_handle.id)
 
-    catch_error(C.g_file_copy, @, dest, flags, cancellable, cb_cast, cb_data) != 0
+    catch_error(C.g_file_copy, @, dest, copy_flags, cancellable, cb_cast, cb_data) != 0
 
   make_directory: => catch_error(C.g_file_make_directory, @, nil) != 0
   make_directory_with_parents: => catch_error(C.g_file_make_directory_with_parents, @, nil) != 0

--- a/lib/ljglibs/spec/gio/file_spec.moon
+++ b/lib/ljglibs/spec/gio/file_spec.moon
@@ -33,6 +33,25 @@ describe 'GFile', ->
   it '.parent return the parent of the file', ->
     assert.equal '/bin', GFile('/bin/ls').parent.path
 
+  describe 'copy(dest, flags, cancellable, progress_callback)', ->
+    it 'copies the given file', ->
+      with_tmpfile 'abc123', (src) ->
+        with_tmpfile '', (dst) ->
+          gdst = GFile dst
+          GFile(src)\copy gdst, {'COPY_OVERWRITE'}, nil, nil
+          assert.equals 'abc123', gdst\load_contents!
+
+    it 'calls the progress callback', ->
+      contents = string.rep "xxxxxxxxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyy zzzzzzzzzzzzzzzzzzz\n", 5000
+      with_tmpfile contents, (src) ->
+        with_tmpfile '', (dst) ->
+          finished = false
+          gsrc = GFile src
+          gsrc\copy GFile(dst), {'COPY_OVERWRITE'}, nil, (file, current, total) ->
+            assert.same gsrc, file
+            finished = true if current == total
+          assert.is_true finished
+
   describe 'get_child(name)', ->
     it 'returns a new file for the given child', ->
       parent = GFile '/bin'

--- a/site/source/doc/api/io/file.md
+++ b/site/source/doc/api/io/file.md
@@ -162,6 +162,14 @@ in which case it is considered a path, or another File instance. When target is
 a string holding a relative path, `base_directory` is used for resolving the
 relative path to an absolute path if given.
 
+### copy (dest, flags)
+
+Copies the contents of the current file to `dest`. Valid values for the `flags`
+table include `COPY_OVERWRITE`, `COPY_BACKUP`, `COPY_NOFOLLOW_SYMLINKS`,
+`COPY_ALL_METADATA`, `COPY_NO_FALLBACK_FOR_MOVE`, and
+`COPY_TARGET_DEFAULT_PERMS`. (Their corresponding effects are documented
+[here](https://developer.gnome.org/gio/stable/GFile.html#GFileCopyFlags)).
+
 ### expand_path (path)
 
 Replaces any ocurrences `~` with the full path to the home directory.

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -3,9 +3,6 @@ import File from howl.io
 import with_tmpfile from File
 
 describe 'Buffer', ->
-  before_each ->
-    config.backup_files = false
-
   buffer = (text) ->
     with Buffer {}
       .text = text

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -3,6 +3,9 @@ import File from howl.io
 import with_tmpfile from File
 
 describe 'Buffer', ->
+  before_each ->
+    config.backup_files = false
+
   buffer = (text) ->
     with Buffer {}
       .text = text

--- a/spec/io/file_spec.moon
+++ b/spec/io/file_spec.moon
@@ -342,6 +342,22 @@ describe 'File', ->
 
           assert.same { 'child1', 'sandwich.lua' }, [f.basename for f in *files]
 
+  describe 'copy(dest)', ->
+    it 'copies the given file', ->
+      with_tmpdir (dir) ->
+        a = dir/'a.txt'
+        b = dir/'b.txt'
+        a.contents = 'hello'
+        a\copy b
+        assert.same b.contents, 'hello'
+
+        a.contents = 'hello 2'
+        assert.has_errors -> a\copy b
+        assert.same b.contents, 'hello'
+
+        a\copy b, {'overwrite'}
+        assert.same b.contents, 'hello 2'
+
   describe 'meta methods', ->
     it '/ and .. joins the file with the specified argument', ->
       file = File('/bin')

--- a/spec/io/file_spec.moon
+++ b/spec/io/file_spec.moon
@@ -355,7 +355,7 @@ describe 'File', ->
         assert.has_errors -> a\copy b
         assert.same b.contents, 'hello'
 
-        a\copy b, {'overwrite'}
+        a\copy b, {'OVERWRITE'}
         assert.same b.contents, 'hello 2'
 
   describe 'meta methods', ->

--- a/spec/io/file_spec.moon
+++ b/spec/io/file_spec.moon
@@ -355,7 +355,7 @@ describe 'File', ->
         assert.has_errors -> a\copy b
         assert.same b.contents, 'hello'
 
-        a\copy b, {'OVERWRITE'}
+        a\copy b, {'COPY_OVERWRITE'}
         assert.same b.contents, 'hello 2'
 
   describe 'meta methods', ->


### PR DESCRIPTION
Closes #147. If anything goes super badly, then the backup will never be able to get deleted, so the file stays intact.

I saved the backups into `~/.howl/backups` instead of the cwd to avoid them potentially being an annoyance if they show up in version control, and the PID is used just in case two different instances of Howl are saving two different files with the same name at the same time.