### PR TITLE
Allowing running different inspectors for idle and save

### DIFF
--- a/bundles/moonscript/moonscript_mode.moon
+++ b/bundles/moonscript/moonscript_mode.moon
@@ -12,7 +12,7 @@ class MoonscriptMode
       @completers = .completers
 
   default_config:
-    inspectors: { 'moonscript' }
+    inspectors_on_idle: { 'moonscript' }
 
   comment_syntax: '--'
 

--- a/bundles/ruby/ruby_mode.moon
+++ b/bundles/ruby/ruby_mode.moon
@@ -39,7 +39,7 @@ continuation_indent = (line, indent_level) ->
 
   default_config:
     word_pattern: r'\\b\\w[\\w\\d_]+[?!=]?\\b'
-    inspectors: { 'ruby' }
+    inspectors_on_idle: { 'ruby' }
 
   indentation: {
     more_after: {

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -259,7 +259,7 @@ on_idle = ->
   return if editor.popup
 
   b = editor.buffer
-  if b.config.auto_inspect == 'idle'
+  if b.config.auto_inspect == 'on'
     if b.size < 1024 * 1024 * 5 -- 5 MB
       update_buffer b, editor, 'idle'
 
@@ -274,9 +274,9 @@ signal.connect 'buffer-modified', (args) ->
 signal.connect 'buffer-saved', (args) ->
   b = args.buffer
   return unless b.size < 1024 * 1024 * 5 -- 5 MB
-  return if b.config.auto_inspect == 'manual'
+  return if b.config.auto_inspect == 'off'
   -- what to load? if config says 'save', all, otherwise only save inspectors
-  scope = b.config.auto_inspect == 'save' and 'all' or 'save'
+  scope = b.config.auto_inspect == 'save_only' and 'all' or 'save'
   update_buffer b, nil, scope
 
 signal.connect 'after-buffer-switch', (args) ->

--- a/lib/howl/variables/core_variables.moon
+++ b/lib/howl/variables/core_variables.moon
@@ -34,8 +34,15 @@ config.define
   scope: 'global'
 
 config.define {
-  name: 'inspectors'
-  description: 'List of inspectors to run for a buffer'
+  name: 'inspectors_on_idle'
+  description: 'List of on-idle inspectors to run for a buffer'
+  type_of: 'string_list'
+  default: {}
+}
+
+config.define {
+  name: 'inspectors_on_save'
+  description: 'List of on-save inspectors to run for a buffer'
   type_of: 'string_list'
   default: {}
 }
@@ -45,9 +52,9 @@ config.define {
   description: 'When to automatically inspect code for abberrations'
   default: 'idle'
   options: {
-    { 'manual', 'Only inspect when explicitly asked' }
-    { 'idle', 'Inspect on idle' }
-    { 'save', 'Inspect when saving a buffer' }
+    { 'manual', 'Run all inspectors when explicitly asked' }
+    { 'idle', 'Run on-idle inspectors on idle and on-save inspectors on save' }
+    { 'save', 'Run all inspectors, but only on save' }
   }
 }
 

--- a/lib/howl/variables/core_variables.moon
+++ b/lib/howl/variables/core_variables.moon
@@ -50,11 +50,11 @@ config.define {
 config.define {
   name: 'auto_inspect'
   description: 'When to automatically inspect code for abberrations'
-  default: 'idle'
+  default: 'on'
   options: {
-    { 'manual', 'Run all inspectors when explicitly asked' }
-    { 'idle', 'Run on-idle inspectors on idle and on-save inspectors on save' }
-    { 'save', 'Run all inspectors, but only on save' }
+    { 'off', 'Run all inspectors only when explicitly asked to' }
+    { 'on', 'Run on-idle inspectors on idle and on-save inspectors on save' }
+    { 'save_only', 'Run all inspectors, but only on save' }
   }
 }
 


### PR DESCRIPTION
The previous solution had only one list of inspectors, and you could
chose when those would run (idle, save or manually). While this was a
simpler (and thus nicer in that sense) solution, it didn't allow for
running lightweight inspections on idle and heavy weight inspections
on save.

With this split there are now two configuration variables for
controlling what inspectors are run, `inspectors_on_idle` and
`inspectors_on_save`. The `auto_inspect` option now allows the
following three alternatives for controlling the running behaviour:

- manual: Run all inspectors when explicitly asked
- idle: Run on-idle inspectors on idle and on-save inspectors on save
- save: Run all inspectors, but only on save

@shalabhc How about this for your heavyweight stuff?