### PR TITLE
Add activity support

### DIFF
--- a/bundles/git/init.moon
+++ b/bundles/git/init.moon
@@ -4,7 +4,7 @@ find = (file) ->
   while file != nil
     git_dir = file\join('.git')
     if git_dir.exists
-      return bundle_load('git') file, git_dir
+      return bundle_load('git') file
     file = file.parent
   nil
 

--- a/lib/aullar/spec/cursor_spec.moon
+++ b/lib/aullar/spec/cursor_spec.moon
@@ -16,7 +16,7 @@ describe 'Cursor', ->
     window = Gtk.OffscreenWindow default_width: 800, default_height: 640
     window\add view\to_gobject!
     window\show_all!
-    pump_mainloop!
+    howl.app\pump_mainloop!
 
   describe '.style', ->
     it 'is "line" by default', ->

--- a/lib/aullar/spec/view_spec.moon
+++ b/lib/aullar/spec/view_spec.moon
@@ -18,7 +18,7 @@ describe 'View', ->
     window = Gtk.OffscreenWindow default_width: 800, default_height: 640
     window\add view\to_gobject!
     window\show_all!
-    pump_mainloop!
+    howl.app\pump_mainloop!
 
   context 'visible line orientation properties', ->
     local nr_lines_in_screen

--- a/lib/howl/activities.moon
+++ b/lib/howl/activities.moon
@@ -1,7 +1,7 @@
 -- Copyright 2017 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-{:timer} = howl
+{:config, :timer} = howl
 {:Activity} = howl.ui
 {:get_monotonic_time} = require 'ljglibs.glib'
 append = table.insert
@@ -95,7 +95,7 @@ run = (def, f) ->
     elseif ms_since_last_show < 400
       0.3
     else
-      0.7
+      config.activities_popup_delay / 1000
     timer_handle = timer.after_approximately interval, update
     return_to_focus = howl.app.window.focus
 

--- a/lib/howl/activities.moon
+++ b/lib/howl/activities.moon
@@ -1,0 +1,205 @@
+-- Copyright 2017 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+{:timer} = howl
+{:Activity} = howl.ui
+{:get_monotonic_time} = require 'ljglibs.glib'
+append = table.insert
+
+activities = {}
+timer_handle = nil
+return_to_focus = nil
+hooked = 0
+hook_count = 0
+last_visibility = 0
+
+cancel = (activity) ->
+  if activity.def.cancel
+    activity.widget.title.text ..= ' (Cancelling..)'
+    activity.widget.shortcuts.text = ''
+    activity.def.cancel!
+  else
+    activity.widget.text = 'This operation cannot be cancelled'
+
+new_widget = (activity) ->
+  def = activity.def
+
+  widget = Activity title: def.title, keymaps: {
+    {
+      ctrl_c: -> cancel activity
+    },
+    activity.def.keymap
+  }
+
+  howl.app.window\add_widget widget\to_gobject!
+
+  widget
+
+update = ->
+  return unless #activities > 0
+
+  timer_handle = timer.after 0.2, update
+
+  for i, activity in ipairs activities
+    focused = i == #activities
+
+    unless activity.widget
+      activity.widget = new_widget activity
+
+    def = activity.def
+    status = def.status!
+    widget = activity.widget
+    widget.text = status
+    activity.widget.keep_focus = focused
+
+    if focused
+      if def.cancel
+        widget.shortcuts.text = '(Ctrl-C to cancel)'
+    else
+      widget.shortcuts.text = ''
+
+  -- what should we show? we can use up to half of the window height
+  _, win_height = howl.app.window\get_size!
+  available_height = win_height / 2
+  used = 0
+
+  for i = #activities, 1, -1
+    activity = activities[i]
+    alloc_height = math.max 50, activity.widget\to_gobject!.allocated_height
+    used += alloc_height
+    visible = used < available_height
+    activity.widget.visible = visible
+
+yield = ->
+  howl.app\pump_mainloop!
+
+ui_update_hook = ->
+  hook_count += 1
+  return unless hook_count % 1000 == 0
+  yield!
+
+run = (def, f) ->
+  assert def.title, "Missing activity field 'title'"
+  assert def.status, "Missing activity field 'status'"
+  return f! unless howl.app.window
+
+  -- start = get_monotonic_time!
+  activity = :def
+  append activities, activity
+
+  ms_since_last_show = (get_monotonic_time!  - last_visibility) / 1000
+
+  unless timer_handle
+    interval = if ms_since_last_show < 200
+      0.1
+    elseif ms_since_last_show < 400
+      0.3
+    else
+      0.7
+    timer_handle = timer.after_approximately interval, update
+    return_to_focus = howl.app.window.focus
+
+  if def.preempt and hooked == 0
+    debug.sethook ui_update_hook, 'c'
+    hooked += 1
+
+  rets = table.pack(pcall f)
+  activities = [a for a in *activities when a != activity]
+
+  if activity.widget
+    howl.app.window\remove_widget activity.widget\to_gobject!
+    last_visibility = get_monotonic_time!
+
+  if #activities == 0
+    timer.cancel timer_handle
+    timer_handle = nil
+    if return_to_focus
+      return_to_focus\grab_focus!
+
+    return_to_focus = nil
+
+  if def.preempt
+    hooked -= 1
+    if hooked == 0
+      debug.sethook!
+      hook_count = 0
+
+  -- end_t = get_monotonic_time!
+  -- print "end activity '#{def.title}' in #{(end_t - start) / 1000 / 1000}"
+
+  status = rets[1]
+
+  if not status
+    log.error "Activity #{def.title} failed: '#{rets[2]}'"
+    nil
+  else
+    table.unpack rets, 2, rets.n
+
+run_process = (def, p) ->
+  interrupted = false
+  read = 0
+  output = {}
+  err_output = {}
+
+  process_status = def.status or ->
+    units = def.read_lines and 'lines' or 'bytes'
+    "$ #{p.command_line}.. (#{read} #{units} read)"
+    "$ #{p.command_line}.."
+
+  cancel_process = ->
+    if interrupted
+      p\send_signal 'KILL'
+    else
+      p\send_signal 'INT'
+      interrupted = true
+
+  p_def = {
+    title: def.title
+    status: process_status
+    cancel: cancel_process
+  }
+
+  on_output = (out) ->
+    return unless out
+    read += #out
+    if def.on_output
+      def.on_output out
+    else
+      if def.read_lines
+        append output, l for l in *out
+      else
+        output[#output + 1] = out
+
+  on_error = (out) ->
+    return unless out
+    if def.on_error
+      def.on_error out
+    else
+      if def.read_lines
+        append err_output, l for l in *out
+      else
+        err_output[#err_output + 1] = out
+
+  run p_def, ->
+    if def.read_lines
+      p\pump_lines on_output, on_error
+    else
+      p\pump on_output, on_error
+
+  unless def.read_lines
+    output = table.concat output
+    err_output = table.concat err_output
+
+  output, err_output
+
+howl.util.property_table {
+  nr:
+    get: -> #activities
+
+  nr_visible:
+    get: -> #[a for a in *activities when a.widget]
+
+  :run
+  :run_process
+  :yield
+}

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -8,6 +8,7 @@ import PropertyObject from howl.util.moon
 Gtk = require 'ljglibs.gtk'
 callbacks = require 'ljglibs.callbacks'
 {:get_monotonic_time} = require 'ljglibs.glib'
+{:C} = require('ffi')
 
 append = table.insert
 coro_create, coro_status = coroutine.create, coroutine.status
@@ -304,6 +305,13 @@ class Application extends PropertyObject
       }
 
     @settings\save_system 'session', session
+
+  pump_mainloop: (max_count = 100) =>
+    jit.off true, true
+    count = 0
+    ctx = C.g_main_context_default!
+    while count < max_count and C.g_main_context_iteration(ctx, false) != 0
+      count += 1
 
   _buffer_for_file: (file) =>
     for b in *@buffers

--- a/lib/howl/commands/edit_commands.moon
+++ b/lib/howl/commands/edit_commands.moon
@@ -1,8 +1,9 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-import app, Buffer, command, interact, mode from howl
-import BufferPopup from howl.ui
+{:activities, :app, :Buffer, :command, :interact, :mode} = howl
+{:BufferPopup} = howl.ui
+{:Process} = howl.io
 
 command.register
   name: 'buffer-search-forward',
@@ -162,14 +163,13 @@ command.register
     return chunk, working_directory, cmd
 
   handler: (chunk, working_directory, cmd) ->
-    stdout, _, process = howl.io.Process.execute cmd,
-      :working_directory,
-      stdin: chunk.text
+    process = Process.open_pipe cmd, :working_directory, stdin: chunk.text
+    out, err = activities.run_process {title: 'Running filter'}, process
     if process.successful
-      chunk.text = stdout
+      chunk.text = out
       log.info "Replaced with output of '#{cmd}'"
     else
-      log.error "Failed to run #{cmd}"
+      log.error "Failed to run #{cmd}: #{err or 'Unknown'}"
 
 command.register
   name: 'editor-move-lines-up'

--- a/lib/howl/inspect.moon
+++ b/lib/howl/inspect.moon
@@ -1,7 +1,7 @@
 -- Copyright 2016 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-{:app, :bindings, :command, :config, :inspection, :interact, :log, :signal, :timer} = howl
+{:activities, :app, :bindings, :command, :config, :inspection, :interact, :log, :signal, :timer} = howl
 {:ActionBuffer, :BufferPopup, :highlight} = howl.ui
 {:Process, :process_output} = howl.io
 {:pcall} = _G
@@ -189,7 +189,7 @@ inspect = (buffer, opts = {}) ->
 
   -- finish off processes
   for p in *processes
-    out, err = p.process\pump!
+    out, err = activities.run_process {title: 'Reading inspection results'}, p.process
     buf = out
     buf ..= "\n#{err}" unless err.is_blank
     inspections = parse_errors buf, p.inspector

--- a/lib/howl/interactions/file_selection.moon
+++ b/lib/howl/interactions/file_selection.moon
@@ -61,11 +61,11 @@ class FileSelector
     @directory = directory
     local matcher
     if @show_subtree
-      items, timed_out = self.subtree_reader(directory, timeout: 3)
+      items, timed_out = self.subtree_reader(directory)
       matcher = subtree_matcher items, directory
       if timed_out
         @command_line.title = (@opts.title or 'File') .. ' (recursive, truncated)'
-        log.warn 'Too many files in recursive listing - truncated.'
+        log.warn 'File scan interrupted - truncated listing.'
       else
         @command_line.title = (@opts.title or 'File') .. ' (recursive)'
     else

--- a/lib/howl/io/file.moon
+++ b/lib/howl/io/file.moon
@@ -206,8 +206,13 @@ class File extends PropertyObject
     if options.timeout
       deadline = glib.get_monotonic_time! + (1000 * 1000 * options.timeout)
 
+    on_enter = options.on_enter
+
     while dir
       if deadline and glib.get_monotonic_time! >= deadline
+        return files, true
+
+      if on_enter and 'break' == on_enter(dir, files)
         return files, true
 
       ok, children = pcall -> dir.children

--- a/lib/howl/timer.moon
+++ b/lib/howl/timer.moon
@@ -70,7 +70,7 @@ every_tick = ->
     co = coroutine.create (...) -> h.handler ...
     status, ret = coroutine.resume co, unpack(h.args)
     unless status
-      _G.log.error "Error invoking tick handler: '#{ret}'"
+      _G.log.error "Error invoking after_approximately handler: '#{ret}'"
 
   true
 

--- a/lib/howl/ui/activity.moon
+++ b/lib/howl/ui/activity.moon
@@ -1,0 +1,76 @@
+-- Copyright 2017 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+Gtk = require 'ljglibs.gtk'
+{:bindings} = howl
+{:ContentBox, :IndicatorBar, :TextWidget} = howl.ui
+{:PropertyObject} = howl.util.moon
+
+class Activity extends PropertyObject
+  new: (@opts = {}) =>
+    @_keep_focus = false
+
+    @text_widget = TextWidget {
+      on_keypress: self\_on_keypress
+      on_focus_lost: self\_on_focus_lost
+    }
+
+    with @text_widget
+      .view.config.view_show_cursor = false
+
+    if opts.text
+      @_text = opts.text
+      @text_widget\info @_text
+
+    @header = IndicatorBar 'header'
+    @spinner = @header\add 'left', 'spinner', Gtk.Spinner!
+    @spinner\start!
+    @title = @header\add 'left', 'title'
+    if @opts.title
+      @title.text = @opts.title
+
+    @shortcuts = @header\add 'left', 'shortcuts'
+
+    @box = ContentBox 'activity', @text_widget\to_gobject!, {
+      header: @header\to_gobject!
+    }
+    with @text_widget.view\to_gobject!
+      .margin_left = 10
+      .margin_top = 5
+      .margin_bottom = 5
+
+    super!
+
+  to_gobject: => @box\to_gobject!
+
+  @property keep_focus:
+    get: => @_keep_focus
+    set: (v) =>
+      @_keep_focus = v
+      if v
+        @text_widget\focus!
+
+  @property text:
+    get: => @text_widget.text
+    set: (t) =>
+      @text_widget.text = ''
+      @text_widget.buffer\append t, 'info'
+      @text_widget.visible_rows = #@text_widget.buffer.lines
+
+  @property visible:
+    get: => @to_gobject!.visible
+    set: (v) =>
+      if v
+        @to_gobject!\show_all!
+      else
+        @to_gobject!.visible = false
+
+  _on_keypress: (event) =>
+    if @opts.keymaps
+      bindings.dispatch event, nil, @opts.keymaps, @
+
+    true
+
+  _on_focus_lost: =>
+    if @_keep_focus
+      @text_widget\focus!

--- a/lib/howl/ui/command_line.moon
+++ b/lib/howl/ui/command_line.moon
@@ -296,7 +296,8 @@ class CommandLine extends PropertyObject
         @on_update!
       on_focus_lost: ->
         @close_popup!
-        @command_widget\focus! if @showing
+        if @showing and howl.activities.nr_visible == 0
+          @command_widget\focus!
 
     @command_widget.visible_rows = 1
     @box\pack_end @command_widget\to_gobject!, false, 0, 0

--- a/lib/howl/ui/window.moon
+++ b/lib/howl/ui/window.moon
@@ -6,9 +6,9 @@ Gtk = require 'ljglibs.gtk'
 ffi = require 'ffi'
 gobject_signal = require 'ljglibs.gobject.signal'
 Background = require 'ljglibs.aux.background'
-import PropertyObject from howl.util.moon
-{:CommandLine, :Status, :theme} = howl.ui
-import signal from howl
+{:PropertyObject} = howl.util.moon
+{:Activity, :CommandLine, :Status, :theme} = howl.ui
+{:signal} = howl
 
 append = table.insert
 ffi_cast = ffi.cast
@@ -34,9 +34,12 @@ class Window extends PropertyObject
       column_homogeneous: true
       row_homogeneous: true
 
+    @activity = Activity!
+    @widgets = Gtk.Box Gtk.ORIENTATION_VERTICAL
     @box = Gtk.Box Gtk.ORIENTATION_VERTICAL, {
       { expand: true, @grid },
       @command_line\to_gobject!
+      @widgets,
       @status\to_gobject!,
     }
     @bg_box = Gtk.Box Gtk.ORIENTATION_VERTICAL, {
@@ -112,6 +115,12 @@ class Window extends PropertyObject
         @win\maximize!
       elseif not state and @maximized
         @win\unmaximize!
+
+  add_widget: (widget) =>
+    @widgets\pack_end widget, true, true, 0
+
+  remove_widget: (widget) =>
+    @widgets\remove widget
 
   siblings: (view, wraparound = false) =>
     current = @get_view to_gobject(view or @focus_child)

--- a/lib/howl/variables/core_variables.moon
+++ b/lib/howl/variables/core_variables.moon
@@ -67,5 +67,12 @@ config.define {
   validate: (v) ->
     return false unless type(v) == 'number'
     v >= 500
+}
 
+config.define {
+  name: 'activities_popup_delay'
+  description: 'The delay before a popup is displayed for a running activity (ms)'
+  type_of: 'number'
+  default: 700
+  scope: 'global'
 }

--- a/lib/ljglibs/cdefs/gdk.moon
+++ b/lib/ljglibs/cdefs/gdk.moon
@@ -270,6 +270,8 @@ ffi.cdef [[
                                 gint *x,
                                 gint *y);
 
+  gint gdk_window_get_scale_factor (GdkWindow *window);
+
   GdkEventMask gdk_window_get_events (GdkWindow *window);
   void gdk_window_set_events (GdkWindow *window, GdkEventMask event_mask);
 

--- a/lib/ljglibs/gdk/window.moon
+++ b/lib/ljglibs/gdk/window.moon
@@ -40,6 +40,7 @@ core.define 'GdkWindow', {
     }
 
     display: => ref_ptr C.gdk_window_get_display @
+    scale_factor: => tonumber C.gdk_window_get_scale_factor @
   }
 
   get_position: =>

--- a/lib/ljglibs/gtk/widget.moon
+++ b/lib/ljglibs/gtk/widget.moon
@@ -61,8 +61,6 @@ core.define 'GtkWidget < GObject', {
 
     -- Added properties
     in_destruction: => C.gtk_widget_in_destruction(@) != 0
-
-    -- added properties
     screen: => ref_ptr C.gtk_widget_get_screen @
     style_context: => ref_ptr C.gtk_widget_get_style_context @
     pango_context: => C.gtk_widget_get_pango_context @

--- a/lint_config.moon
+++ b/lint_config.moon
@@ -193,7 +193,6 @@
       'howl_main_ctx'
       'it',
       'moon',
-      'pump_mainloop',
       'set_howl_loop',
       'settimeout',
       'setup',

--- a/site/source/doc/api/activities.md
+++ b/site/source/doc/api/activities.md
@@ -1,0 +1,148 @@
+---
+title: howl.activities
+---
+
+# howl.activities
+
+The activities module keeps track of long running operations with Howl, that
+either is or should appear to be blocking in nature.
+
+While most operations within Howl are fast enough that any blocking is at most a
+nuisance, some things can be slow enough that it's not reasonable to perform
+them in a blocking manner without any feedback to the user (apart from an
+unresponsive editor). Alternatively, some operations can be slow but
+non-blocking (e.g. using some of Howl's asynchronous APIs), and could by mistake
+allow the user to work before the result of a needed operation is ready.
+
+Using the `run` or `run_process` functions available from the activities module,
+code can run designated blocks of code as activities. An activity is in its most
+basic form simply a named part of code, with an associated dynamic status, whose
+execution is supervised by the activities module. If the execution of the
+activity has not completed within a specific interval the user is alerted to the
+ongoing operation via a popup at the bottom at the current window, providing
+insight into what is being done and optionally any progress.
+
+_A note about Howl's execution model_:
+
+Howl is a single threaded application. It still allows multiple concurrent
+operations, such as running processes, etc., via the use of asynchronous IO.
+This is not something that is always readily apparant since Howl's APIs hides
+this fact and provides the illusion of a blocking execution, but it's necessary
+to know that at most one trail of execution is taking place at any given time.
+With regards to activities the implication is that any activity that uses an API
+which ends up doing asynchronous IO works well out of the box with the
+activities module, as it's able to update the user interface properly. However,
+for other activities such as activities heavy in data manipulation or
+computation explicit action needs to be taken to ensure that the activities
+module can properly run. This can be done either by using the [yield] function,
+or as a last resort specifying the `preempt` flag to [run] or
+[run_process].
+
+## Properties
+
+### nr
+
+The number of currently running activities.
+
+### nr_visible
+
+The number of currently running activities with visible status windows.
+
+## Functions
+
+### run (options, f)
+
+Runs an activity function `f`, described by `options`.
+
+`options` can contain any of the following keys:
+
+- *title*: (required) The title of the activity.
+
+- *status*: (required) A status function. This will be invoked dynamically as
+necessary in order to get an updated status to show to the user.
+
+- *cancel*: (optional) Providing this function marks an activity as cancellable.
+If the user chooses to cancel the operation this function will be called. Note
+that the function might possibly be called more than once.
+
+- *keymap*: (optional) An extra keymap for the activity that will be accessible
+when the activity is being visibly displayed.
+
+- *preempt*: (optional) This is available as a last fallback resort for
+activities which would otherwise run uninterruptibly, and which can not for some
+reason be instrumented using [yield]. Avoid using this if at all possible since
+it has a very large impact on performance.
+
+#### Example use (Moonscript):
+
+```moon
+files_found = 0
+cancel = false
+
+activities.run {
+  title: "Scanning '#{directory}'"
+  status: -> "Reading files.. (#{files_found} files read)"
+  cancel: -> cancel = true
+}, ->
+  directory\find
+    on_enter: (dir, files) ->
+      files_found = #files
+      return 'break' if cancel
+```
+
+### run_process (options, f)
+
+Runs a process `p` as an activity, described by `options`. `options` can contain
+the keys `title`, `status` and `keymap`, which work the same way as for [run].
+Note however that `status` is optional when calling this function - if not
+provided a generic status function will be provided based on the running
+process.
+
+In addition, `options` can contain the following keys:
+
+- *on_output*: (optional) A handler function that process output as it becomes
+available. Depending on the `read_lines` flag this function will be invoked zero
+or more time with either a table of lines, or a string containing the output. If
+this is not specified the process' error output is returned as the first return
+value.
+
+- *on_error*: (optional) A handler function that process error output as it
+becomes available. Depending on the `read_lines` flag this function will be
+invoked zero or more time with either a table of lines, or a string containing
+the output. If this is not specified the process' error output is returned as
+the second return value.
+
+- *read_lines*: (optional) Specifies whether the process output should be
+returned or passed as tables of parsed lines or simply as text. Defaults to
+`false`.
+
+The default behaviour of this function is to return the process' output as its
+return values, as table of lines or as text, depending on whether the
+`read_lines` option was passed or not. Should any output handler be specified
+(`on_output` or `on_error`) the corresponding return value will be empty.
+
+### yield ()
+
+Some activities will unless checked run uninterrupted, not providing the
+activities module with any chance of kicking in. In these cases the offending
+code can be instrumented with `yield` calls at suitable intervals.
+
+#### Example use (Moonscript):
+
+```moon
+cancel = false
+activities.run {
+  title: "Juggernaut",
+  status: -> "I love iterating!",
+  cancel: -> cancel = true
+}, ->
+  entries = load_100k_entries!
+  return for i = 1, #entries
+    break if cancel
+    activities.yield! if i % 1000 == 0
+    map_entry entries[i]
+```
+
+[run]: #run
+[run_process]: #run_process
+[yield]: #yield

--- a/site/source/doc/api/application.md
+++ b/site/source/doc/api/application.md
@@ -108,6 +108,12 @@ active editor. Emits the `file-opened` signal if the file was opened
 successfully. If the file was successfully opened, returns the [Buffer] and the
 [Editor] holding the buffer. Otherwise `nil` is returned.
 
+### pump_mainloop(max_count = 100)
+
+Explicitly runs Howl's main loop, at most `max_count` number of iterations. The
+number of actual iterations might be lower than `max_count`, should there not
+exist any work to do.
+
 ### save_all ()
 
 Saves all modified buffers in one go.

--- a/site/source/doc/api/io/file.md
+++ b/site/source/doc/api/io/file.md
@@ -208,8 +208,11 @@ an error if unsuccesful.
 ### find (options = {})
 
 For a directory, returns all files within the directory or any sub directory of
-the directory. `options` allows for additional control of the operation, and can
-contain the following fields:
+the directory. In addition to the files, a boolean is returned indicated whether
+the result is partial or not (`true` indicating a partial result and `false` a
+complete result). The result will always be complete, unless one of the options
+causes a premature halt to the execution. `options` allows for additional
+control of the operation, and can contain the following fields:
 
 - `filter`: A callback that will recieve each file as its sole argument. To
 filter a file, i.e. exclude it from the results, the callback should return
@@ -217,6 +220,16 @@ true. The search is performed breadth first, so filtering a directory means that
 it won't be descended into at all.
 
 - `sort`: Causes the entries of all directories to be sorted before processing.
+
+- `timeout`: Provides a timeout in seconds for the find operation. If this is
+reached, execution is ended and a partial result is returned.
+
+- `on_enter`: If given, this function is invoked each time a new directory is
+entered (including the first one). The function is passed the directory to
+enter, as well as the found files so far. This function can also optionally
+cancel the execution, by return the special return value 'break'. If this is
+done, execution is ended and a partial result is returned.
+
 
 ### is_below (directory)
 

--- a/site/source/doc/api/timer.md
+++ b/site/source/doc/api/timer.md
@@ -7,7 +7,8 @@ title: howl.timer
 ## Overview
 
 The timer module provides support for "timers", that is having functions invoked
-at a later time. All callbacks are always invoked on the main GUI thread.
+at a later time. All callbacks are invoked on the main GUI thread, and acts as
+one-shot timers, meaning they will only fire once.
 
 _See also_:
 
@@ -31,7 +32,9 @@ to cancel the timer.
 
 Invokes `callback` after approximately `seconds` seconds, passing along any
 optional extra parameters passed to `after`. `seconds` can contain fractions,
-allowing you schedule callbacks at sub-second rates.
+allowing you schedule callbacks at sub-second rates. `after` functions as a
+convenience function which internally dispatches to either
+[after_approximately] or [after_exactly], depending on the value of seconds.
 
 Returns an opaque handle for the timer, which can be passed to [cancel] in order
 to cancel the timer.
@@ -46,12 +49,35 @@ callback = (text) ->
 timer.after 0.5, callback, 'Log me!'
 ```
 
+### after_approximately (seconds, callback, ...)
+
+Invokes `callback` after approximately `seconds` seconds, passing along any
+optional extra parameters passed to `after`. `seconds` can contain fractions,
+allowing you schedule callbacks at sub-second rates. However, compared to
+[after_exactly], callbacks registered with this function are dispatched using a
+low precision, shared timer. As this requires less resources you should use this
+(or [after]) over [after_exactly] unless you require precision in the sub 200 ms
+range. You should not however expect higher precision than that.
+
+Returns an opaque handle for the timer, which can be passed to [cancel] in order
+to cancel the timer.
+
+### after_exactly (seconds, callback, ...)
+
+Invokes `callback` after `seconds` seconds, passing along any optional extra
+parameters passed to `after`. `seconds` can contain fractions, allowing you
+schedule callbacks at sub-second rates. Callbacks registered with this function
+are dispatched using private high precision timers. As this requires more
+resources, it is preferable to use [after_approximately] (or [after]) if the
+requirements allow for the lower precision.
+
+Returns an opaque handle for the timer, which can be passed to [cancel] in order
+to cancel the timer.
+
 ### cancel (handle)
 
 Cancels the timer associated with `handle`. `handle` must be one the values
 returned from [asap](#asap), [after](#after) or [on_idle](#on_idle).
-
-[cancel]: #cancel
 
 ### on_idle (seconds, callback, ...)
 
@@ -61,3 +87,8 @@ Invokes `callback` after the application has been idle for approximately
 
 Returns an opaque handle for the timer, which can be passed to [cancel] in order
 to cancel the timer.
+
+[cancel]: #cancel
+[after]: #after
+[after_exactly]: #after_exactly
+[after_approximately]: #after_approximately

--- a/site/source/doc/api/ui/window.md
+++ b/site/source/doc/api/ui/window.md
@@ -13,8 +13,9 @@ examples of this.
 
 A window has, apart from the grid components described above, always two
 graphical elements associated with it; A [Status] instance used for displaying
-informational message to the user, and a [CommandLine] instance allowing for user
-input.
+informational message to the user, and a [CommandLine] instance allowing for
+user input. It can also optionally display arbitrary widgets at the bottom via
+the use of [push_widget].
 
 The currently focused window is accessible as
 [Application.window](../application.html#window).
@@ -83,6 +84,47 @@ reference to an [Editor]. Should you need to map a particular view to an
 
 ## Methods
 
+### add_view (view, placement = 'right_of', anchor = @focus_child)
+
+Adds `view` to the grid. If `view` is not a Gtk view, it's automatically cast
+using the view's `to_gobject`, if it's present. `placement` specifies where to
+place the view in the grid, relative to `anchor` which should be an existing
+view in the grid. Valid values for `placement` are:
+
+- `left_of`: Places the view left of `anchor`
+- `right_of`: Places the view right of `anchor`.
+- `above`: Places the view above `anchor`.
+- `below`:Places the view below `anchor`.
+
+### add_widget (widget)
+
+Adds the specified widget `widget` to the window's widget area (lower part).
+Call [remove_widget] to remove the widget later.
+
+### get_view (o)
+
+Gets the view information for the object `o`. The return value is a table with
+same fields as is documented in [views](#views). Returns `nil` if `o` is not in
+the window grid.
+
+### remember_focus ()
+
+Remember the currently focused view as the focussed view until the focus
+switches to another view in the grid. This means even when the focus switches to
+a view outside the grid, peroperties and methods that use the current view - for
+example, [`current_view`](#current_view) - will continue to use the remembered
+view.
+
+### remove_view (view = nil)
+
+Removes the specified `view`, or the currently focused view if not specified,
+from the grid.
+
+### remove_widget (widget)
+
+Removes the specified widget `widget` (which should have been previously added
+using [add_widget]) from the window's widget area.
+
 ### siblings (view, wraparound = false)
 
 Returns a a table of siblings for `view`, which should be a Gtk view. The
@@ -99,37 +141,8 @@ siblings will wrap around in a left-to-right, top-to-bottom order fashion.
 
 Returns the underlying Gtk window.
 
-### add_view (view, placement = 'right_of', anchor = @focus_child)
-
-Adds `view` to the grid. If `view` is not a Gtk view, it's automatically cast
-using the view's `to_gobject`, if it's present. `placement` specifies where to
-place the view in the grid, relative to `anchor` which should be an existing
-view in the grid. Valid values for `placement` are:
-
-- `left_of`: Places the view left of `anchor`
-- `right_of`: Places the view right of `anchor`.
-- `above`: Places the view above `anchor`.
-- `below`:Places the view below `anchor`.
-
-### remember_focus ()
-
-Remember the currently focussed view as the focussed view until the focus
-switches to another view in the grid. This means even when the focus switches to
-a view outside the grid, peroperties and methods that use the current view - for
-example, [`current_view`](#current_view) - will continue to use the remembered
-view.
-
-### remove_view (view = nil)
-
-Removes the specified `view`, or the currently focused view if not specified,
-from the grid.
-
-### get_view (o)
-
-Gets the view information for the object `o`. The return value is a table with
-same fields as is documented in [views](#views). Returns `nil` if `o` is not in
-the window grid.
-
 [CommandLine]: command_line.html
 [Editor]: editor.html
 [Status]: status.html
+[push_widget]: #push_widget
+[remove_widget]: #remove_widget

--- a/spec/io/file_spec.moon
+++ b/spec/io/file_spec.moon
@@ -352,6 +352,38 @@ describe 'File', ->
 
           assert.same { 'child1', 'sandwich.lua' }, [f.basename for f in *files]
 
+    context 'when the on_enter parameter is given', ->
+      it 'is called once for each directory with the dir and files so far', ->
+        with_populated_dir (dir) ->
+          dirs = {}
+          total_files = 0
+          dir\find on_enter: (enter_dir, files) ->
+            dirs[#dirs + 1] = enter_dir
+            total_files = files
+
+          assert.equal 3, #dirs
+          assert.equal 6, #total_files
+          table.sort dirs
+          assert.same {
+            dir,
+            dir\join('child1'),
+            dir\join('child1')\join('sub_dir'),
+          }, dirs
+
+      context 'and it returns "break"', ->
+        it 'causes an early return', ->
+          with_populated_dir (dir) ->
+            files, cancelled = dir\find on_enter: (enter_dir, files) ->
+              if enter_dir.basename == 'child1'
+                return 'break'
+
+            assert.equal true, cancelled
+            table.sort files
+            assert.same {
+              dir\join('child1'),
+              dir\join('child2'),
+            }, files
+
   describe 'copy(dest)', ->
     it 'copies the given file', ->
       with_tmpdir (dir) ->

--- a/spec/support/spec_helper.moon
+++ b/spec/support/spec_helper.moon
@@ -97,12 +97,6 @@ export howl_async = (f) ->
   status, err = coroutine.resume co
   error err unless status
 
-export pump_mainloop = ->
-  jit.off true, true
-  count = 0
-  while count < 100 and C.g_main_context_iteration(howl_main_ctx, false) != 0
-    count += 1
-
 export within_activity = (activity_function, on_show) ->
   command_line = howl.app.window.command_line
   command_line.orig_show = command_line.show

--- a/spec/ui/cursor_spec.moon
+++ b/spec/ui/cursor_spec.moon
@@ -10,7 +10,7 @@ describe 'Cursor', ->
   window = Gtk.OffscreenWindow default_width: 800, default_height: 640
   window\add editor\to_gobject!
   window\show_all!
-  pump_mainloop!
+  howl.app\pump_mainloop!
 
   before_each ->
     cursor.pos = 1

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -12,7 +12,7 @@ describe 'Editor', ->
   window = Gtk.OffscreenWindow!
   window\add editor\to_gobject!
   window\show_all!
-  pump_mainloop!
+  howl.app\pump_mainloop!
 
   before_each ->
     buffer = Buffer {}

--- a/spec/ui/selection_spec.moon
+++ b/spec/ui/selection_spec.moon
@@ -11,7 +11,7 @@ describe 'Selection', ->
   window = Gtk.OffscreenWindow!
   window\add editor\to_gobject!
   window\show_all!
-  pump_mainloop!
+  howl.app\pump_mainloop!
 
   before_each ->
     editor.view.selection\clear!


### PR DESCRIPTION
From the module documentation:

The activities module keeps track of long running operations with Howl, that
either is or should appear to be blocking in nature.

While most operations within Howl are fast enough that any blocking is at most a
nuisance, some things can be slow enough that it's not reasonable to perform
them in a blocking manner without any feedback to the user (apart from an
unresponsive editor). Alternatively, some operations can be slow but
non-blocking (e.g. using some of Howl's asynchronous APIs), and could by mistake
allow the user to work before the result of a needed operation is ready.

Using the `run` or `run_process` functions available from the activities module,
code can run designated blocks of code as activities. An activity is in its most
basic form simply a named part of code, with an associated dynamic status, whose
execution is supervised by the activities module. If the execution of the
activity has not completed within a specific interval the user is alerted to the
ongoing operation via a popup at the bottom at the current window, providing
insight into what is being done and optionally any progress.
