### PR TITLE
Configuration auto persistence and more

### DIFF
--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -252,6 +252,9 @@ class Application extends PropertyObject
     if force or not @_should_abort_quit!
       @save_session! unless #@args > 1
 
+      unless pcall config.save_config
+        print 'Error saving config'
+
       for _, process in pairs Process.running
         process\send_signal 'KILL'
 

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -252,8 +252,9 @@ class Application extends PropertyObject
     if force or not @_should_abort_quit!
       @save_session! unless #@args > 1
 
-      unless pcall config.save_config
-        print 'Error saving config'
+      if config.save_config_on_exit
+        unless pcall config.save_config
+          print 'Error saving config'
 
       for _, process in pairs Process.running
         process\send_signal 'KILL'

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -250,11 +250,12 @@ class Application extends PropertyObject
 
   quit: (force = false) =>
     if force or not @_should_abort_quit!
-      @save_session! unless #@args > 1
+      unless #@args > 1
+        @save_session!
 
-      if config.save_config_on_exit
-        unless pcall config.save_config
-          print 'Error saving config'
+        if config.save_config_on_exit
+          unless pcall config.save_config
+            print 'Error saving config'
 
       for _, process in pairs Process.running
         process\send_signal 'KILL'

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -308,7 +308,8 @@ class Buffer extends PropertyObject
     scope = @_config_scope
     @_file = file
     config.merge scope, @_config_scope
-
+    config.delete scope
+    @_set_config!
     @title = file and file.basename or 'Untitled'
 
   _set_config: =>

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -307,7 +307,7 @@ class Buffer extends PropertyObject
   _associate_with_file: (file) =>
     scope = @_config_scope
     @_file = file
-    config.copy scope, @_config_scope
+    config.merge scope, @_config_scope
 
     @title = file and file.basename or 'Untitled'
 

--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -417,6 +417,13 @@ command.register
   input: (path=nil) -> interact.get_external_command :path
   handler: launch_cmd
 
+command.register
+  name: 'save-config'
+  description: 'Save the current configuration'
+  handler: ->
+    config.save_config!
+    log.info 'Configuration saved'
+
 config.define
   name: 'project_build_command'
   description: 'The command to execute when project-build is run'

--- a/lib/howl/config.moon
+++ b/lib/howl/config.moon
@@ -8,7 +8,7 @@ layer_defs = {'default': {}}
 defs = {}
 watchers = {}
 
-unsaved_scopes = howl.Regex '^buffer/'
+saved_scopes = {''}
 
 predefined_types =
   boolean: {
@@ -134,8 +134,9 @@ save_config = (dir=nil) ->
   return unless scopes
   settings = Settings dir
   scopes_copy = {}
-  for scope, values in pairs scopes
-    continue if unsaved_scopes\match scope
+  for scope, values in *saved_scopes
+    values = scopes[scope]
+    continue unless values
     persisted_values = nil
     if get 'persist_config', scope
       persisted_values = values

--- a/lib/howl/config.moon
+++ b/lib/howl/config.moon
@@ -112,6 +112,13 @@ define
   type: 'boolean'
   default: true
 
+define
+  name: 'save_config_on_exit'
+  description: 'Whether to automatically save the current configuration on exit'
+  type: 'boolean'
+  default: false
+  scope: 'global'
+
 load_config = (force=false, dir=nil) ->
   return if scopes and not force
   settings = Settings dir

--- a/lib/howl/config.moon
+++ b/lib/howl/config.moon
@@ -8,6 +8,8 @@ layer_defs = {'default': {}}
 defs = {}
 watchers = {}
 
+unsaved_scopes = howl.Regex '^buffer/'
+
 predefined_types =
   boolean: {
     options: { true, false }
@@ -131,13 +133,15 @@ save_config = (dir=nil) ->
   settings = Settings dir
   scopes_copy = {}
   for scope, values in pairs scopes
+    continue if unsaved_scopes\match scope
     persisted_values = nil
     if get 'persist_config', scope
       persisted_values = values
     else
       persisted_values = {'persist_config': values['persist_config']}
 
-    if persisted_values
+    empty = not next persisted_values
+    if persisted_values and not empty
       scopes_copy[scope] = persisted_values
 
   settings\save_system('config', scopes_copy)

--- a/lib/howl/config.moon
+++ b/lib/howl/config.moon
@@ -175,11 +175,21 @@ proxy = (scope, write_layer='default', read_layer=write_layer) ->
   }
   setmetatable proxy, proxy_mt
 
-copy = (scope, new_scope) ->
-  scopes[new_scope] = {}
+merge = (scope, target_scope) ->
   if scopes[scope]
-    for k, v in pairs scopes[scope]
-      scopes[new_scope][k] = moon.copy v
+    scopes[target_scope] or= {}
+    target = scopes[target_scope]
+    source = scopes[scope]
+    for layer, layer_config in pairs source
+      if target[layer]
+        for name, value in pairs layer_config
+          target[layer][name] = value
+      else
+        target[layer] = moon.copy layer_config
+
+replace = (scope, target_scope) ->
+  scopes[target_scope] = {}
+  merge scope, target_scope
 
 delete = (scope) ->
   error 'Cannot delete global scope' if scope == ''
@@ -194,7 +204,8 @@ config = {
   :watch
   :reset
   :proxy
-  :copy
+  :replace
+  :merge
   :delete
 }
 

--- a/lib/howl/mode.moon
+++ b/lib/howl/mode.moon
@@ -19,19 +19,20 @@ instance_for_mode = (m) ->
   parent = if m.name != 'default' then by_name m.parent or 'default'
   target = m.create m.name
 
-  mode_config = config.proxy '', layer_for(m.name)
+  config_layer = layer_for m.name
+  mode_config = config.proxy '', config_layer
 
   if target.default_config
-    mode_config[k] = v for k,v in pairs target.default_config
+    config.set_default(k, v, config_layer) for k,v in pairs target.default_config
 
   mode_vars = mode_variables[m.name]
   if mode_vars
-    mode_config[k] = v for k,v in pairs mode_vars
+    config.set_default(k, v, config_layer) for k,v in pairs mode_vars
 
   instance = setmetatable {
     name: m.name
     config: mode_config
-    config_layer: layer_for(m.name)
+    :config_layer
     :parent
   }, {
     __index: (_, k) -> target[k] or parent and parent[k]

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -199,6 +199,19 @@ describe 'Buffer', ->
       assert.equal 'b1_value', b1.config.buf_var
       assert.equal 'b2_value', b2.config.buf_var
 
+    it 'uses a buffer scoped config for unsaved files', ->
+      b1 = buffer 'unsaved'
+      b1.config.buf_var = 'b1_value'
+      assert.equal 'b1_value', config.get 'buf_var', 'buffer/'..b1.id
+
+    it 'uses a file scoped config when associated with a file', ->
+      b1 = buffer 'saved'
+      with_tmpfile (file) ->
+        b1.file = file
+        b1.config.buf_var = 'f1_value'
+        assert.equal 'f1_value', config.get 'buf_var', 'file'..file.path
+        assert.equal 'def value', config.get 'buf_var', 'buffer'..b1.id
+
   describe 'delete(start_pos, end_pos)', ->
     it 'deletes the specified range, inclusive', ->
       b = buffer 'ño örf'

--- a/spec/config_spec.moon
+++ b/spec/config_spec.moon
@@ -501,3 +501,10 @@ describe 'config', ->
         assert.same true, config.get 'persist_config', 'scope1'
         assert.same false, config.get 'persist_config', 'scope2'
 
+    it 'does not save buffer scopes', ->
+      with_tmpdir (dir) ->
+        config.set 'name1', 'value1-global'
+        config.set 'name1', 'value2-buffer', 'buffer/123'
+        config.save_config dir
+        config.load_config true, dir
+        assert.same 'value1-global', config.get 'name1', 'buffer/123'

--- a/spec/config_spec.moon
+++ b/spec/config_spec.moon
@@ -389,21 +389,21 @@ describe 'config', ->
           assert.same 4, proxy_inner_mixed.my_var
 
 
-  context 'copy()', ->
+  context 'replace()', ->
     before_each ->
       config.define_layer 'layer1'
       config.define_layer 'layer2'
       config.define name: 'name1', description: 'description'
       config.define name: 'name2', description: 'description'
 
-    it 'deep copies all values from one scope into a new scope', ->
+    it 'clobbers new scope and deep copies all values from scope to new scope', ->
       config.set 'name1', 'value1', 'here', 'layer1'
       config.set 'name2', 'value2', 'here', 'layer2'
 
       assert.is_nil config.get 'name1', 'there', 'layer1'
       assert.is_nil config.get 'name2', 'there', 'layer2'
 
-      config.copy 'here', 'there'
+      config.replace 'here', 'there'
 
       assert.same 'value1', config.get 'name1', 'there', 'layer1'
       assert.same 'value2', config.get 'name2', 'there', 'layer2'
@@ -412,6 +412,29 @@ describe 'config', ->
 
       config.set 'name1', 'value1-new', 'here', 'layer1'
       assert.same 'value1', config.get 'name1', 'there', 'layer1'
+
+  context 'merge()', ->
+    before_each ->
+      config.define_layer 'layer1'
+      config.define_layer 'layer2'
+      config.define name: 'name1', description: 'description'
+      config.define name: 'name2', description: 'description'
+      config.define name: 'name3', description: 'description'
+
+    it 'deep copies values from scope to new scope, preserves other values in old scope', ->
+      config.set 'name1', 'value1', 'here', 'layer1'
+      config.set 'name2', 'value2', 'here', 'layer2'
+      config.set 'name1', 'there-value1', 'there', 'layer1'
+      config.set 'name3', 'there-value3', 'there', 'layer2'
+
+      assert.same 'there-value1', config.get 'name1', 'there', 'layer1'
+      assert.same nil, config.get 'name2', 'there', 'layer2'
+
+      config.merge 'here', 'there'
+
+      assert.same 'value1', config.get 'name1', 'there', 'layer1'
+      assert.same 'value2', config.get 'name2', 'there', 'layer2'
+      assert.same 'there-value3', config.get 'name3', 'there', 'layer2'
 
   context 'delete()', ->
     before_each ->

--- a/spec/config_spec.moon
+++ b/spec/config_spec.moon
@@ -482,7 +482,7 @@ describe 'config', ->
     it 'save_config() saves and load_config() loads the saved config', ->
       with_tmpdir (dir) ->
         config.set 'name1', 'value1'
-        config.set 'name2', 'value2', 'scope1'
+        config.set 'name2', 'value2'
         config.save_config dir
 
         config.set 'name1', nil
@@ -490,40 +490,46 @@ describe 'config', ->
 
         config.load_config true, dir
         assert.same 'value1', config.get 'name1'
-        assert.same 'value2', config.get 'name2', 'scope1'
+        assert.same 'value2', config.get 'name2'
 
-    it 'only saves scopes where persist_config is true', ->
+    it 'non global scopes are not persisted', ->
       with_tmpdir (dir) ->
-        config.set 'name1', 'value1'
+        config.set 'name1', 'value1', 'scope1'
+        config.save_config dir
+
         config.set 'name1', 'value2', 'scope1'
-        config.set 'name1', 'value3', 'scope2'
-        config.set 'name1', 'value4', 'scope2/scope3'
-        config.set 'persist_config', false, 'scope2'
-        config.save_config dir
-
-        config.set 'name1', nil
-        assert.same nil, config.get 'name1'
 
         config.load_config true, dir
-        assert.same 'value1', config.get 'name1'
-        assert.same 'value2', config.get 'name1', 'scope1'
-        assert.same 'value1', config.get 'name1', 'scope2'
-        assert.same 'value1', config.get 'name1', 'scope2/scope3'
+        assert.same nil, config.get 'name1', 'scope1'
 
 
-    it 'always saves persist_config for each scope', ->
+    it 'does not save values if persist_config is false', ->
       with_tmpdir (dir) ->
         config.set 'name1', 'value1'
-        config.set 'persist_config', true, 'scope1'
-        config.set 'persist_config', false, 'scope2'
+        config.set 'name2', 'value2'
+        config.set 'persist_config', false
+        config.save_config dir
+
+        config.set 'name1', nil
+        config.set 'name2', nil
+        assert.same nil, config.get 'name1'
+
+        config.load_config true, dir
+        assert.same nil, config.get 'name1'
+        assert.same nil, config.get 'name1', 'scope1'
+
+
+    it 'saves persist_config value', ->
+      with_tmpdir (dir) ->
+        config.set 'name1', 'value1'
+        config.set 'persist_config', false
         config.save_config dir
 
         config.set 'name1', nil
         assert.same nil, config.get 'name1'
 
         config.load_config true, dir
-        assert.same true, config.get 'persist_config', 'scope1'
-        assert.same false, config.get 'persist_config', 'scope2'
+        assert.same false, config.get 'persist_config'
 
     it 'does not save buffer scopes', ->
       with_tmpdir (dir) ->


### PR DESCRIPTION
Adds automatic configuration persistence. Fixes #13 

Config value set via command line or API can now be automatically persisted on clean exit. To enable this `config.save_config_on_exit` must be set to true (default is false). In addition, the `save-config` command can be used at any time to save the current config. The saved config is loaded automatically on the next startup.

Also includes a bugfix and replaces the `config.copy` method with `config.replace` and `config.merge` to make it more explicit.