### PR TITLE
Allow bundles to exposed vendored lua modules

### DIFF
--- a/lib/howl/util/sandboxed_loader.moon
+++ b/lib/howl/util/sandboxed_loader.moon
@@ -29,7 +29,12 @@ new = (dir, name, sandbox_options = {}) ->
       return loaded[rel_path] if loaded[rel_path]
       loading[rel_path] = true
       path = dir / rel_path
-      path = find_file dir, rel_path unless path.exists
+
+      if path.is_directory
+        path = find_file path, 'init'
+      elseif not path.exists
+        path = find_file dir, rel_path
+
       mod = load_file path, box, ...
       loading[rel_path] = false
       loaded[rel_path] = mod

--- a/lint_config.moon
+++ b/lint_config.moon
@@ -21,6 +21,10 @@
       'user_load',
     },
 
+    ['bundles/']: {
+      'provide_module'
+    }
+
     ['themes/']: {
       'flair',
       'highlight',

--- a/spec/util/sandboxed_loader_spec.moon
+++ b/spec/util/sandboxed_loader_spec.moon
@@ -52,26 +52,31 @@ describe 'SandboxedLoader', ->
         assert.equals 1, loader -> foo_load 'aux'
 
       context '(loading files from sub directories)', ->
+        local sub_dir
+
+        before_each ->
+          sub_dir = dir\join('subdir')
+          sub_dir\mkdir!
+
         it 'supports both slashes and dots in the path', ->
-          sub = dir\join('down/sub.lua')
-          sub.parent\mkdir!
-          sub.contents = 'return "sub"'
+          sub_dir\join('sub.lua').contents = 'return "sub"'
+          sub_dir\join('sub2.lua').contents = 'return "sub2"'
 
-          dir\join('down/sub2.lua').contents = 'return "sub2"'
-
-          assert.equals 'sub', loader -> foo_load 'down/sub'
-          assert.equals 'sub2', loader -> foo_load 'down.sub2'
+          assert.equals 'sub', loader -> foo_load 'subdir/sub'
+          assert.equals 'sub2', loader -> foo_load 'subdir.sub2'
 
         it 'loads the file once regardless of whether dots or slashes are used', ->
-          sub = dir\join('down/sub.lua')
-          sub.parent\mkdir!
-          sub.contents = [[
+          sub_dir\join('sub.lua').contents = [[
             _G.load_count = _G.load_count + 1
             return _G.load_count
           ]]
           _G.load_count = 0
-          assert.equals 1, loader -> foo_load 'down/sub'
-          assert.equals 1, loader -> foo_load 'down.sub'
+          assert.equals 1, loader -> foo_load 'subdir/sub'
+          assert.equals 1, loader -> foo_load 'subdir.sub'
+
+        it 'loads an implicit init file for bare directory references', ->
+          sub_dir\join('init.lua').contents = 'return "lua"'
+          assert.equals 'lua', loader -> foo_load 'subdir'
 
       it 'signals an error upon cyclic dependencies', ->
         dir\join('aux.lua').contents = 'foo_load("aux2")'


### PR DESCRIPTION
Allow bundles to expose modules using `provide_module` helper
    
This allows for a bundle to easily vendor an entire lua module. The `provide_module` helper exposes this both internally within the bundle and externally with Howl, so that any files can be `require`d just as if they we're on the default search path.
