### PR TITLE
Primary selection

### DIFF
--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -731,19 +731,31 @@ class Editor extends PropertyObject
     return true if bindings.process event, 'editor', maps, self
 
   _on_button_press: (view, event) =>
-    @drag_press_type = event.type
-    @drag_press_pos = @_pos_from_coordinates(event.x, event.y)
+    return false if event.button == 3
 
-    if event.type == Gdk.GDK_2BUTTON_PRESS
-      group = @current_context.word
-      group = @current_context.token if group.empty
+    if event.button == 1
+      @drag_press_type = event.type
+      @drag_press_pos = @_pos_from_coordinates(event.x, event.y)
 
-      unless group.empty
-        @selection\set group.start_pos, group.end_pos + 1
-        true
+      if event.type == Gdk.GDK_2BUTTON_PRESS
+        group = @current_context.word
+        group = @current_context.token if group.empty
 
-    elseif event.type == Gdk.GDK_3BUTTON_PRESS
-      @selection\set @current_line.start_pos, @_next_line_start(@current_line)
+        unless group.empty
+          @selection\set group.start_pos, group.end_pos + 1
+          true
+
+      elseif event.type == Gdk.GDK_3BUTTON_PRESS
+        @selection\set @current_line.start_pos, @_next_line_start(@current_line)
+
+    elseif event.button == 2
+      text = clipboard.primary.text
+      if text
+        pos = @_pos_from_coordinates(event.x, event.y)
+        @selection\remove!
+        @cursor.pos = pos
+        @insert text
+        clipboard.primary.text = text
 
   _on_button_release: (view, event) =>
     @drag_press_type = nil

--- a/lib/howl/ui/selection.moon
+++ b/lib/howl/ui/selection.moon
@@ -13,6 +13,9 @@ class Selection extends PropertyObject
     @_sel = _view.selection
     @includes_cursor = false
     @_sel.listener = on_selection_changed: self\_on_selection_changed
+
+    self = @
+    @selection_getter = -> self.text
     super!
 
   @property _buffer: get: => @_view.buffer
@@ -102,6 +105,8 @@ class Selection extends PropertyObject
 
   _on_selection_changed: =>
     signal.emit 'selection-changed'
+    unless @empty
+      clipboard.primary.text = @selection_getter
 
   _copy_to_clipboard: (clip_options = {}, clipboard_options) =>
     clip = moon.copy clip_options

--- a/lib/ljglibs/cdefs/gtk.moon
+++ b/lib/ljglibs/cdefs/gtk.moon
@@ -280,15 +280,52 @@ ffi.cdef [[
   typedef struct {} GtkEntry;
   GtkEntry * gtk_entry_new (void);
 
-  typedef struct {
-    gchar *target;
-    guint  flags;
-    guint  info;
-  } GtkTargetEntry;
+  /*** Clipboard & selections ***/
 
-  /* GtkClipboard */
+  /* GtkTargetEntry */
+  typedef struct {} GtkTargetEntry;
+
+  typedef enum {
+    GTK_TARGET_SAME_APP = 1 << 0,
+    GTK_TARGET_SAME_WIDGET = 1 << 1,
+    GTK_TARGET_OTHER_APP = 1 << 2,
+    GTK_TARGET_OTHER_WIDGET = 1 << 3
+  } GtkTargetFlags;
+
+  GtkTargetEntry * gtk_target_entry_new (const gchar *target,
+                                         guint flags,
+                                         guint info);
+
+  void gtk_target_entry_free (GtkTargetEntry *data);
+
+  /* GtkTargetList */
+  typedef struct {} GtkTargetList;
+
+  GtkTargetList * gtk_target_list_new (const GtkTargetEntry *targets,
+                                      guint ntargets);
+  void gtk_target_list_unref (GtkTargetList *list);
+  void gtk_target_list_add (GtkTargetList *list,
+                            GdkAtom target,
+                            guint flags,
+                            guint info);
+
+  /* GtkTargetTable */
+  GtkTargetEntry * gtk_target_table_new_from_list (GtkTargetList *list,
+                                                   gint *n_targets);
+  void gtk_target_table_free (GtkTargetEntry *targets,
+                              gint n_targets);
+
+  /* GtkSelectionData */
+  typedef struct {} GtkSelectionData;
+
+  gboolean gtk_selection_data_set_text (GtkSelectionData *selection_data,
+                                        const gchar *str,
+                                        gint len);
+
   typedef struct {} GtkClipboard;
   typedef GVCallback3 GtkClipboardTextReceivedFunc;
+  typedef GVCallback4 GtkClipboardGetFunc;
+  typedef GVCallback2 GtkClipboardClearFunc;
 
   GtkClipboard * gtk_clipboard_get (GdkAtom selection);
   gchar * gtk_clipboard_wait_for_text (GtkClipboard *clipboard);
@@ -303,6 +340,13 @@ ffi.cdef [[
   void gtk_clipboard_set_can_store (GtkClipboard *clipboard,
                                     const GtkTargetEntry *targets,
                                     gint n_targets);
+
+  gboolean gtk_clipboard_set_with_data (GtkClipboard *clipboard,
+                                        const GtkTargetEntry *targets,
+                                        guint n_targets,
+                                        GtkClipboardGetFunc get_func,
+                                        GtkClipboardClearFunc clear_func,
+                                        gpointer user_data);
 
   /* GtkSpinner */
   typedef struct {} GtkSpinner;

--- a/lib/ljglibs/gtk/clipboard.moon
+++ b/lib/ljglibs/gtk/clipboard.moon
@@ -7,10 +7,21 @@ require 'ljglibs.cdefs.gtk'
 core = require 'ljglibs.core'
 glib = require 'ljglibs.glib'
 callbacks = require 'ljglibs.callbacks'
+require 'ljglibs.gtk.selection_data'
 
-C = ffi.C
+C, ffi_cast = ffi.C, ffi.cast
 
 jit.off true, true
+
+clear_funcs = setmetatable {}, __mode: 'v'
+
+clipboard_clear_func = ffi.cast 'GVCallback2', (clipboard, data) ->
+  data = tonumber ffi.cast('gint', data)
+  clear_handler = clear_funcs[data]
+  if clear_handler
+    clear_handler clipboard
+
+clipboard_get_func = ffi.cast 'GtkClipboardGetFunc', callbacks.void4
 
 core.define 'GtkClipboard < GObject', {
   get: (atom) -> C.gtk_clipboard_get atom
@@ -25,6 +36,7 @@ core.define 'GtkClipboard < GObject', {
   store: => C.gtk_clipboard_store @
   set_text: (text) => C.gtk_clipboard_set_text @, text, #text
   wait_for_text: => glib.g_string C.gtk_clipboard_wait_for_text @
+
   request_text: (callback) =>
     self = @
     local cb_handle
@@ -37,13 +49,29 @@ core.define 'GtkClipboard < GObject', {
     cb_handle = callbacks.register handler, 'clipboard-request-text'
     C.gtk_clipboard_request_text @, ffi.cast('GtkClipboardTextReceivedFunc', callbacks.void3), callbacks.cast_arg(cb_handle.id)
 
-  set_can_store: (targets) =>
-    nr_targets = targets and #targets or 0
-    if nr_targets > 0
-      t = ffi.new 'GtkTargetEntry[?]', nr_targets
-      for i = 1, nr_targets
-        t[i - 1] = targets[i]
-      targets = t
+  set: (targets, nr_targets, get_func, clear_func) =>
+    return unless nr_targets > 0
 
+    local get_handle
+
+    handler = (clipboard, selection_data, info) ->
+      selection_data = ffi_cast('GtkSelectionData *', selection_data)
+      val = get_func @
+      if val
+        selection_data\set_text val
+
+    get_handle = callbacks.register handler, 'clipboard-get-func'
+    clear_funcs[get_handle.id] = clear_func
+
+    status = C.gtk_clipboard_set_with_data @,
+      targets,
+      nr_targets,
+      clipboard_get_func,
+      clipboard_clear_func,
+      callbacks.cast_arg(get_handle.id)
+
+    status != 0
+
+  set_can_store: (targets, nr_targets) =>
     C.gtk_clipboard_set_can_store @, targets, nr_targets
 }

--- a/lib/ljglibs/gtk/init.moon
+++ b/lib/ljglibs/gtk/init.moon
@@ -49,6 +49,12 @@ core.auto_loading 'gtk', {
     'ALIGN_END',
     'ALIGN_CENTER',
     'ALIGN_BASELINE',
+
+    -- GtkTargetFlags
+    'TARGET_SAME_APP',
+    'TARGET_SAME_WIDGET',
+    'TARGET_OTHER_APP',
+    'TARGET_OTHER_WIDGET',
   }
 
   cairo_should_draw_window: (cr, window) ->

--- a/lib/ljglibs/gtk/selection_data.moon
+++ b/lib/ljglibs/gtk/selection_data.moon
@@ -1,0 +1,12 @@
+-- Copyright 2017 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+ffi = require 'ffi'
+require 'ljglibs.cdefs.gdk'
+core = require 'ljglibs.core'
+C = ffi.C
+
+core.define 'GtkSelectionData', {
+  set_text: (text) =>
+    C.gtk_selection_data_set_text @, text, #text
+}

--- a/lib/ljglibs/gtk/target_entry.moon
+++ b/lib/ljglibs/gtk/target_entry.moon
@@ -1,0 +1,16 @@
+-- Copyright 2017 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+ffi = require 'ffi'
+require 'ljglibs.cdefs.gdk'
+core = require 'ljglibs.core'
+C = ffi.C
+
+core.define 'GtkTargetEntry', {
+  new: (target, flags, info) ->
+    flags = core.parse_flags('GTK_TARGET_', flags)
+    ptr = C.gtk_target_entry_new target, flags, info
+    ffi.gc ptr, C.gtk_target_entry_free
+
+}, (def, target, flags = 0, info = 0) ->
+  def.new target, flags, info

--- a/lib/ljglibs/gtk/target_list.moon
+++ b/lib/ljglibs/gtk/target_list.moon
@@ -1,0 +1,19 @@
+-- Copyright 2017 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+ffi = require 'ffi'
+require 'ljglibs.cdefs.gdk'
+core = require 'ljglibs.core'
+C = ffi.C
+
+core.define 'GtkTargetList', {
+  new: () ->
+    ptr = C.gtk_target_list_new nil, 0
+    ffi.gc ptr, C.gtk_target_list_unref
+
+  add: (target, flags = 0, info = 0) =>
+    flags = core.parse_flags('GTK_TARGET_', flags)
+    C.gtk_target_list_add @, target, flags, info
+
+}, (def, targets) ->
+  def.new targets

--- a/lib/ljglibs/gtk/target_table.moon
+++ b/lib/ljglibs/gtk/target_table.moon
@@ -1,0 +1,15 @@
+-- Copyright 2017 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+ffi = require 'ffi'
+ffi_new = ffi.new
+require 'ljglibs.cdefs.gdk'
+core = require 'ljglibs.core'
+C = ffi.C
+
+core.define 'GtkTargetTable', {
+  new_from_list: (list) ->
+    n_targets = ffi_new 'gint[1]'
+    t_ptr = C.gtk_target_table_new_from_list list, n_targets
+    ffi.gc(t_ptr, C.gtk_target_table_free), tonumber n_targets[1]
+}

--- a/lib/ljglibs/spec/gtk/clipboard_spec.moon
+++ b/lib/ljglibs/spec/gtk/clipboard_spec.moon
@@ -1,5 +1,6 @@
 Atom = require 'ljglibs.gdk.atom'
 Clipboard = require 'ljglibs.gtk.clipboard'
+TargetEntry = require 'ljglibs.gtk.target_entry'
 
 describe 'Clipboard', ->
   describe 'get(atom)', ->
@@ -22,3 +23,23 @@ describe 'Clipboard', ->
       assert.equals 'set!', cb.text
       cb.text = 'new'
       assert.equals 'new', cb\wait_for_text!
+
+  describe 'set(targets, get_func, clear_func)', ->
+    local cb, target
+
+    before_each ->
+      cb = Clipboard.get Atom.SELECTION_PRIMARY
+      target = TargetEntry('UTF8_STRING')
+
+    it 'invokes and returns the value of `get_func` on demand', ->
+      get_func = () -> 'SPEC_TEXT'
+      cb\set target, 1, get_func
+      assert.equals 'SPEC_TEXT', cb.text
+
+    it 'invokes the clear_func if the clipboard is cleared', ->
+      get_func = () -> 'SPEC_TEXT'
+      clear_func = spy.new ->
+      cb\set target, 1, get_func, clear_func
+      cb\clear!
+      assert.spy(clear_func).was_called_with(cb)
+      assert.is_nil cb.text

--- a/site/source/doc/api/clipboard.md
+++ b/site/source/doc/api/clipboard.md
@@ -7,9 +7,10 @@ title: howl.clipboard
 ## Overview
 
 The clipboard module keeps track of copied text in Howl, and handles
-synchronization with the system clipboard. It provides two ways of remembering
-clipboard items: As a list of anynomous clips that is automatically updated with
-each copy/delete/cut operation, and within named registers.
+synchronization with the system clipboard and primary selection. It provides two
+ways of remembering clipboard items: As a list of anynomous clips that is
+automatically updated with each copy/delete/cut operation, and within named
+registers.
 
 ### Clipboard items
 
@@ -40,6 +41,28 @@ new item and removing older items as necessary.
 ### current
 
 The most recent anynomous clipboard item available on the clipboard.
+
+### primary
+
+The `primary` object is used for synchronization with the systems primary
+selection (i.e. the one used for middle button action). It has a `.text`
+property that can be used to fetch or store the contents of the primary
+selection, as well as a `clear` method that can be used for clearing the
+selection. In contrast to the ordinary clipboard it's possible to set virtual
+content for the primary clipboard, via the use of a provider function. Such a
+function would be called on-demand as necessary to provide the content.
+
+Example:
+
+```moonscript
+primary = howl.clipboard.primary
+primary.text = 'direct'
+print primary.text -- => 'direct'
+primary.text = -> 'on-demand'
+print primary.text -- => 'on-demand'
+primary\clear!
+```
+
 
 ### registers
 

--- a/spec/clipboard_spec.moon
+++ b/spec/clipboard_spec.moon
@@ -62,3 +62,19 @@ describe 'Clipboard', ->
       clipboard.synchronize!
       assert.equals 'pushed', clipboard.current.text
       assert.equals 1, #clipboard.clips
+
+  describe '.primary', ->
+    local primary_cb
+
+    before_each ->
+      primary_cb = GtkClipboard.get Atom.SELECTION_PRIMARY
+
+    it 'allows getting and setting the primary clipboard', ->
+      clipboard.primary.text = 'spec'
+      assert.equals 'spec', primary_cb.text
+      primary_cb.text = 'lower'
+      assert.equals 'lower', clipboard.primary.text
+
+    it 'allows setting a provider function instead of the direct text', ->
+      clipboard.primary.text = -> 'async'
+      assert.equals 'async', primary_cb.text


### PR DESCRIPTION
This enables the use of the X11 primary selection from within Howl. It allows for pasting from the primary selection using the middle button, and also integrates the Howl selection with the primary selection in the system.

Fixes #308.