### PR TITLE
Add support for navigation (breadcrumbs)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased (in master)
 
+- Added support for navigating back and forth in a list of previously visited
+locations. Two new commands, `navigate-back` and `navigate-forward` were added,
+bound to `ctrl_<` and `ctrl_>` respectively.
+
 - Added two new commands, `editor-newline-above` and `editor-newline-below`,
 that insert a new line above/below the current line. Bound these commands to
 `ctrl_shift_return` and `ctrl_return`.

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -2,7 +2,7 @@
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 import Window, Editor, theme from howl.ui
-import Buffer, Settings, mode, bundle, bindings, keymap, signal, interact, timer, clipboard, config from howl
+import Buffer, Settings, mode, breadcrumbs, bundle, bindings, keymap, signal, interact, timer, clipboard, config from howl
 import File, Process from howl.io
 import PropertyObject from howl.util.moon
 Gtk = require 'ljglibs.gtk'
@@ -147,6 +147,7 @@ class Application extends PropertyObject
 
     append @_buffers, buffer
     if show and @editor
+      breadcrumbs.drop!
       @editor.buffer = buffer
       @editor
 
@@ -174,12 +175,14 @@ class Application extends PropertyObject
   open_file: (file, editor = @editor) =>
     buffer = @_buffer_for_file file
     if buffer
+      breadcrumbs.drop!
       editor.buffer = buffer
       return buffer, editor
 
     buffer = @new_buffer mode.for_file file
     status, err = pcall ->
       buffer.file = file
+      breadcrumbs.drop!
       if editor
         editor.buffer = buffer
       else

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -170,7 +170,12 @@ class Application extends PropertyObject
     if buffer.showing
       for editor in *@editors
         if editor.buffer == buffer
+          if editor == @editor -- if showing in the current editor
+            breadcrumbs.drop! -- we drop a crumb here
+
           editor.buffer = @next_buffer
+
+    signal.emit 'buffer-closed', :buffer
 
   open_file: (file, editor = @editor) =>
     buffer = @_buffer_for_file file
@@ -248,6 +253,8 @@ class Application extends PropertyObject
     signal.connect 'window-focused', self\synchronize
     signal.connect 'editor-destroyed', (s_args) ->
       @_editors =  [e for e in *@_editors when e != s_args.editor]
+
+    breadcrumbs.init!
 
     @g_app\run args
 
@@ -501,6 +508,11 @@ signal.register 'file-opened',
   parameters:
     buffer: 'The buffer that the file was opened into'
     file: 'The file that was opened'
+
+signal.register 'buffer-closed',
+  description: 'Signaled right after a buffer was closed',
+  parameters:
+    buffer: 'The buffer that was closed'
 
 signal.register 'app-ready',
   description: 'Signaled right after the application has completed initialization'

--- a/lib/howl/breadcrumbs.moon
+++ b/lib/howl/breadcrumbs.moon
@@ -24,7 +24,7 @@ next_marker_id = ->
 clear_crumb = (crumb) ->
   marker = crumb.buffer_marker
   return unless marker
-  buf = marker.buffer_holder.buffer
+  buf = marker.buffer
   return unless buf
   buf.markers\remove name: marker.name
 
@@ -36,15 +36,15 @@ clear = ->
 
 navigable_crumb = (crumb) ->
   return true if crumb.file and crumb.file.exists
-  crumb.buffer_marker and crumb.buffer_marker.buffer_holder.buffer
+  crumb.buffer_marker and crumb.buffer_marker.buffer
 
 crumbs_are_equal = (c1, c2) ->
   return false unless c1 and c2
   return false unless c1.pos == c2.pos
   return true if (c1.file and c2.file) and c1.file == c2.file
 
-  c1_buffer = c1.buffer_marker and c1.buffer_marker.buffer_holder.buffer
-  c2_buffer = c2.buffer_marker and c2.buffer_marker.buffer_holder.buffer
+  c1_buffer = c1.buffer_marker and c1.buffer_marker.buffer
+  c2_buffer = c2.buffer_marker and c2.buffer_marker.buffer
 
   return true if (c1_buffer and c2_buffer) and c1_buffer == c2_buffer
 
@@ -57,7 +57,7 @@ adjust_crumbs_for_closed_buffer = (buffer) ->
   lower_location_by = 0
   for i = #crumbs, 1, -1
     crumb = crumbs[i]
-    if crumb.buffer_marker and crumb.buffer_marker.buffer_holder.buffer == buffer
+    if crumb.buffer_marker and crumb.buffer_marker.buffer == buffer
       if crumb.file and crumb.file.exists
         crumb.buffer_marker = nil
       else
@@ -89,7 +89,7 @@ adjust_location_for_inactive_buffer = (buffer) ->
 
   buf_at_location = (loc) ->
     c = crumbs[loc]
-    c.buffer_marker and c.buffer_marker.buffer_holder.buffer
+    c.buffer_marker and c.buffer_marker.buffer
 
   crumb_buf = buf_at_location location - 1
 
@@ -103,7 +103,7 @@ adjust_location_for_inactive_buffer = (buffer) ->
       break unless crumb_buf == buffer
 
 goto_crumb = (crumb) ->
-  buffer = if crumb.buffer_marker then crumb.buffer_marker.buffer_holder.buffer
+  buffer = if crumb.buffer_marker then crumb.buffer_marker.buffer
   app = _G.howl.app
   local editor
   return unless app.editor
@@ -134,7 +134,7 @@ add_crumb = (crumb, at, insert_crumb = false) ->
   return false if next_crumb and crumbs_are_equal crumb, next_crumb
 
   if crumb.buffer_marker
-    crumb.buffer_marker.buffer_holder.buffer.markers\add {
+    crumb.buffer_marker.buffer.markers\add {
       {
         name: crumb.buffer_marker.name,
         start_offset: crumb.pos,
@@ -165,10 +165,10 @@ new_crumb = (opts = {}) ->
   local buffer_marker
 
   if buffer
-    buffer_marker = {
-      buffer_holder: setmetatable {:buffer}, __mode: 'v'
+    buffer_marker = setmetatable {
+      :buffer,
       name: "breadcrumb-#{next_marker_id!}"
-    }
+    }, __mode: 'v'
 
   {
     :file,

--- a/lib/howl/breadcrumbs.moon
+++ b/lib/howl/breadcrumbs.moon
@@ -1,0 +1,161 @@
+-- Copyright 2017 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+{:File} = howl.io
+{:PropertyTable} = howl.util
+{:remove, :insert} = table
+
+crumbs = {}
+location = 1
+marker_id = 0
+
+next_location = ->
+  nr = location + 1
+  nr = 1 if nr >= math.huge
+  nr
+
+next_marker_id = ->
+  marker_id += 1
+  marker_id = 1 if marker_id >= math.huge
+  marker_id
+
+clear_crumb = (crumb) ->
+  marker = crumb.buffer_marker
+  return unless marker
+  buf = marker.buffer_holder.buffer
+  return unless buf
+  buf.markers\remove name: marker.name
+
+clear = ->
+  while #crumbs > 0
+    clear_crumb remove(crumbs)
+
+  location = 1
+
+navigable_crumb = (crumb) ->
+  return true if crumb.file and crumb.file.exists
+  crumb.buffer_marker and crumb.buffer_marker.buffer_holder.buffer
+
+goto_crumb = (crumb) ->
+  buffer = if crumb.buffer_marker then crumb.buffer_marker.buffer_holder.buffer
+  app = _G.howl.app
+
+  if buffer
+    app.editor.buffer = buffer
+    app.editor.cursor.pos = crumb.pos
+  elseif crumb.file
+    app\open_file crumb.file
+    app.editor.cursor.pos = crumb.pos
+
+crumbs_are_equal = (c1, c2) ->
+  return false unless c1.pos == c2.pos
+  return true if (c1.file and c2.file) and c1.file == c2.file
+
+  c1_buffer = c1.buffer_marker and c1.buffer_marker.buffer_holder.buffer
+  c2_buffer = c2.buffer_marker and c2.buffer_marker.buffer_holder.buffer
+
+  return true if (c1_buffer and c2_buffer) and c1_buffer == c2_buffer
+
+  return true if c1.file and c2_buffer and c1.file == c2_buffer.file
+  return true if c2.file and c1_buffer and c2.file == c1_buffer.file
+
+  false
+
+add_crumb = (crumb, at, insert_crumb = false) ->
+  prev_crumb = crumbs[at - 1]
+  return false if prev_crumb and crumbs_are_equal crumb, prev_crumb
+
+  next_crumb_pos = insert_crumb and at or at + 1
+  next_crumb = crumbs[next_crumb_pos]
+  return false if next_crumb and crumbs_are_equal crumb, next_crumb
+
+  if crumb.buffer_marker
+    crumb.buffer_marker.buffer_holder.buffer.markers\add {
+      {
+        name: crumb.buffer_marker.name,
+        start_offset: crumb.pos,
+        end_offset: crumb.pos
+      }
+    }
+
+  if insert_crumb
+    insert crumbs, at, crumb
+  else
+    crumbs[at] = crumb
+
+  true
+
+new_crumb = (buffer, file, pos) ->
+  if type(file) == 'string'
+    file = File(file)
+
+  if buffer and not file
+    file = buffer.file
+
+  unless pos and (buffer or file)
+    error "Must provide `pos` (was #{pos}), and either of `buffer` (was #{buffer}) and `file` (was #{file})", 3
+
+  local buffer_marker
+
+  if buffer
+    buffer_marker = {
+      buffer_holder: setmetatable {:buffer}, __mode: 'v'
+      name: "breadcrumb-#{next_marker_id!}"
+    }
+
+  :file, :pos, :buffer_marker
+
+current_edit_location_crumb = ->
+  editor = _G.howl.app.editor
+  return nil unless editor
+  new_crumb editor.buffer, editor.buffer.file, editor.cursor.pos
+
+drop = (opts) ->
+  -- clear any existing forward crumbs
+  while #crumbs >= location
+    clear_crumb remove(crumbs)
+
+  crumb = if opts
+    new_crumb opts.buffer, opts.file, opts.pos
+  else
+    current_edit_location_crumb!
+
+  return unless crumb
+  add_crumb crumb, location
+  location = next_location!
+
+go_back = ->
+  while true
+    crumb = crumbs[location - 1]
+    break unless crumb
+    location -= 1
+    if navigable_crumb crumb
+      current_crumb = current_edit_location_crumb!
+      add_crumb current_crumb, location + 1, true
+      goto_crumb crumb
+      break
+
+go_forward = ->
+  while true
+    crumb = crumbs[location + 1]
+    break unless crumb
+    location += 1
+    if navigable_crumb crumb
+      current_crumb = current_edit_location_crumb!
+      if add_crumb(current_crumb, location, true)
+        location += 1
+
+      goto_crumb crumb
+      break
+
+PropertyTable {
+  trail: crumbs
+  location: get: -> location
+  previous: get: -> crumbs[location - 1]
+  next: get: -> crumbs[location + 1]
+  :clear
+  :go_back
+  :go_forward
+  :drop
+}
+

--- a/lib/howl/breadcrumbs.moon
+++ b/lib/howl/breadcrumbs.moon
@@ -1,11 +1,11 @@
 -- Copyright 2017 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-{:signal} = howl
+{:signal, :config} = howl
 {:File} = howl.io
 {:PropertyTable} = howl.util
 {:remove, :insert} = table
-{:max} = math
+{:min, :max} = math
 
 crumbs = {}
 location = 1
@@ -75,6 +75,14 @@ adjust_crumbs_for_cycle = ->
   previous_match = crumbs[location - 4]
   return unless crumbs_are_equal previous, previous_match
   location -= 2
+
+prune_crumbs_according_to_limit = ->
+  limit = config.breadcrumb_limit
+  nr_to_remove = min max(#crumbs - limit, 0), location
+  for i = 1, nr_to_remove
+    remove crumbs, 1
+
+  location -= nr_to_remove
 
 adjust_location_for_inactive_buffer = (buffer) ->
   return unless location > 1
@@ -190,6 +198,7 @@ drop = (opts) ->
     location = next_location!
 
     adjust_crumbs_for_cycle!
+    prune_crumbs_according_to_limit!
 
     -- clear any existing forward crumbs
     while #crumbs >= location
@@ -231,6 +240,13 @@ init = ->
     adjust_crumbs_for_closed_buffer params.buffer
 
   initialized = true
+
+config.define
+  name: 'breadcrumb_limit'
+  description: 'The maximum number of breadcrumbs to keep'
+  scope: 'global'
+  type_of: 'number'
+  default: 200
 
 PropertyTable {
   :init

--- a/lib/howl/breadcrumbs.moon
+++ b/lib/howl/breadcrumbs.moon
@@ -179,7 +179,7 @@ new_crumb = (opts = {}) ->
 
 current_edit_location_crumb = ->
   editor = _G.howl.app.editor
-  return nil unless editor
+  return nil unless editor and editor.cursor
   new_crumb {
     buffer: editor.buffer,
     pos: editor.cursor.pos,

--- a/lib/howl/breadcrumbs.moon
+++ b/lib/howl/breadcrumbs.moon
@@ -131,7 +131,10 @@ goto_crumb = (crumb) ->
   editor.cursor.pos = pos
 
   if crumb.line_at_top
+    -- we try to maintain the same scrolling offset
     editor.line_at_top = crumb.line_at_top
+    -- but due to potential edits we need to ensure we're actually visible
+    editor\ensure_visible pos
 
 add_crumb = (crumb, at, insert_crumb = false) ->
   prev_crumb = crumbs[at - 1]

--- a/lib/howl/breadcrumbs.moon
+++ b/lib/howl/breadcrumbs.moon
@@ -66,6 +66,16 @@ adjust_crumbs_for_closed_buffer = (buffer) ->
 
   location = max 1, location - lower_location_by
 
+adjust_crumbs_for_cycle = ->
+  return unless location > 4
+  last = crumbs[location - 1]
+  last_match = crumbs[location - 3]
+  return unless crumbs_are_equal last, last_match
+  previous = crumbs[location - 2]
+  previous_match = crumbs[location - 4]
+  return unless crumbs_are_equal previous, previous_match
+  location -= 2
+
 adjust_location_for_inactive_buffer = (buffer) ->
   return unless location > 1
 
@@ -178,6 +188,8 @@ drop = (opts) ->
 
   if add_crumb crumb, location
     location = next_location!
+
+    adjust_crumbs_for_cycle!
 
     -- clear any existing forward crumbs
     while #crumbs >= location

--- a/lib/howl/breadcrumbs.moon
+++ b/lib/howl/breadcrumbs.moon
@@ -103,7 +103,8 @@ adjust_location_for_inactive_buffer = (buffer) ->
       break unless crumb_buf == buffer
 
 goto_crumb = (crumb) ->
-  buffer = if crumb.buffer_marker then crumb.buffer_marker.buffer
+  marker = crumb.buffer_marker
+  buffer = if marker then marker.buffer
   app = _G.howl.app
   local editor
   return unless app.editor
@@ -120,7 +121,14 @@ goto_crumb = (crumb) ->
   else
     return
 
-  editor.cursor.pos = crumb.pos
+  pos = crumb.pos
+
+  if marker and buffer
+    markers = buffer.markers\find(name: marker.name)
+    if #markers > 0
+      pos = markers[1].start_offset
+
+  editor.cursor.pos = pos
 
   if crumb.line_at_top
     editor.line_at_top = crumb.line_at_top

--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -284,6 +284,7 @@ command.register
   handler: ->
     if breadcrumbs.previous
       breadcrumbs.go_back!
+      log.info "navigate: now at #{breadcrumbs.location} of #{#breadcrumbs.trail}"
     else
       log.info "No previous location recorded"
 
@@ -293,6 +294,7 @@ command.register
   handler: ->
     if breadcrumbs.next
       breadcrumbs.go_forward!
+      log.info "navigate: now at #{breadcrumbs.location} of #{#breadcrumbs.trail}"
     else
       log.info "No next location recorded"
 

--- a/lib/howl/commands/ui_commands.moon
+++ b/lib/howl/commands/ui_commands.moon
@@ -1,7 +1,7 @@
 -- Copyright 2012-2014-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-import app, command, config, mode from howl
+import app, breadcrumbs, command, config, mode from howl
 import style, ActionBuffer, BufferPopup, StyledText from howl.ui
 serpent = require 'serpent'
 
@@ -63,6 +63,7 @@ command.register
   description: "Closes the current view"
   handler: ->
     if #app.window.views > 1
+      breadcrumbs.drop!
       app.window\remove_view!
       collectgarbage!
     else
@@ -74,6 +75,7 @@ command.register
   handler: ->
     target = app.window\siblings(nil, true).right
     if target
+      breadcrumbs.drop!
       target\grab_focus!
     else
       log.warn "No other view found"
@@ -93,6 +95,7 @@ for cmd in *{
     handler: ->
       target = app.window\siblings![direction]
       if target
+        breadcrumbs.drop!
         target\grab_focus!
       else
         log.info "No view #{human_placement} the current one found"
@@ -103,6 +106,7 @@ for cmd in *{
     handler: ->
       target = app.window\siblings(true)[direction]
       if target
+        breadcrumbs.drop!
         target\grab_focus!
       else
         log.info "No view #{human_placement} the current one found"
@@ -113,6 +117,7 @@ for cmd in *{
     handler: ->
       target = app.window\siblings![direction]
       if target
+        breadcrumbs.drop!
         target\grab_focus!
       else
         howl.app\new_editor :placement
@@ -120,4 +125,6 @@ for cmd in *{
   command.register
     name: "view-new-#{placement\gsub '_', '-'}",
     description: "Adds a new view #{human_placement} the current one"
-    handler: -> howl.app\new_editor :placement
+    handler: ->
+      breadcrumbs.drop!
+      howl.app\new_editor :placement

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -83,6 +83,9 @@
     ctrl_up:           'editor-scroll-up'
     ctrl_down:         'editor-scroll-down'
 
+    'ctrl_<':          'navigate-back'
+    'ctrl_>':          'navigate-forward'
+
     ctrl_shift_left:   'cursor-word-left-extend'
     ctrl_shift_right:  'cursor-word-right-extend'
     ctrl_shift_up:     'editor-scroll-up'
@@ -165,6 +168,9 @@
         -- meta_shift_right:  'cursor-word-right-extend'
         -- meta_backspace:    'editor-delete-back-word'
         -- meta_delete:       'editor-delete-forward-word'
+
+        'ctrl_<':          'navigate-back'
+        'ctrl_>':          'navigate-forward'
 
         ctrl_shift_d:      'vc-diff-file'
         ctrl_meta_d:       'vc-diff'

--- a/lib/howl/ui/cursor.moon
+++ b/lib/howl/ui/cursor.moon
@@ -1,8 +1,8 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-import PropertyObject from howl.util.moon
-import command from howl
+{:command, :breadcrumbs} = howl
+{:PropertyObject} = howl.util.moon
 aullar = require 'aullar'
 {:min} = math
 
@@ -221,38 +221,37 @@ class Cursor extends PropertyObject
   @property _line: get: =>
     @container.buffer.lines[@cursor.line]
 
+-- name, aullar name, drop breadcrumb, desc
 commands = {
-  { 'down',               'down',        'Move cursor down' },
-  { 'up',                 'up',          'Move cursor up' },
-  { 'left',               'backward',        'Move cursor left' },
-  { 'right',              'forward',       'Move cursor right' },
-  { 'word_left',          'word_left',        'Move cursor one word left' },
-  { 'word_left_end',      'word_left_end',    'Move cursor left, to the end of the previous word' },
-  { 'word_right',         'word_right',       'Move cursor one word right' },
-  { 'word_right_end',     'word_right_end',   'Move cursor right, to the end of the word' },
-  { 'home',               'start_of_line',             'Move cursor to the first column' },
-  { 'home_indent',        'home_indent',           'Move cursor to the first non-blank column' }, -- { 'home_indent_display','vchome_display',   'Move cursor to the first non-blank column of the display line' },
-  -- { 'home_display',       'home_display',     'Move cursor to the first column of the display line' },
-  -- { 'home_auto',          'home_wrap',        'Move cursor the first column of the real or display line' },
-  { 'home_indent_auto',   'home_indent_auto',      'Move cursor the first column or the first non-blank column' },
-  { 'line_end',           'end_of_line',         'Move cursor to the end of line' },
-  -- { 'line_end_display',   'line_end_display', 'Move cursor to the end of the display line' },
-  -- { 'line_end_auto',      'line_end_wrap',    'Move cursor to the end of the real or display line' },
-  { 'start',              'start_of_file',    'Move cursor to the start of the buffer' },
-  { 'eof',                'end_of_file',     'Move cursor to the end of the buffer' },
-  { 'page_up',            'page_up',          'Move cursor one page up' },
-  { 'page_down',          'page_down',        'Move cursor one page down' },
-  { 'para_down',          'para_down',        'Move cursor one paragraph down' },
-  { 'para_up',            'para_up',          'Move cursor one paragraph up' },
+  { 'down',               'down',           false, 'Move cursor down' },
+  { 'up',                 'up',             false, 'Move cursor up' },
+  { 'left',               'backward',       false, 'Move cursor left' },
+  { 'right',              'forward',        false, 'Move cursor right' },
+  { 'word_left',          nil,              false, 'Move cursor one word left' },
+  { 'word_left_end',      nil,              false, 'Move cursor left, to the end of the previous word' },
+  { 'word_right',         nil,              false, 'Move cursor one word right' },
+  { 'word_right_end',     nil,              false, 'Move cursor right, to the end of the word' },
+  { 'home',               'start_of_line',  false, 'Move cursor to the first column' },
+  { 'home_indent',        nil,              false, 'Move cursor to the first non-blank column' },
+  { 'home_indent_auto',   nil,              false, 'Move cursor the first column or the first non-blank column' },
+  { 'line_end',           'end_of_line',    false, 'Move cursor to the end of line' },
+  { 'start',              'start_of_file',  true,  'Move cursor to the start of the buffer' },
+  { 'eof',                'end_of_file',    true,  'Move cursor to the end of the buffer' },
+  { 'page_up',            'page_up',        false, 'Move cursor one page up' },
+  { 'page_down',          'page_down',      false, 'Move cursor one page down' },
+  { 'para_down',          nil,              false, 'Move cursor one paragraph down' },
+  { 'para_up',            nil,              false, 'Move cursor one paragraph up' },
 }
 
 for cmd in *commands
-  name, key_cmd, description = cmd[1], cmd[2], cmd[3]
+  {name, key_cmd, drop_crumb, description} = cmd
   f = aullar.Cursor[key_cmd]
 
-  unless Cursor.__base[name]
+  if key_cmd
     Cursor.__base[name] = (extend_selection) =>
       opts = extend_selection and {extend: true} or {}
+      if drop_crumb
+        breadcrumbs.drop!
       f @cursor, opts
 
   cmd_name = name\gsub '_', '-'

--- a/lib/howl/ui/searcher.moon
+++ b/lib/howl/ui/searcher.moon
@@ -104,7 +104,11 @@ class Searcher
       @backward_to @last_search, @last_type, false
 
   commit: =>
-    breadcrumbs.drop buffer: @buffer, pos: @start_pos
+    breadcrumbs.drop {
+      buffer: @buffer,
+      pos: @start_pos,
+      line_at_top: @start_line_at_top
+    }
     @buffer = nil
     @start_pos = nil
     @active = false
@@ -195,6 +199,7 @@ class Searcher
 
   _init: =>
     @start_pos = @editor.cursor.pos
+    @start_line_at_top = @editor.line_at_top
     @buffer = @editor.buffer
     @active = true
 

--- a/lib/howl/ui/searcher.moon
+++ b/lib/howl/ui/searcher.moon
@@ -1,8 +1,8 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-import config from howl
-import highlight from howl.ui
+{:breadcrumbs, :config} = howl
+{:highlight} = howl.ui
 
 highlight.define_default 'search', {
   type: highlight.ROUNDED_RECTANGLE,
@@ -104,6 +104,7 @@ class Searcher
       @backward_to @last_search, @last_type, false
 
   commit: =>
+    breadcrumbs.drop buffer: @buffer, pos: @start_pos
     @buffer = nil
     @start_pos = nil
     @active = false

--- a/site/source/doc/api/breadcrumbs.md
+++ b/site/source/doc/api/breadcrumbs.md
@@ -1,0 +1,98 @@
+---
+title: howl.breadcrumbs
+---
+
+# howl.breadcrumbs
+
+## Overview
+
+The breadcrumbs module keeps track of previously visited locations within Howl,
+and provides functions for remembering a specific location as well as for
+navigating forward and backward in the breadcrumb trail.
+
+### Structure of a breadcrumb
+
+Each crumb describes a previously visited location, and has the following
+fields:
+
+- `pos`: The position in the buffer or file.
+
+- `file` _(optional)_: The file associated with the location. This is not always
+present, as not all buffers have an associated file.
+
+- `buffer_marker` _(optional)_: A table providing information about a buffer
+location. This contains two fields:
+  - `buffer`: A reference to the buffer
+  - `name`: The name of a marker used for tracking the location
+
+As can be seen above, a crumb has a file reference, or a buffer reference via
+the `buffer_marker` field, or both at the same time. In the case where a marker
+is available that should be used for determining the correct position, as `pos`
+could become stale due to subsequent edits.
+
+---
+
+_Related_:
+
+- The `navigate-back` and `navigate-forward` commands can be used in bindings or
+from the command line to navigate the crumbs.
+
+## Properties
+
+### location
+
+The current location in the trail. As the user edits this will typically point
+to an uninitialized crumb, as it points to the position that will be next used
+for storing a crumb using [drop](#drop).
+
+### next
+
+The next crumb in the trail, if any. This will be non-nil only if the user has
+navigated back in the breadcrumb trail.
+
+### previous
+
+The previous crumb in the trail, if any, or `nil`.
+
+### trail
+
+The table of breadcrumbs.
+
+## Functions
+
+### clear ()
+
+Clears all current breadcrumbs. After this [location] would be 1, and
+[trail] would have a size of 0.
+
+### drop (opts)
+
+Inserts a crumb at the current [location] based on on the value in `opts`, if
+provided, or otherwise on the current edit location. `opts` can contain the
+following fields:
+
+- `buffer`: A reference to a [Buffer] for the crumb.
+
+- `file`: A reference to a [File] for the crumb. If this isn't provided, but
+`buffer` is, then this is deduced from the buffer if possible.
+
+- `pos`: The position of the crumb.
+
+If `opts` is provided, then `pos` must be present, and at least one of `buffer`
+and `file`. If `opts` is `nil` then a breadcrumb based on the current editing
+location.
+
+### go_back ()
+
+This moves backwards in the breadcrumb trail, if possible. Note that as part of
+moving backwards, a new crumb is first inserted at the current location.
+
+### go_forward ()
+
+This moves forward in the breadcrumb trail, if possible. Note that as part of
+moving forward, a new crumb is first inserted at the current location.
+
+[location]: #location
+[trail]: #trail
+[File]: io/file.html
+[Buffer]: buffer.html

--- a/site/source/doc/api/io/file.md
+++ b/site/source/doc/api/io/file.md
@@ -2,7 +2,7 @@
 title: howl.io.File
 ---
 
-# howl.ui.File
+# howl.io.File
 
 ## Overview
 

--- a/site/source/doc/index.haml
+++ b/site/source/doc/index.haml
@@ -25,7 +25,7 @@ title: Howl Documentation (master branch)
     = hdr_link 1, 'Getting started', 'manual/getting-started.html'
     = hdr_link 2, 'Configuring Howl', 'manual/configuration.html'
     = hdr_link 3, 'Using Howl completions', 'manual/completions.html'
-    = hdr_link 4, 'Working with files', 'manual/files.html'
+    = hdr_link 4, 'Working with files & buffers', 'manual/files.html'
     = hdr_link 5, 'Editing', 'manual/editing.html'
     = hdr_link 6, 'Using multiple views', 'manual/views.html'
     = hdr_link 7, 'Running external commands', 'manual/running_commands.html'

--- a/site/source/doc/manual/files.md
+++ b/site/source/doc/manual/files.md
@@ -2,7 +2,7 @@
 title: Working with files
 ---
 
-# Working with files
+# Working with files & buffers
 
 ## Opening files
 
@@ -74,11 +74,27 @@ command (bound to `ctrl_shift_s` in the default keymap). There's also a related
 command, `save-and-quit`, that allows you to save any modified buffers and exit
 Howl in one go.
 
-## Switching between open buffers
+## Navigating buffers
 
 While Howl provides the ability to view more than one buffer at a time by
 supporting multiple open views, you'll likely have more buffers open than you
-can fit on your screen. In order to switch to another buffer, you can use the
+can fit on your screen, and need ways of viewing different buffers.
+
+### Navigating back and forth
+
+As you open buffers, perform edits and move around, Howl tries to keep track of
+your previous locations. This can be used to quickly move back and forth in your
+editing history, by using the `navigate-back` and `navigate-forward` commands
+(the commands are bound to `ctrl_<` and `ctrl_>` by default).
+
+Note that the navigation is very useful not only as a tool for switching
+buffers, but for keeping track of previous locations even within the same file.
+This can be a useful time saver, as it's quite common to jump around alot in the
+same file as you search or jump to definitions, etc.
+
+### Switching between open buffers
+
+In order to switch to another buffer of your chosing, you can use the
 `switch-buffer` command (bound to `ctrl_b` by default):
 
 ![switch-buffer](/images/screenshots/monokai/switch-buffer.png)
@@ -90,8 +106,8 @@ down the list.
 
 Another command that might prove useful to you is
 `switch-to-last-hidden-buffer`. This will switch to the most recently accessed
-buffer that is not currently showing in any view, and is thus useful for quickly
-switching between to related files in the same view.
+buffer that is not currently showing in any view, and can thus be useful for
+quickly switching between to related files in the same view.
 
 ## Creating new buffers / files
 

--- a/spec/breadcrumbs_spec.moon
+++ b/spec/breadcrumbs_spec.moon
@@ -1,0 +1,283 @@
+-- Copyright 2017 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+{:app, :Buffer, :breadcrumbs} = howl
+{:File} = howl.io
+{:Window} = howl.ui
+
+describe 'breadcrumbs', ->
+
+  buffer = (text) ->
+    with Buffer {}
+      .text = text
+
+  setup ->
+    app.window = Window!
+    app.editor = app\new_editor!
+
+  teardown ->
+    app.editor = nil
+    app.window\destroy!
+
+  before_each ->
+    app.editor.buffer = buffer ''
+
+  after_each ->
+    breadcrumbs.clear!
+
+  describe 'drop(opts)', ->
+
+    it 'accepts a file and a pos', ->
+      file = File('/tmp/foo')
+      breadcrumbs.drop :file, pos: 3
+      assert.same {:file, pos: 3}, breadcrumbs.previous
+
+    it 'accepts a file path and a pos', ->
+      file = '/tmp/foo'
+      breadcrumbs.drop :file, pos: 3
+      assert.same {file: File(file), pos: 3}, breadcrumbs.previous
+
+    it 'accepts a buffer and a pos', ->
+      file = File('/tmp/foo')
+      file.contents = '123456789\nabcdefgh'
+      b = buffer ''
+      b.file = file
+      breadcrumbs.drop buffer: b, pos: 3
+      assert.equals b.file, breadcrumbs.previous.file
+      assert.equals 3, breadcrumbs.previous.pos
+      assert.not_nil breadcrumbs.previous.buffer_marker
+
+    context 'when a buffer is present', ->
+      it 'sets a marker in the buffer pointing to the crumb', ->
+        b = buffer '123456789\nabcdefgh'
+        breadcrumbs.drop buffer: b, pos: 3
+        assert.equals 3, breadcrumbs.previous.pos
+        assert.not_nil breadcrumbs.previous.buffer_marker
+
+        m = breadcrumbs.previous.buffer_marker
+        marker_buffer = m.buffer_holder.buffer
+        markers = marker_buffer.markers\find name: m.name
+        assert.equals 1, #markers
+        assert.equals 3, markers[1].start_offset
+        assert.equals 3, markers[1].end_offset
+
+    context 'when opts is missing', ->
+      it 'adds a crumb for the current buffer and position', ->
+        File.with_tmpfile (file) ->
+          file.contents = '1234\n6789'
+          app.editor.buffer.file = file
+          app.editor.cursor.pos = 7
+          breadcrumbs.drop!
+          crumb = breadcrumbs.previous
+          assert.equals 7, crumb.pos
+          assert.equals app.editor.buffer, crumb.buffer_marker.buffer_holder.buffer
+          assert.equals file, crumb.file
+
+    it 'avoids adding duplicate crumbs', ->
+      b = buffer '123456789'
+      breadcrumbs.drop buffer: b, pos: 3
+      breadcrumbs.drop buffer: b, pos: 3
+      assert.equals 1, #breadcrumbs.trail
+      markers = b.markers\find {}
+      assert.equals 1, #markers
+
+    context 'when forward crumbs exists', ->
+      it 'invalidates all such crumbs and buffer markers', ->
+        b = buffer '123456789\nabcdefgh'
+        breadcrumbs.drop buffer: b, pos: 3
+        breadcrumbs.drop buffer: b, pos: 6
+        breadcrumbs.drop buffer: b, pos: 9
+        breadcrumbs.go_back!
+        breadcrumbs.go_back!
+        assert.is_not_nil breadcrumbs.trail[2]
+        assert.is_not_nil breadcrumbs.trail[3]
+        breadcrumbs.drop buffer: b, pos: 4
+        assert.equals 4, breadcrumbs.trail[2].pos
+        assert.is_nil breadcrumbs.trail[3]
+        markers = [m.start_offset for m in *b.markers\find({})]
+        table.sort markers
+        assert.same { 3, 4 }, markers
+
+  describe 'clear', ->
+    it 'invalidates any existing crumbs (buffer markers and crumbs)', ->
+      b = buffer '123456789\nabcdefgh'
+      breadcrumbs.drop buffer: b, pos: 3
+      crumb = breadcrumbs.previous
+      breadcrumbs.clear!
+
+      assert.equals 1, breadcrumbs.location
+      assert.same {}, b.markers\find name: crumb.buffer_marker.name
+      assert.is_nil breadcrumbs.trail[1]
+
+  describe 'go_back', ->
+    context 'with a buffer and pos available', ->
+      it 'opens the buffer and set the current position', ->
+        b = buffer '123456789\nabcdefgh'
+        breadcrumbs.drop buffer: b, pos: 3
+        breadcrumbs.go_back!
+        assert.equals 3, app.editor.cursor.pos
+        assert.equals b, app.editor.buffer
+        assert.equals 1, breadcrumbs.location
+
+    context 'with a file and pos available', ->
+      it 'opens the file and sets the current position', ->
+        File.with_tmpfile (file) ->
+          file.contents = '123456789\nabcdefgh'
+          breadcrumbs.drop file: file, pos: 3
+          breadcrumbs.go_back!
+          assert.equals 3, app.editor.cursor.pos
+          assert.equals file, app.editor.buffer.file
+
+    context 'when the buffer has been collected', ->
+      it 'falls back to the file when available', ->
+        File.with_tmpfile (file) ->
+          file.contents = '1234\n6789'
+          b = buffer ''
+          b.file = file
+          breadcrumbs.drop file: file, buffer: b, pos: 3
+          b = nil
+          collectgarbage!
+          breadcrumbs.go_back!
+          assert.equals 3, app.editor.cursor.pos
+          assert.equals file, app.editor.buffer.file
+
+      it 'moves to the crumb before if present', ->
+        b1 = buffer 'buffer1'
+        breadcrumbs.drop buffer: b1, pos: 3
+
+        b2 = buffer 'buffer2'
+        breadcrumbs.drop buffer: b2, pos: 5
+
+        b2 = nil
+        collectgarbage!
+
+        breadcrumbs.go_back!
+        assert.equals 3, app.editor.cursor.pos
+        assert.equals b1, app.editor.buffer
+        assert.equals 1, breadcrumbs.location
+
+    it 'inserts a crumb if needed before going back', ->
+        b = buffer '123456789'
+        app.editor.buffer = b
+        app.editor.cursor.pos = 2
+        breadcrumbs.drop buffer: b, pos: 3
+        breadcrumbs.drop buffer: b, pos: 5
+        app.editor.cursor.pos = 7
+        breadcrumbs.go_back!
+        assert.equals 5, app.editor.cursor.pos -- at pos 5
+        assert.equals 2, breadcrumbs.location -- at breadcrumbs location 2
+        assert.equals 3, #breadcrumbs.trail -- with two forward crumbs
+        assert.equals 5, breadcrumbs.trail[2].pos -- the old one
+        assert.equals 7, breadcrumbs.trail[3].pos -- and the newly inserted
+
+        breadcrumbs.go_back!
+        assert.equals 3, app.editor.cursor.pos -- at pos 3
+        assert.equals 1, breadcrumbs.location -- at breadcrumbs location 1
+        -- we shouldn't have any added crumb added for this case
+        assert.equals 3, #breadcrumbs.trail -- only three forward crumbs
+        assert.same {3, 5, 7}, [c.pos for c in *breadcrumbs.trail]
+
+  describe 'go_forward', ->
+    context 'with a buffer and pos available', ->
+      it 'opens the buffer and set the current position', ->
+        b = buffer '123456789\nabcdefgh'
+        breadcrumbs.drop buffer: b, pos: 3
+        breadcrumbs.drop buffer: b, pos: 7
+        breadcrumbs.go_back!
+        breadcrumbs.go_back!
+        breadcrumbs.go_forward!
+        assert.equals 7, app.editor.cursor.pos
+        assert.equals b, app.editor.buffer
+
+    context 'with a file and pos available', ->
+      it 'opens the file and sets the current position', ->
+        File.with_tmpfile (file) ->
+          file.contents = '123456789\nabcdefgh'
+          breadcrumbs.drop file: file, pos: 3
+          breadcrumbs.drop file: file, pos: 7
+          breadcrumbs.go_back!
+          breadcrumbs.go_back!
+          breadcrumbs.go_forward!
+          assert.equals 7, app.editor.cursor.pos
+          assert.equals file, app.editor.buffer.file
+
+    context 'when the buffer has been collected', ->
+      it 'falls back to the file when available', ->
+        File.with_tmpfile (file) ->
+          file.contents = '1234\n6789'
+          b = buffer ''
+          b.file = file
+          breadcrumbs.drop file: file, buffer: b, pos: 3
+          breadcrumbs.drop file: file, buffer: b, pos: 7
+          b = nil
+          breadcrumbs.go_back!
+          breadcrumbs.go_back!
+          collectgarbage!
+          breadcrumbs.go_forward!
+          assert.equals 7, app.editor.cursor.pos
+          assert.equals file, app.editor.buffer.file
+
+      it 'moves to the crumb after if present', ->
+        b1 = buffer 'buffer1'
+        breadcrumbs.drop buffer: b1, pos: 3
+        breadcrumbs.drop buffer: b1, pos: 4
+
+        b2 = buffer 'buffer2'
+        breadcrumbs.drop buffer: b2, pos: 5
+
+        breadcrumbs.go_back!
+        breadcrumbs.go_back!
+
+        b1 = nil
+        collectgarbage!
+        breadcrumbs.go_forward!
+
+        assert.equals 5, app.editor.cursor.pos
+        assert.equals b2, app.editor.buffer
+
+    it 'inserts a crumb if needed before going forward', ->
+        b = buffer '123456789'
+        app.editor.buffer = b
+        breadcrumbs.drop buffer: b, pos: 3
+        breadcrumbs.drop buffer: b, pos: 5
+        breadcrumbs.drop buffer: b, pos: 7
+        app.editor.cursor.pos = 7
+        breadcrumbs.go_back!
+        breadcrumbs.go_back!
+        breadcrumbs.go_back!
+
+        -- we start out with the three crumbs above, at pos 3
+        assert.equals 3, app.editor.cursor.pos
+        assert.equals 3, #breadcrumbs.trail -- with three forward crumbs
+        assert.equals 1, breadcrumbs.location -- at breadcrumbs location 1
+
+        -- -- we'll move the cursor some and then go forward
+        app.editor.cursor.pos = 4
+        breadcrumbs.go_forward!
+        assert.equals 5, app.editor.cursor.pos -- at pos 5
+
+        -- -- this should have inserted a new crumb at the interim location
+        assert.equals 4, #breadcrumbs.trail -- with two forward crumbs
+        assert.equals 3, breadcrumbs.location -- with location thus = 3
+        assert.equals 3, breadcrumbs.trail[1].pos -- old back crumb
+        assert.equals 4, breadcrumbs.trail[2].pos -- newly inserted
+        assert.equals 5, breadcrumbs.trail[3].pos -- old forward crumb
+        assert.equals 7, breadcrumbs.trail[4].pos -- old forward crumb
+
+        -- -- forward again, without interim movement
+        breadcrumbs.go_forward!
+        assert.equals 7, app.editor.cursor.pos -- at pos 5
+
+        -- -- this should not have introduced any new crumb
+        assert.equals 4, #breadcrumbs.trail
+        assert.equals 4, breadcrumbs.location
+
+  it 'memory management', ->
+    it 'keeps weak references to buffers', ->
+      holder = setmetatable {
+        buffer: buffer '123456789\nabcdefgh'
+      }, __mode: 'v'
+
+      breadcrumbs.drop buffer: holder.buffer, pos: 3
+      collectgarbage!
+      assert.is_nil holder.buffer

--- a/spec/breadcrumbs_spec.moon
+++ b/spec/breadcrumbs_spec.moon
@@ -56,7 +56,7 @@ describe 'breadcrumbs', ->
         assert.not_nil breadcrumbs.previous.buffer_marker
 
         m = breadcrumbs.previous.buffer_marker
-        marker_buffer = m.buffer_holder.buffer
+        marker_buffer = m.buffer
         markers = marker_buffer.markers\find name: m.name
         assert.equals 1, #markers
         assert.equals 3, markers[1].start_offset
@@ -71,7 +71,7 @@ describe 'breadcrumbs', ->
           breadcrumbs.drop!
           crumb = breadcrumbs.previous
           assert.equals 7, crumb.pos
-          assert.equals app.editor.buffer, crumb.buffer_marker.buffer_holder.buffer
+          assert.equals app.editor.buffer, crumb.buffer_marker.buffer
           assert.equals file, crumb.file
 
     it 'avoids adding duplicate crumbs', ->

--- a/spec/breadcrumbs_spec.moon
+++ b/spec/breadcrumbs_spec.moon
@@ -154,6 +154,13 @@ describe 'breadcrumbs', ->
         assert.equals b, app.editor.buffer
         assert.equals 1, breadcrumbs.location
 
+      it 'uses a buffer marker for positioning to account for updates', ->
+        b = buffer '123456789'
+        breadcrumbs.drop buffer: b, pos: 6
+        b\insert 'xx', 2
+        breadcrumbs.go_back!
+        assert.equals 8, app.editor.cursor.pos
+
     context 'with a file and pos available', ->
       it 'opens the file and sets the current position', ->
         File.with_tmpfile (file) ->
@@ -223,6 +230,16 @@ describe 'breadcrumbs', ->
         breadcrumbs.go_forward!
         assert.equals 7, app.editor.cursor.pos
         assert.equals b, app.editor.buffer
+
+      it 'uses a buffer marker for positioning to account for updates', ->
+        b = buffer '123456789'
+        breadcrumbs.drop buffer: b, pos: 1
+        breadcrumbs.drop buffer: b, pos: 6
+        breadcrumbs.go_back!
+        breadcrumbs.go_back!
+        b\insert 'xx', 2
+        breadcrumbs.go_forward!
+        assert.equals 8, app.editor.cursor.pos
 
     context 'with a file and pos available', ->
       it 'opens the file and sets the current position', ->

--- a/spec/breadcrumbs_spec.moon
+++ b/spec/breadcrumbs_spec.moon
@@ -82,6 +82,15 @@ describe 'breadcrumbs', ->
       markers = b.markers\find {}
       assert.equals 1, #markers
 
+    it 'reduces unnecessary loops', ->
+      b = buffer '123456789'
+      breadcrumbs.drop buffer: b, pos: 3
+      breadcrumbs.drop buffer: b, pos: 6
+      breadcrumbs.drop buffer: b, pos: 3
+      breadcrumbs.drop buffer: b, pos: 6
+      assert.equals 2, #breadcrumbs.trail
+      assert.equals 3, breadcrumbs.location
+
     context 'when forward crumbs exists', ->
       it 'invalidates all such crumbs and buffer markers', ->
         b = buffer '123456789\nabcdefgh'
@@ -320,7 +329,6 @@ describe 'breadcrumbs', ->
         breadcrumbs.drop buffer: b2, pos: 5
         breadcrumbs.drop buffer: b2, pos: 7
         assert.equals 4, breadcrumbs.location
-        print "close_buffer b2"
         app\close_buffer b2
         assert.equals 1, breadcrumbs.location
 

--- a/spec/breadcrumbs_spec.moon
+++ b/spec/breadcrumbs_spec.moon
@@ -1,7 +1,7 @@
 -- Copyright 2017 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-{:app, :Buffer, :breadcrumbs} = howl
+{:app, :Buffer, :breadcrumbs, :config} = howl
 {:File} = howl.io
 {:Window} = howl.ui
 
@@ -112,6 +112,26 @@ describe 'breadcrumbs', ->
         markers = [m.start_offset for m in *b.markers\find({})]
         table.sort markers
         assert.same { 3, 4 }, markers
+
+    context 'house cleaning according to breadcrumb_limit', ->
+      local old_limit
+
+      before_each ->
+        old_limit = config.breadcrumb_limit
+        config.breadcrumb_limit = 2
+
+      after_each ->
+        config.breadcrumb_limit = old_limit
+
+      it 'purges old crumbs according to breadcrumb_limit', ->
+        b = buffer '123456789\nabcdefgh'
+        breadcrumbs.drop buffer: b, pos: 1
+        breadcrumbs.drop buffer: b, pos: 2
+        breadcrumbs.drop buffer: b, pos: 3
+
+        assert.equals 2, #breadcrumbs.trail
+        assert.equals 3, breadcrumbs.location
+        assert.same {2, 3}, [c.pos for c in *breadcrumbs.trail]
 
   describe 'clear', ->
     it 'invalidates any existing crumbs (buffer markers and crumbs)', ->


### PR DESCRIPTION
This adds support for navigating back and forth in a list of previously visited locations (breadcrumbs). Two new commands, `navigate-back` and `navigate-forward` are added, bound to `ctrl_<` and `ctrl_>` respectively.

This allows one to quickly retrace one's step after switching buffers, or after jumping around in the current buffer via searches, buffer structure, etc.

