### PR TITLE
Only coalesce revisions when requested

### DIFF
--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -594,7 +594,7 @@ Buffer = {
 
     part_of_revision = @revisions.processing
     revision = if not part_of_revision and @_collect_revisions
-      @revisions\push(type, offset, text, prev_text)
+      @revisions\push(type, offset, text, :prev_text)
 
     args = {
       :offset,

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -472,7 +472,7 @@ Buffer = {
 
   get_revision_id: (snapshot=false) =>
     if snapshot and @revisions.last
-      @revisions.last.dont_merge = true
+      @revisions.last.allow_coalescing = false
     return @revisions.revision_id
 
   notify: (event, parameters) =>

--- a/lib/aullar/revisions.moon
+++ b/lib/aullar/revisions.moon
@@ -37,13 +37,20 @@ define_class {
     revision_id: => @last and @last.revision_id or 0
   }
 
-  push: (type, offset, text, prev_text = nil, meta = {}) =>
+  push: (type, offset, text, opts = {}) =>
     unless VALID_TYPES[type]
       error "Unknown revision type '#{type}'", 2
 
     return if @processing
     group = @grouping > 0 and @group_id or nil
-    entry =  :type, :offset, :text, :prev_text, :meta, :group
+    entry =  {
+      :type,
+      :offset,
+      :text,
+      prev_text: opts.prev_text,
+      meta: opts.meta or {},
+      :group
+    }
     last = @last
     if last and entry.group == last.group
       return last if coalesce(entry, last)

--- a/lib/aullar/revisions.moon
+++ b/lib/aullar/revisions.moon
@@ -7,7 +7,9 @@ config = require 'aullar.config'
 {:max} = math
 
 coalesce = (entry, prev) ->
-  return false if not prev or prev.dont_merge
+  return false unless prev
+  return false unless prev.allow_coalescing and entry.allow_coalescing
+
   if entry.type == 'inserted' and prev.type == 'inserted'
     if entry.offset == prev.offset + #prev.text
       prev.text ..= entry.text
@@ -49,7 +51,8 @@ define_class {
       :text,
       prev_text: opts.prev_text,
       meta: opts.meta or {},
-      :group
+      :group,
+      allow_coalescing: opts.allow_coalescing
     }
     last = @last
     if last and entry.group == last.group

--- a/lib/aullar/spec/revisions_spec.moon
+++ b/lib/aullar/spec/revisions_spec.moon
@@ -24,7 +24,7 @@ describe 'Revisions', ->
         revision_id: 1
       }, revisions.entries[1]
 
-      revisions\push 'deleted', 3, 'f', nil, foo: 1
+      revisions\push 'deleted', 3, 'f', meta: {foo: 1}
       assert.same {
         type: 'deleted',
         offset: 3,
@@ -33,7 +33,7 @@ describe 'Revisions', ->
         revision_id: 2
       }, revisions.entries[2]
 
-      revisions\push 'changed', 3, 'f', 'x'
+      revisions\push 'changed', 3, 'f', prev_text: 'x'
       assert.same {
         type: 'changed',
         offset: 3,
@@ -134,7 +134,7 @@ describe 'Revisions', ->
       -- starting with '123456789'
       revisions\push 'deleted', 9, '9' -- and we've deleted '9' at 9
       revisions\push 'inserted', 4, 'xxx' -- and inserted 'xxx' at 3
-      revisions\push 'changed', 1, 'abc', '123' -- and replaced '123' with 'abc'
+      revisions\push 'changed', 1, 'abc', prev_text: '123' -- and replaced '123' with 'abc'
       buffer.text = 'abcxxx45678' -- this is what it looks like
 
       revisions\pop buffer -- pop the change
@@ -177,7 +177,7 @@ describe 'Revisions', ->
 
       it 'handles changes', ->
         buffer.text = '12xy'
-        revisions\push 'changed', 3, 'xy', '3'
+        revisions\push 'changed', 3, 'xy', prev_text: '3'
         revisions\pop buffer
         assert.equal '123', buffer.text
         revisions\forward buffer

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -59,7 +59,7 @@ View = {
     @im_context = Gtk.ImContextSimple!
     with @im_context
       append @_handlers, \on_commit (ctx, s) ->
-        @insert s
+        @insert s, allow_coalescing: true
 
       append @_handlers, \on_preedit_start ->
         @in_preedit = true
@@ -313,17 +313,17 @@ View = {
     @_updating_scrolling = false
     notify @, 'on_scroll', opts
 
-  insert: (text) =>
+  insert: (text, opts = {}) =>
     if @selection.is_empty
-      @_buffer\insert @cursor.pos, text
+      @_buffer\insert @cursor.pos, text, #text, opts
     else
       start_pos = @selection\range!
-      @_buffer\replace start_pos, @selection.size, text
+      @_buffer\replace start_pos, @selection.size, text, #text, opts
 
     notify @, 'on_insert_at_cursor', :text
     nil
 
-  delete_back: =>
+  delete_back: (opts = {}) =>
     if @selection.is_empty
       cur_pos = @cursor.pos
       @cursor\backward!
@@ -333,11 +333,11 @@ View = {
 
       if size > 0
         text = @_buffer\sub prev_pos, cur_pos
-        @_buffer\delete(prev_pos, size)
+        @_buffer\delete prev_pos, size, opts
         notify @, 'on_delete_back', :text, pos: prev_pos
     else
       start_pos = @selection\range!
-      @_buffer\delete start_pos, @selection.size
+      @_buffer\delete start_pos, @selection.size, opts
 
   to_gobject: => @bin
 

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -406,7 +406,7 @@ class Editor extends PropertyObject
         @cursor.column = max(1, cur_line.indentation - gap)
         return
 
-    @view\delete_back!
+    @view\delete_back allow_coalescing: true
 
   delete_back_word: =>
     if @selection.empty


### PR DESCRIPTION
As noted in #156, we currently coalesce whenever we can. This is not the right thing to do as it will for instance mix pastes with ordinary inserts. With this PR we turn this around and never coalesce revisions unless the affected revisions are explicitly marked as supporting this. Fixes #156.