### PR TITLE
Refresh editor config when buffer mode changes.

### DIFF
--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -68,6 +68,12 @@ signal.connect 'buffer-title-set', (args) ->
     if buffer == e.buffer
       e.indicator.title.label = buffer.title
 
+signal.connect 'buffer-mode-set', (args) ->
+  buffer = args.buffer
+  for e in *editors!
+    if buffer == e.buffer
+      e\_set_config_settings!
+
 class Editor extends PropertyObject
 
   register_indicator: (id, placement = 'bottom_right', factory) ->
@@ -630,9 +636,11 @@ class Editor extends PropertyObject
   refresh_variable: (name) =>
     value = @buffer.config[name]
     if aullar_config_vars[name]
-      @view.config[aullar_config_vars[name]] = value
+      if @view.config[aullar_config_vars[name]] != value
+        @view.config[aullar_config_vars[name]] = value
     elseif editor_config_vars[name]
-      @[editor_config_vars[name]] = value
+      if @[editor_config_vars[name]] != value
+        @[editor_config_vars[name]] = value
     else
       error "Invalid var #{name}"
 

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -889,3 +889,24 @@ describe 'Editor', ->
       editor2.buffer.config.line_numbers = false
       assert.true editor.line_numbers
       assert.false editor2.line_numbers
+
+    it 'buffer mode change triggers config refresh for containing editor', ->
+      mode1 = {}
+      mode2 = {}
+
+      howl.mode.register name: 'test_mode1', create: -> mode1
+      howl.mode.register name: 'test_mode2', create: -> mode2
+      howl.mode.configure 'test_mode1',
+        line_numbers: false
+
+      howl.mode.configure 'test_mode2',
+        line_numbers: true
+
+      buffer.mode = howl.mode.by_name 'test_mode1'
+      assert.false editor.line_numbers
+
+      buffer.mode = howl.mode.by_name 'test_mode2'
+      assert.true editor.line_numbers
+
+      howl.mode.unregister 'test_mode1'
+      howl.mode.unregister 'test_mode2'


### PR DESCRIPTION
- Fixes #347
- Also don't set the config value unless different from existing value