### PR TITLE
Improve Python lexing of f strings

### DIFF
--- a/bundles/python/misc/examples.py
+++ b/bundles/python/misc/examples.py
@@ -82,6 +82,7 @@ f_string_spec = f'{v!r}'
 another_braced_f_string = f'{v:a4c{abc}}abc'
 f_string_with_bang = f'{v!=0}'
 triple_dq_f_string = f"""abc{defg}"""
+brace_escape_f_string = f'{{this is not an expr}}'
 
 if False:
   # Dictionaries


### PR DESCRIPTION
The previous lexing was too loose. It would start a f string, scan until the
end or until a starting brace, and then lex anything followed by more f string
scanning. This obviously causes problems if the string has ended, but we still
lexed something else and continue with the f string.

Instead tighten up the lexing. We scan the f string until the end or until the
first brace. If and only if we're looking at an interpolation then attempt that,
but otherwise handle ends, etc., correctly.

Also lex double braces in f strings correctly.

Closes #379.