### PR TITLE
A new set command that unifies and replaces all existing set commands

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,10 @@ button).
 you've relied on it: set it explicitly to its' previous value `1` in your Howl
 configuration.
 
+- **breaking** - Overhauled the configuration system to use a flexible *scope*
+and *layer* structure. Replaced all 'set*' commands with a new `set` command as
+part of this. See the documentation for more details.
+
 - Added `config.save_config_on_exit` variable to automatically save global
 configuration to `~/.howl/system/config.lua`.
 

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -131,7 +131,7 @@ class Buffer extends PropertyObject
     set: (v) => @_buffer.read_only = v
 
   @property config_scope:
-    get: => @_file and ('file' .. @_file.path) or ('buffer/' .. @id)
+    get: => @_file and config.scope_for_file(@_file.path) or ('buffer/' .. @id)
 
   chunk: (start_pos, end_pos) => Chunk self, start_pos, end_pos
 

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -130,7 +130,7 @@ class Buffer extends PropertyObject
     get: => @_buffer.read_only
     set: (v) => @_buffer.read_only = v
 
-  @property _config_scope:
+  @property config_scope:
     get: => @_file and ('file' .. @_file.path) or ('buffer/' .. @id)
 
   chunk: (start_pos, end_pos) => Chunk self, start_pos, end_pos
@@ -296,7 +296,7 @@ class Buffer extends PropertyObject
   config_at: (pos) =>
     mode_at = @mode_at pos
     return @config if mode_at == @mode
-    return config.proxy @_config_scope, mode_at.config_layer
+    return config.proxy @config_scope, mode_at.config_layer
 
   add_view_ref: =>
     @viewers += 1
@@ -305,15 +305,15 @@ class Buffer extends PropertyObject
     @viewers -= 1
 
   _associate_with_file: (file) =>
-    scope = @_config_scope
+    scope = @config_scope
     @_file = file
-    config.merge scope, @_config_scope
+    config.merge scope, @config_scope
     config.delete scope
     @_set_config!
     @title = file and file.basename or 'Untitled'
 
   _set_config: =>
-    @config = config.proxy @_config_scope, 'default', @mode.config_layer
+    @config = config.proxy @config_scope, 'default', @mode.config_layer
 
   _on_text_inserted: (_, _, args) =>
     @_on_buffer_modification 'text-inserted', args

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -130,7 +130,7 @@ class Buffer extends PropertyObject
     get: => @_buffer.read_only
     set: (v) => @_buffer.read_only = v
 
-  @property config_scope:
+  @property _config_scope:
     get: => @_file and config.scope_for_file(@_file.path) or ('buffer/' .. @id)
 
   chunk: (start_pos, end_pos) => Chunk self, start_pos, end_pos
@@ -296,7 +296,7 @@ class Buffer extends PropertyObject
   config_at: (pos) =>
     mode_at = @mode_at pos
     return @config if mode_at == @mode
-    return config.proxy @config_scope, mode_at.config_layer
+    return config.proxy @_config_scope, mode_at.config_layer
 
   add_view_ref: =>
     @viewers += 1
@@ -305,15 +305,15 @@ class Buffer extends PropertyObject
     @viewers -= 1
 
   _associate_with_file: (file) =>
-    scope = @config_scope
+    scope = @_config_scope
     @_file = file
-    config.merge scope, @config_scope
+    config.merge scope, @_config_scope
     config.delete scope
     @_set_config!
     @title = file and file.basename or 'Untitled'
 
   _set_config: =>
-    @config = config.proxy @config_scope, 'default', @mode.config_layer
+    @config = config.proxy @_config_scope, 'default', @mode.config_layer
 
   _on_text_inserted: (_, _, args) =>
     @_on_buffer_modification 'text-inserted', args

--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -74,9 +74,10 @@ command.register
   description: 'Set a configuration variable'
   input: interact.get_variable_assignment
   handler: (variable_assignment) ->
-    scope = if variable_assignment.scope == 'global' then '' else variable_assignment.buffer.config_scope
-    config.set variable_assignment.var, variable_assignment.value, scope, variable_assignment.layer
-    _G.log.info ('"%s" is now set to "%s"')\format variable_assignment.var, variable_assignment.value
+    target = variable_assignment.target
+    target[variable_assignment.var] = variable_assignment.value
+
+    _G.log.info ('"%s" is now set to "%s" for %s')\format variable_assignment.var, variable_assignment.value, variable_assignment.scope_name
 
 command.register
   name: 'describe-key',

--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -69,34 +69,14 @@ command.register
 
     _G.log.error 'No hidden buffer found'
 
-set_variable = (assignment, target) ->
-  if assignment
-    value = assignment.value
-    if config.definitions[assignment.name]
-      target[assignment.name] = value
-      _G.log.info ('"%s" is now set to "%s"')\format assignment.name, assignment.value
-    else
-      log.error "Undefined variable '#{assignment.name}'"
-
 command.register
   name: 'set',
-  description: 'Set a configuration variable globally'
-  input: interact.get_variable_assignment
-  handler: (variable_assignment) -> set_variable variable_assignment, config
-
-command.register
-  name: 'set-for-mode',
-  description: 'Set a configuration variable for the current mode'
+  description: 'Set a configuration variable'
   input: interact.get_variable_assignment
   handler: (variable_assignment) ->
-    set_variable variable_assignment, app.editor.buffer.mode.config
-
-command.register
-  name: 'set-for-buffer',
-  description: 'Set a configuration variable for the current buffer'
-  input: interact.get_variable_assignment
-  handler: (variable_assignment) ->
-    set_variable variable_assignment, app.editor.buffer.config
+    scope = if variable_assignment.scope == 'global' then '' else variable_assignment.buffer.config_scope
+    config.set variable_assignment.var, variable_assignment.value, scope, variable_assignment.layer
+    _G.log.info ('"%s" is now set to "%s"')\format variable_assignment.var, variable_assignment.value
 
 command.register
   name: 'describe-key',

--- a/lib/howl/config.moon
+++ b/lib/howl/config.moon
@@ -245,14 +245,20 @@ proxy_mt = {
   __newindex: (proxy, key, value) -> set(key, value, proxy._scope, proxy._write_layer)
 }
 
+local proxy
 proxy = (scope, write_layer='default', read_layer=write_layer) ->
-  proxy = {
+  _proxy = {
     clear: => scopes[@_scope] = {}
+    for_layer: (layer) -> proxy scope, layer
     _scope: scope
     _write_layer: write_layer
     _read_layer: read_layer
   }
-  setmetatable proxy, proxy_mt
+  setmetatable _proxy, proxy_mt
+
+scope_for_file = (file) -> 'file'..file
+
+for_file = (file) -> proxy scope_for_file file
 
 merge = (scope, target_scope) ->
   if scopes[scope]
@@ -286,6 +292,8 @@ config = {
   :watch
   :reset
   :proxy
+  :scope_for_file
+  :for_file
   :replace
   :merge
   :delete

--- a/lib/howl/config.moon
+++ b/lib/howl/config.moon
@@ -260,6 +260,8 @@ scope_for_file = (file) -> 'file'..file
 
 for_file = (file) -> proxy scope_for_file file
 
+for_layer = (layer) -> proxy '', layer
+
 merge = (scope, target_scope) ->
   if scopes[scope]
     scopes[target_scope] or= {}
@@ -294,6 +296,7 @@ config = {
   :proxy
   :scope_for_file
   :for_file
+  :for_layer
   :replace
   :merge
   :delete

--- a/lib/howl/interact.moon
+++ b/lib/howl/interact.moon
@@ -21,13 +21,15 @@ sequence = (order, def) ->
 
     state = {}
     pos = 1
+    local current
 
     while true
       def.update state if def.update
 
+      prev = current
       current = order[pos]
       if current
-        result = def[current](state)
+        result = def[current](state, prev)
         return nil unless result
 
         if result.back

--- a/lib/howl/interact.moon
+++ b/lib/howl/interact.moon
@@ -15,9 +15,36 @@ register = (spec) ->
 unregister = (name) ->
   interactions[name] = nil
 
+sequence = (order, def) ->
+    for name in *order
+      error "#{name} not found in def" unless def[name]
+
+    state = {}
+    pos = 1
+
+    while true
+      def.update state if def.update
+
+      current = order[pos]
+      if current
+        result = def[current](state)
+        return nil unless result
+
+        if result.back
+            pos -= 1
+            state[order[pos]] = nil
+        else
+            state[current] = result
+            pos += 1
+        continue
+      else
+        if def.finish
+          return def.finish state
+        return state
+
 get = (name) -> interactions[name]
 
-return setmetatable {:register, :unregister, :get}, {
+return setmetatable {:register, :unregister, :get, :sequence}, {
   __index: (interaction_name) =>
     spec = get(interaction_name)
     return if not spec

--- a/lib/howl/interactions/selection_list.moon
+++ b/lib/howl/interactions/selection_list.moon
@@ -28,6 +28,12 @@ class SelectionList
     if not @opts.hide_until_tab
       @show_list!
 
+    @quick_selections = {}
+    if @opts.items
+      for item in *@opts.items
+        if item.quick_select
+          @quick_selections[item.quick_select] = item
+
     if @opts.text
       @command_line\write @opts.text
       @on_update @opts.text
@@ -48,6 +54,13 @@ class SelectionList
     @showing_list = true
 
   on_update: (text) =>
+    if @quick_selections[text]
+      self.finish
+        selection: @quick_selections[text]
+        :text
+        quick: true
+      return
+
     @_change_triggered = false
     @list_widget\update text
     @_handle_change! unless @_change_triggered

--- a/lib/howl/interactions/selection_list.moon
+++ b/lib/howl/interactions/selection_list.moon
@@ -82,6 +82,10 @@ class SelectionList
       else
         @submit!
 
+  handle_back: =>
+    if @opts.cancel_on_back
+      self.finish back: true
+
 interact.register
   name: 'select'
   description: 'Get selection made by user from a list of items'

--- a/lib/howl/interactions/selection_list.moon
+++ b/lib/howl/interactions/selection_list.moon
@@ -32,7 +32,11 @@ class SelectionList
     if @opts.items
       for item in *@opts.items
         if item.quick_select
-          @quick_selections[item.quick_select] = item
+          if type(item.quick_select) == 'table'
+            for quick_select in *item.quick_select
+              @quick_selections[quick_select] = item
+          else
+            @quick_selections[item.quick_select] = item
 
     if @opts.text
       @command_line\write @opts.text

--- a/lib/howl/interactions/text_entry.moon
+++ b/lib/howl/interactions/text_entry.moon
@@ -8,12 +8,17 @@ class ReadText
     with app.window.command_line
       .prompt = opts.prompt or ''
       .title = opts.title
+    @opts = moon.copy opts
 
   keymap:
     enter: =>
       self.finish app.window.command_line.text
 
     escape: => self.finish!
+
+  handle_back: =>
+    if @opts.cancel_on_back
+      self.finish back: true
 
 interact.register
   name: 'read_text'

--- a/lib/howl/interactions/variable_assignment.moon
+++ b/lib/howl/interactions/variable_assignment.moon
@@ -74,10 +74,13 @@ interact.register
           { header: 'Description', style: 'comment' }
         }
 
-      scope: (state) ->
+      scope: (state, from_state) ->
         def = state.var.selection.def
         if def.scope == 'global'
-          return {selection: {'global', scope: 'global'}}
+          if from_state == 'value'
+            return { back: true }
+          else
+            return { selection: { 'global', scope: 'global' } }
 
         interact.select
           title: def.name

--- a/lib/howl/interactions/variable_assignment.moon
+++ b/lib/howl/interactions/variable_assignment.moon
@@ -45,13 +45,13 @@ scope_item = (def, scope_name, target, description='', layer=nil) ->
   }
 
 scope_items = (def, buffer) ->
-  mode_layer = buffer and buffer.mode.config_layer
-  mode_name = mode_layer and buffer.mode.name
   items = {}
   append items, scope_item(def, 'global', config)
 
   return items if def.scope == 'global' or not buffer
 
+  mode_layer = buffer.mode.config_layer
+  mode_name = buffer.mode.name
   append items, scope_item(
     def, 'global', config, "For all buffers with mode #{mode_name}", mode_layer)
 
@@ -60,11 +60,11 @@ scope_items = (def, buffer) ->
     if project
       append items, scope_item(
         def, 'project', project.config,
-        "For all files under #{project.root.basename}")
+        "For all files under #{project.root.short_path}")
 
       append items, scope_item(
         def, 'project', project.config,
-        "For all files under #{project.root.basename} with mode #{mode_name}", mode_layer)
+        "For all files under #{project.root.short_path} with mode #{mode_name}", mode_layer)
 
   append items, scope_item(
     def, 'buffer', buffer.config,

--- a/lib/howl/interactions/variable_assignment.moon
+++ b/lib/howl/interactions/variable_assignment.moon
@@ -44,11 +44,13 @@ scope_items = (def, buffer) ->
   return items if def.scope == 'global' or not buffer
 
   append items,
-    { scope_str('global', mode_layer), to_s(buffer.mode.config[def.name]), '',
+    { scope_str('global', mode_layer), to_s(buffer.mode.config[def.name]),
+      "For all buffers with mode #{buffer.mode.name}",
       scope: 'global', layer: mode_layer, quick_select: scope_str('global', mode_layer) .. '='}
 
   append items,
-    { scope_str('buffer'), to_s(buffer.config[def.name]), buffer.title,
+    { scope_str('buffer'), to_s(buffer.config[def.name]),
+      "For #{buffer.title} only",
       scope: 'buffer', quick_select: scope_str('buffer') .. '='}
 
   return items

--- a/lib/howl/interactions/variable_assignment.moon
+++ b/lib/howl/interactions/variable_assignment.moon
@@ -56,7 +56,7 @@ scope_items = (def, buffer) ->
   return items
 
 get_vars = ->
-  vars = [{name, def.description, :def, quick_select: name..'='} for name, def in pairs config.definitions]
+  vars = [{name, def.description, :def, quick_select: {name..'=', name..'@'}} for name, def in pairs config.definitions]
   table.sort vars, (a, b) -> a[1] < b[1]
   return vars
 

--- a/lib/howl/project.moon
+++ b/lib/howl/project.moon
@@ -1,7 +1,7 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-import VC, interact from howl
+import config, VC, interact from howl
 
 append = table.insert
 
@@ -55,6 +55,7 @@ class Project
   new: (root, vc) =>
     @root = root
     @vc = vc
+    @config = config.for_file root
 
   files: =>
     if @vc and @vc.files

--- a/lib/howl/ui/command_line.moon
+++ b/lib/howl/ui/command_line.moon
@@ -563,12 +563,19 @@ class CommandLine extends PropertyObject
 
     f1: => @show_help!
 
-  add_widget: (name, widget) =>
+  add_widget: (name, widget, pos='bottom') =>
     error('No widget provided', 2) if not widget
 
     @remove_widget name
 
-    @box\pack_end widget\to_gobject!, false, 0, 0
+    local pack
+    if pos == 'bottom'
+        pack = @box\pack_end
+    elseif pos == 'top'
+        pack = @box\pack_start
+    else
+        error "Invalid pos #{pos}"
+    pack widget\to_gobject!, false, 0, 0
     @_widgets[name] = widget
 
     widget\show!

--- a/lib/howl/ui/command_line.moon
+++ b/lib/howl/ui/command_line.moon
@@ -543,8 +543,14 @@ class CommandLine extends PropertyObject
       ["cursor-right"]: => @command_widget.cursor\right!
 
       ["editor-delete-back"]: =>
-        -- don't backspace into prompt
-        return true if @command_widget.cursor.pos <= @_prompt_end
+        if @command_widget.cursor.pos <= @_prompt_end
+          -- backspace attempted into prompt
+          if @_activity and @_activity.handle_back
+            @_activity\handle_back!
+            return true
+          else
+            return true
+
         range_start = @command_widget.selection\range!
         return if range_start and range_start < @_prompt_end
         @command_widget\delete_back!

--- a/site/source/doc/api/config.md
+++ b/site/source/doc/api/config.md
@@ -11,9 +11,9 @@ variables". An example configuration variable is `font_size`, which sets the
 size of the main font.
 
 Configuration variables are set either interactively from within Howl, using the
-`set` command, or programmatically from code. To get an overview of currently
-available variables, open the command line, type `set` and press `space` - this
-shows a list of all variables.
+[`set`](../manual/configuration.html) command, or programmatically from code. To
+get an overview of currently available variables, open the command line, type
+`set` and press `space` - this shows a list of all variables.
 
 Values for configuration variables can be specified at multiple levels, called
 *scopes*, and at multiple *layers* within each scope. These are described below.
@@ -41,11 +41,9 @@ Some common scopes are:
 
 - **Unsaved file scope (buffer scope)**
 
-  Unsaved file scopes are used to specify configuraiton for buffers that are not
+  Unsaved file scopes are used to specify configuration for buffers that are not
   associated with any file. These scopes start with `'buffer'`, e.g.
   `'buffer/1234'`, and the value applies to the specific buffer only.
-
-  The `set-for-buffer` command sets variables at the file or buffer scope.
 
 ### Layers
 
@@ -59,8 +57,6 @@ available at *all* scopes.
 
 Within each scope, the layer specific value applies. If the requested layer
 value does not exist, the `default` layer value applies.
-
-The `set-for-mode` command sets the mode specific layer at the global scope.
 
 ### Evaluation
 
@@ -97,12 +93,13 @@ returned:
 The primitive API consists of [`get()`](#get) and [`set`](#set) calls which
 accept scope and layer as additional parameters. However, the following code
 snippet illustrates the idiomatic ways of setting variables globally, for a
-mode, and for a specific buffer only:
+mode, for a specific buffer and for a specific file only:
 
 ```lua
 howl.config.my_var = 'foo'
 howl.mode.by_name('ruby').config.my_var = 'foo'
 howl.app:new_buffer().config.my_var = 'foo'
+howl.config.for_file('/path/to/file').my_var = 'foo'
 ```
 
 Note that internally the values are organized within scopes and layers, but this
@@ -168,6 +165,16 @@ into a native representation.
   - number
   - string
   - string_list
+
+### for_file (path)
+
+Returns a [proxy](#proxy) config object for the specified file scope. The
+returned object can be used to get and set configuration variables directly for the file scope, for instance:
+
+```moonscript
+c = config.for_file '/home/user/some/path'
+c.indent = 4
+```
 
 ### get (name, scope, layer)
 

--- a/site/source/doc/manual/configuration.md
+++ b/site/source/doc/manual/configuration.md
@@ -13,14 +13,24 @@ for [Moonscript](http://moonscript.org) and `init.lua` for
 [Lua](http://www.lua.org). Should a startup file be found, it is loaded
 after Howl is initialized, which includes loading all available bundles.
 Howl does not have any special configuration format for use with the
-startup file, instead it's just plain Lua or Moonscript. While the startup
-file would typically be mostly used for various type of configuration,
-there's no restriction to what you can do in it - you have access to the entire
-[Howl API](../#api-reference).
+startup file, instead it's just plain Lua or Moonscript.
+
+The startup file is typically used for various type of configuration, there's no
+restriction to what you can do in it - you have access to the entire
+[Howl API](../#api-reference). However, some parts of the API, such as running
+commands, can only be accessed after the application has fully initialized, and
+need be bound to the `'app-ready'` signal, rather than at the top level in the
+init file. For instance, this code launches the file selection command on
+startup:
+
+```moon
+howl.signal.connect 'app-ready', ->
+  howl.command.run 'open'
+```
 
 You can split up your startup code in multiple files if you like. Your local
 user files will be not found by an ordinary `require`, since the user directory
-is not part of the search path. However, there is an `user_load` helper available
+is not part of the search path. However, there is a `user_load` helper available
 from your startup files that works the same way. For example, given
 `init.moon` and `other.moon` in the Howl user directory, you could load
 'other' from init like so:
@@ -73,44 +83,71 @@ press enter again to switch to the specified theme. See the sections below,
 [Automatic persistence](#automatic-persistence), for information on how to
 change a setting so that it persists across restarts.
 
-Configuration variables can be specified at three different levels in Howl,
-in ascending order of priority:
+### Scopes and layers
 
-- *Globally*
+The value for each configuration variable can be set at multiple levels, called
+*scopes*, and at multiple *layers* for each scope. The scope is the path for
+which the configuration value applies. For instance, a configuration value set
+at the *global* scope applies to all buffers. A configuration value at a
+*file* scope applies to a specific file only, overriding any global value for
+the same variable. A folder scope (similar to file scope, but referencing a
+folder) applies a value to all files under a specific folder.
 
-The value set for the variable is used unless overridden by a mode or buffer
-specific setting (the `set` command always sets variables globally).
+Scopes work well when the same configuration value applies to all types of files
+within a scope. To use different values depending on the
+[mode](getting-started.html#modes), configuration *layers* are used. A layer is
+a string such as `'mode:moonscript'` and can by specified in addition to the
+scope for a variable. So a value set at global scope for layer
+`'mode:moonscript'` is applied to all moonscript buffers. A value set for scope
+`'file/path/to/project'` and layer `'mode:python'` is applied to all python
+files under the `path/to/project` folder.
 
-- *Per mode*
+### Interactive configuration
 
-The value is set for a particular mode (e.g. "Lua" or "Ruby"), and is applied
-whenever a buffer with that particular mode is active. The value is used unless
-overridden by a buffer specific setting, and overrides any global setting.
+As seen above, the `set` command is used to specify values for configuration
+variables. When setting the `theme`, you did not have a choice for scope because
+the theme can only be specified for the `global` scope. For other variables, the
+`set` command allows you to specify the scope, and optionally, the layer.
 
-- *Per buffer*
+The syntax for the `set` command is:
 
-The value is set for a particular buffer, and is applied whenever that buffer
-is active. The value overrides any mode specific or global setting.
+```
+set name@scope_name[layer]=value
+```
 
-As an example of how this could be used a real life scenario, consider the
-case of indentation: You might generally prefer your source code to be indented
-with two spaces. However, some languages might have generally accepted style
-guidelines where four spaces is considered the norm. Even so, certain projects
-written in such a language might have adopted the inexplicable custom of using
-three spaces for indentation.
+While you can type out the entire command by hand, a selection list for the
+scope_name and another for the value (if applicable) is displayed to make
+command entry easier. Let's see a few examples of using this command to set the
+`indent` configuration variable for different scopes and layers. The `indent`
+variable specifies the number of characters to use for each level of
+indentation.
 
-In such a scenario, you could set the `indent` variable to 2 globally, override
-it with 4 for a given mode, and override with 3 for any buffer with an associated
-file in a certain directory.
+* *Global scope*: To set the global value of indent to '3', use the command `set
+indent@global=3`. Note that after you type `set indent@`, the command shows an
+auto complete list containing different options for *scope* and the current
+effective value at each scope.
+
+* *For current buffer*: To set the configuration for the current buffer only to
+4, use the command `set indent@buffer=4`. This applies the the currently active
+buffer only, and no other buffers.
+
+* *For current mode*: Another available option applies to the global scope and
+mode layer for the current mode. This command looks something like `set
+indent@globa[mode:moonscript]=2` (assuming the current mode is *moonscript*).
+This applies indent=2 to all buffers with that are in moonscript mode.
+
+Once you type the full command, pressing `enter` makes it effective and pressing
+`escape` cancels, making no changes. You can also press `backspace` to go back
+and change the selected scope, or the originally selected variable.
 
 ### Programmatic access
 
-As described above, variables can be set on three different levels. No matter
-the on what level they're set, they're always set (and accessed) using
-`config` objects. For global accesses, you can use the main config object in
-the howl namespace. For mode variables you access variables using the config
-object on a particular mode instance, and similarily for buffer variables
-you use the config object for a particular buffer.
+The Howl API can be used to update the configuration values as well. An easy way
+to set (and access) variables is using `config` objects. For the global scope,
+you can use the main config object in the `howl` namespace. For a specific mode,
+you access variables using the config object on a particular mode instance, and
+similarily for buffer variables you use the config object for a particular
+buffer.
 
 The following code snippet illustrates the various ways of setting variables on
 different levels:
@@ -121,13 +158,17 @@ howl.mode.by_name('ruby').config.my_var = 'foo'
 howl.app:new_buffer().config.my_var = 'foo'
 ```
 
+For more fine grained access to configuration variables, see the [config
+API](../api/config.html).
+
 ### Setting variables upon startup
 
-Let's have a look at configuring the `indent` variable as discussed in the
-[overview](#overview), using the below example Moonscript init file (init.moon):
+Let's have a look at configuring the `indent` variable as discussed in
+[Interactive configuration](#interactive-configuration) earlier, using the below
+example Moonscript init file (init.moon):
 
 ```moon
-import config, mode, signal from howl
+import config, mode from howl
 import File from howl.io
 
 -- Set indent globally to two spaces
@@ -138,12 +179,8 @@ mode.configure 'c', {
   indent: 4
 }
 
--- Hook up a signal handler to set it to three for this weird project
-that_project_root = File '/home/nino/code/that_project'
-
-signal.connect 'file-opened', (args) ->
-  if args.file\is_below that_project_root
-    args.buffer.config.indent = 3
+-- Set it to three for this weird project
+config.for_file('/home/nino/code/some_project').indent = 3
 ```
 
 A few notes on the above example:
@@ -158,31 +195,29 @@ A few notes on the above example:
   to set a variable. Using configure() instead means that it will be set once
   the mode is loaded (or straight away should the mode already be loaded).
 
-- We use [signal.connect](../api/signal.html#connect) to add a signal handler
-  for the `file-opened` signal, and set the indent for a certain buffer with
-  an associated file under a given directory.
-
+- We use [config.for_file](../api/config.html#for_file) to add access a config
+  *proxy* object that sets and gets variables for the file scope.
 
 ### Automatic persistence
 
-Howl does not, by default, automatically save any configuration variables
-updated via the command line or the API. One way to save your settings is to
-manually update the `init.moon` file as described in the previous section.
-Another way is to use the  `save_config_on_exit` configuration variable which
-enables automatic persistence of global configuration variables.
+Howl does not automatically save any configuration variables updated via the
+command line or the API. One way to save your settings is to manually update the
+`init.moon` file as described in the previous section. Another way is to use the
+ `save_config_on_exit` configuration variable which enables automatic
+persistence of global configuration variables.
 
 A simple way to enable automatic persistence is to add the following line to
 your `init.moon`:
 
-```moonscript
+```moon
 config.save_config_on_exit = true
 ```
 
 Once `save_config_on_exit` is set to `true`, the current state of global
 configuration variables is automatically saved on exit and reloaded on startup.
 Note that automatic persistence applies to global variables and mode
-configuration only - buffer level variables are not automatically persisted
-currently.
+configuration only - configuration at other scopes such as files and buffer is
+not currently persisted.
 
 Automatically persisted variables are stored in the file
 `~/.howl/system/config.lua`. Any variables set via `init.moon` override the

--- a/site/source/doc/manual/configuration.md
+++ b/site/source/doc/manual/configuration.md
@@ -15,13 +15,12 @@ after Howl is initialized, which includes loading all available bundles.
 Howl does not have any special configuration format for use with the
 startup file, instead it's just plain Lua or Moonscript.
 
-The startup file is typically used for various type of configuration, there's no
-restriction to what you can do in it - you have access to the entire
+The startup file is typically used for various types of configuration, but
+there's no restriction to what you can do in it - you have access to the entire
 [Howl API](../#api-reference). However, some parts of the API, such as running
 commands, can only be accessed after the application has fully initialized, and
-need be bound to the `'app-ready'` signal, rather than at the top level in the
-init file. For instance, this code launches the file selection command on
-startup:
+needs be run within an `'app-ready'` signal handler, rather than at the top
+level. For instance, this code launches the file selection command on startup:
 
 ```moon
 howl.signal.connect 'app-ready', ->

--- a/spec/config_spec.moon
+++ b/spec/config_spec.moon
@@ -578,16 +578,16 @@ describe 'config', ->
         assert.same nil, config.for_file(dir).name33
         assert.same nil, config.name3
 
-    context 'for_layer', ->
-      it 'creates another proxy for specified layer at same scope', ->
-        with_tmpdir (dir) ->
-          with config.for_file(dir).for_layer('layer1')
-            .name1 = 'dir-layer1-value1'
-          with config.for_file(dir)
-            .name1 = 'dir-value1'
+  context 'for_layer', ->
+    it 'creates another proxy for specified layer at same scope', ->
+      with_tmpdir (dir) ->
+        with config.for_file(dir).for_layer('layer1')
+          .name1 = 'dir-layer1-value1'
+        with config.for_file(dir)
+          .name1 = 'dir-value1'
 
-          with config.for_file(dir..'abc').for_layer('layer1')
-            .name1 =  'file-layer1-value1'
+        with config.for_file(dir..'abc').for_layer('layer1')
+          .name1 =  'file-layer1-value1'
 
-          assert.same 'file-layer1-value1', config.for_file(dir..'abc').for_layer('layer1').name1
-          assert.same 'dir-value1', config.for_file(dir..'abc').name1
+        assert.same 'file-layer1-value1', config.for_file(dir..'abc').for_layer('layer1').name1
+        assert.same 'dir-value1', config.for_file(dir..'abc').name1

--- a/spec/config_spec.moon
+++ b/spec/config_spec.moon
@@ -544,3 +544,50 @@ describe 'config', ->
         config.save_config dir
         config.load_config true, dir
         assert.same 'value1-global', config.get 'name1', 'buffer/123'
+
+  context 'for_file', ->
+    before_each ->
+      config.define name: 'name1', description: ''
+      config.define name: 'name2', description: ''
+      config.define name: 'name3', description: ''
+      config.define_layer 'layer1'
+      config.define_layer 'layer2'
+
+    it 'returns a proxy that inherits from global', ->
+      with_tmpdir (dir) ->
+        config.set 'name1', 'value1'
+        assert.same 'value1', config.for_file(dir .. 'abc').name1
+
+    it 'returns the same config for same file path', ->
+      with_tmpdir (dir) ->
+        fileconfig = config.for_file(dir .. 'abc')
+        fileconfig.name1 = 'file-value1'
+        fileconfig2 =  config.for_file(dir.path .. '/abc')
+        assert.same 'file-value1', fileconfig2.name1
+
+    it 'constructs scopes that inherit from ancestor file scopes', ->
+      with_tmpdir (dir) ->
+        with config.for_file(dir)
+          .name1 = 'dir-value1'
+          .name2 = 'dir-value2'
+        with config.for_file(dir .. 'abc')
+          .name1 = 'file-value1'
+          .name3= 'file-value3'
+        assert.same 'file-value1', config.for_file(dir .. 'abc').name1
+        assert.same 'dir-value2', config.for_file(dir .. 'abc').name2
+        assert.same nil, config.for_file(dir).name33
+        assert.same nil, config.name3
+
+    context 'for_layer', ->
+      it 'creates another proxy for specified layer at same scope', ->
+        with_tmpdir (dir) ->
+          with config.for_file(dir).for_layer('layer1')
+            .name1 = 'dir-layer1-value1'
+          with config.for_file(dir)
+            .name1 = 'dir-value1'
+
+          with config.for_file(dir..'abc').for_layer('layer1')
+            .name1 =  'file-layer1-value1'
+
+          assert.same 'file-layer1-value1', config.for_file(dir..'abc').for_layer('layer1').name1
+          assert.same 'dir-value1', config.for_file(dir..'abc').name1

--- a/spec/interact_spec.moon
+++ b/spec/interact_spec.moon
@@ -116,3 +116,23 @@ describe 'interact', ->
         finish2 = captured_finish
 
         assert.has_no_error finish2
+
+  describe 'sequence()', ->
+    it 'runs specified functions in serial, returns table containing all results', ->
+      calls = {}
+      local result
+      run_in_coroutine ->
+        result = interact.sequence {'first', 'second', 'third'},
+          first: ->
+            table.insert calls, 'first'
+            'first-result'
+          second: ->
+            table.insert calls, 'second'
+            'second-result'
+          third: ->
+            table.insert calls, 'third'
+            'third-result'
+      assert.same {'first', 'second', 'third'}, calls
+      assert.same 'first-result', result.first
+      assert.same 'second-result', result.second
+      assert.same 'third-result', result.third

--- a/spec/interact_spec.moon
+++ b/spec/interact_spec.moon
@@ -136,3 +136,28 @@ describe 'interact', ->
       assert.same 'first-result', result.first
       assert.same 'second-result', result.second
       assert.same 'third-result', result.third
+
+    it 'a function returning nil cancels the entire interaction', ->
+      calls = {}
+      local result
+      run_in_coroutine ->
+        result = interact.sequence {'first', 'second', 'third'},
+          first: ->
+            table.insert calls, 'first'
+            'first-result'
+          second: ->
+            table.insert calls, 'second'
+            nil
+          third: ->
+            table.insert calls, 'third'
+            'third-result'
+      assert.same {'first', 'second'}, calls
+      assert.same nil, result
+
+    it 'calls `finish`, if present, on the final result and returns that', ->
+      local result
+      run_in_coroutine ->
+        result = interact.sequence {'first'},
+          first: -> 'first-result'
+          finish: (r) -> 'finish ' .. r.first
+      assert.same 'finish first-result', result


### PR DESCRIPTION
The new set command has the following form:

```
  set <name>@<scope>[<layer>]=<value>
```

The [<layer>] part is optional.

Examples:
```
  set theme@global=Monokai
  set indent@global[mode:moonscript]=2
  set indent@project[mode:python]=4
  set auto_inspect@buffer=manual
```
Selection lists provide auto-complete for the `name` and `scope` part,
making it generally unnecessary to type out the whole thing.

This is now implemented as a sequence of three interactions, rather
than one complex text entry interaction.

Backspacing backtracks to the previous interaction, allowing you to
edit any part of the command, but different than the current behavior
in that it clears the whole previous selection, rather than deleting
one character. (In that sense it is similar to backspacing into the
parent directory in the file browser).