### PR TITLE
Add `force` to cp howl command in Makefile install

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -76,8 +76,8 @@ install: all
 	@mkdir -p $(DESTDIR)$(PREFIX)/share/howl/
 	@mkdir -p $(DESTDIR)$(PREFIX)/share/howl/spec
 
-	@cp -p howl $(DESTDIR)$(PREFIX)/bin/
-	@cp -p ../bin/howl-spec $(DESTDIR)$(PREFIX)/bin/
+	@cp -fp howl $(DESTDIR)$(PREFIX)/bin/
+	@cp -fp ../bin/howl-spec $(DESTDIR)$(PREFIX)/bin/
 	@cp -rp ../bundles $(DESTDIR)$(PREFIX)/share/howl
 	@cp -rp ../fonts $(DESTDIR)$(PREFIX)/share/howl
 	@cp -rp ../lib $(DESTDIR)$(PREFIX)/share/howl


### PR DESCRIPTION
If Howl is running, the install won't complete the copy. I oftenly keep
several instances of Howl running for days (weeks) on end, and I might
not want to close down a certain session just to recompile. I think it's
the right thing (TM).