### PR TITLE
Switch binding translation character around when caps lock is on

### DIFF
--- a/lib/howl/bindings.moon
+++ b/lib/howl/bindings.moon
@@ -169,10 +169,17 @@ export translate_key = (event) ->
   alternate = alternate_names[event.key_name]
 
   translations = {}
-  append translations, ctrl .. meta .. alt .. event.character if event.character
+  character = event.character
+  if event.lock and character
+    if event.shift
+      character = character.uupper
+    else
+      character = character.ulower
+
+  append translations, ctrl .. meta .. alt .. character if character
   modifiers = ctrl .. meta .. shift .. alt
 
-  if event.key_name and event.key_name != event.character
+  if event.key_name and event.key_name != character
     append translations, modifiers .. event.key_name
 
   if typeof(alternate) == 'table'

--- a/lib/ljglibs/util.moon
+++ b/lib/ljglibs/util.moon
@@ -1,4 +1,4 @@
--- Copyright 2014-2015 The Howl Developers
+-- Copyright 2014-2017 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 ffi = require 'ffi'
@@ -36,6 +36,7 @@ explain_key_code = (code, event) ->
       alt: band(key_event.state, C.GDK_MOD1_MASK) != 0,
       super: band(key_event.state, C.GDK_SUPER_MASK) != 0,
       meta: band(key_event.state, C.GDK_META_MASK) != 0,
+      lock: band(key_event.state, C.GDK_LOCK_MASK) != 0,
     }
     explain_key_code key_event.keyval, event
     event

--- a/spec/bindings_spec.moon
+++ b/spec/bindings_spec.moon
@@ -68,6 +68,19 @@ describe 'bindings', ->
           control: true, shift: true
         assert.same tr, { 'ctrl_A', 'ctrl_shift_a', 'ctrl_shift_123' }
 
+    context 'when lock is on', ->
+      it 'downcases the character for translations', ->
+        tr = bindings.translate_key
+          character: 'A', key_name: 'a', key_code: 123, lock: true
+        assert.same { 'a', '123' }, tr
+
+      context 'and shift is held', ->
+        it 'upcases the character for translations', ->
+          tr = bindings.translate_key
+            character: 'A', key_name: 'a', key_code: 123, lock: true, shift: true
+
+          assert.same { 'A', 'shift_a', 'shift_123' }, tr
+
     it 'adds special case translations for certain common keys', ->
       for_keynames = {
         kp_up: 'up'


### PR DESCRIPTION
While it's slightly weird, it makes it possible to use ordinary key
bindings (at least for the most common cases) even when typing with
caps lock on.

Fixes #282.