### PR TITLE
Allow completions to be tables in addition to strings

### DIFF
--- a/lib/howl/completer.moon
+++ b/lib/howl/completer.moon
@@ -28,12 +28,19 @@ at_most = (limit, t) ->
 
   t2
 
+completion_text = (compl) ->
+  if type(compl) == 'table'
+    return compl.completion or tostring compl[1]
+  return compl
+
 differentiate_by_case = (prefix, completions) ->
   for i = 2, #completions
     first = completions[i - 1]
     second = completions[i]
-    if first.ulower == second.ulower
-      if second[1] == prefix[1]
+    first_text = completion_text first
+    second_text = completion_text second
+    if first_text.ulower == second_text.ulower
+      if second_text[1] == prefix[1]
         completions[i - 1] = second
         completions[i] = first
 
@@ -76,6 +83,7 @@ class Completer
     return differentiate_by_case(prefix, at_most(limit, completions)), prefix
 
   accept: (compl, pos) =>
+    compl = completion_text compl
     chunk = @buffer\context_at(pos).word
     chunk = @buffer\chunk(chunk.start_pos, pos - 1) unless @config.hungry_completion
     chunk.text = compl

--- a/spec/completer_spec.moon
+++ b/spec/completer_spec.moon
@@ -46,6 +46,10 @@ describe 'Completer', ->
       _, search = Completer(buffer, 4)\complete 4
       assert.same search, 'pre'
 
+    it 'allows completions to be tables', ->
+      append buffer.completers, -> complete: -> { {'first', 'second'}, {'third', 'fourth'} }
+      assert.same Completer(buffer, 1)\complete(1), { {'first', 'second'}, {'third', 'fourth'} }
+
     it 'calls <completer.complete()> with (completer, context)', ->
       buffer.text = 'mr.cat'
       comp = complete: spy.new -> {}
@@ -133,6 +137,15 @@ describe 'Completer', ->
         completer = Completer(buffer, 7)
         completer\accept 'over', 7
         assert.equal 'hello overthere', buffer.text
+
+    context 'when completions are tables', ->
+      it 'inserts table.completion text if present, else table[1]', ->
+        buffer.text = 'hello '
+        completer = Completer(buffer, 7)
+        completer\accept {'first', 'second', completion: 'real'}, 7
+        assert.equal 'hello real', buffer.text
+        completer\accept {'third', 'fourth'}, 7
+        assert.equal 'hello thirdreal', buffer.text
 
     it 'returns the position after the accepted completion', ->
         buffer.text = 'hello there'


### PR DESCRIPTION
When a table is specified, the value of the 'completion' key is
inserted on accepting the completion. Tables are automatically
rendered as styled table and accept markup.