### PR TITLE
Better EOL handling

### DIFF
--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -50,6 +50,13 @@ class Buffer extends PropertyObject
       if file.exists
         @text = file.contents
         @sync_etag = file.etag
+
+        -- update EOL from loaded file if possible
+        first_line = @_buffer\get_line 1
+        if first_line and first_line.has_eol
+          eol = @_buffer\sub first_line.size + 1, first_line.end_offset
+          @eol = eol
+
       else
         @text = ''
         @sync_etag = nil

--- a/lib/howl/buffer_lines.moon
+++ b/lib/howl/buffer_lines.moon
@@ -103,7 +103,7 @@ Line = (nr, buffer) ->
       chunk: =>
         start_pos = @start_pos
         end_pos = @end_pos
-        end_pos -= 1
+        end_pos -= #buffer.eol
         buffer\chunk start_pos, end_pos
 
       previous_non_blank: =>

--- a/spec/buffer_lines_spec.moon
+++ b/spec/buffer_lines_spec.moon
@@ -185,6 +185,14 @@ describe 'BufferLines', ->
         assert.equal 7, chunk.start_pos
         assert.equal 10, chunk.end_pos
 
+      it 'respects the buffer eol', ->
+        buf.text = 'MORE\r\nDOS'
+        buf.eol = '\r\n'
+        chunk = lines[1].chunk
+        assert.equal 'MORE', chunk.text
+        assert.equal 1, chunk.start_pos
+        assert.equal 4, chunk.end_pos
+
       it 'is an empty chunk for empty lines', ->
         buf.text = '\n'
         chunk = lines[1].chunk

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -118,12 +118,30 @@ describe 'Buffer', ->
         b.file = file
         assert.is_false b.can_undo
 
-  it '.eol is "\\n" by default', ->
-    assert.equals '\n', buffer('').eol
+  describe '.eol', ->
+    it 'is "\\n" by default', ->
+      assert.equals '\n', buffer('').eol
 
-  describe '.eol = <string>', ->
-    it 'raises an error if the eol is unknown', ->
+    it 'raises an error if a assignment value is unknown', ->
       assert.raises 'Unknown', -> buffer('').eol = 'foo'
+
+    it 'is adjusted automatically when a file is loaded', ->
+      b = buffer('')
+      with_tmpfile (plain_file) ->
+        with_tmpfile (file) ->
+          file.contents = 'o hai\r\nDOS'
+          b.file = file
+          assert.equals '\r\n', b.eol
+
+          b.file = plain_file
+          file.contents = 'o hai\nNIX'
+          b.file = file
+          assert.equals '\n', b.eol
+
+          b.file = plain_file
+          file.contents = 'venerable\rMac'
+          b.file = file
+          assert.equals '\r', b.eol
 
   it '.properties is a table', ->
     assert.equal 'table', type buffer('').properties


### PR DESCRIPTION
Automatically set EOL after loading a file, and fix buffer lines's .chunk to account for EOL according to @shalabhc's pointer.

Fixes #369 