### PR TITLE
Automatically remove an empty buffer when another one is added

### DIFF
--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -343,10 +343,13 @@ class Application extends PropertyObject
       count += 1
 
   _append_buffer: (buffer) =>
-    if config.autoclose_single_buffer and #@_buffers == 1 and not @_buffers[1].file and not @_buffers[1].modified
-      @_buffers[1] = buffer
-    else
-      append @_buffers, buffer
+    if config.autoclose_single_buffer and #@_buffers == 1
+      present = @_buffers[1]
+      if not present.file and not present.modified and present.length == 0
+        @_buffers[1] = buffer
+        return
+
+    append @_buffers, buffer
 
   _buffer_for_file: (file) =>
     for b in *@buffers

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -343,7 +343,7 @@ class Application extends PropertyObject
       count += 1
 
   _append_buffer: (buffer) =>
-    if #@_buffers == 1 and not @_buffers[1].file and not @_buffers[1].modified
+    if config.autoclose_single_buffer and #@_buffers == 1 and not @_buffers[1].file and not @_buffers[1].modified
       @_buffers[1] = buffer
     else
       append @_buffers, buffer
@@ -550,6 +550,13 @@ config.define
   description: 'The number of files to remember in the recently closed list'
   default: 1000
   type_of: 'number'
+  scope: 'global'
+
+config.define
+  name: 'autoclose_single_buffer'
+  description: 'When only one, empty buffer is open, automatically close it when another is created'
+  default: true
+  type_of: 'boolean'
   scope: 'global'
 
 signal.register 'file-opened',

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -139,14 +139,14 @@ class Application extends PropertyObject
   new_buffer: (buffer_mode) =>
     buffer_mode or= mode.by_name 'default'
     buffer = Buffer buffer_mode
-    append @_buffers, buffer
+    @_append_buffer buffer
     buffer
 
   add_buffer: (buffer, show = true) =>
     for b in *@buffers
       return if b == buffer
 
-    append @_buffers, buffer
+    @_append_buffer buffer
     if show and @editor
       breadcrumbs.drop!
       @editor.buffer = buffer
@@ -341,6 +341,12 @@ class Application extends PropertyObject
     ctx = C.g_main_context_default!
     while count < max_count and C.g_main_context_iteration(ctx, false) != 0
       count += 1
+
+  _append_buffer: (buffer) =>
+    if #@_buffers == 1 and not @_buffers[1].file and not @_buffers[1].modified
+      @_buffers[1] = buffer
+    else
+      append @_buffers, buffer
 
   _buffer_for_file: (file) =>
     for b in *@buffers

--- a/spec/application_spec.moon
+++ b/spec/application_spec.moon
@@ -26,6 +26,12 @@ describe 'Application', ->
       buffer = application\new_buffer!
       assert.same { buffer }, application.buffers
 
+    it 'closes a single untitled buffer if present', ->
+      config.autoclose_single_buffer = true
+      application\new_buffer!
+      buffer = application\new_buffer!
+      assert.same { buffer }, application.buffers
+
   describe 'add_buffer(buffer, show)', ->
     it 'adds the buffer to .buffers', ->
       buf = Buffer {}

--- a/spec/application_spec.moon
+++ b/spec/application_spec.moon
@@ -1,9 +1,10 @@
 {:File} = howl.io
-{:Application, :Buffer, :mode} = howl
+{:Application, :Buffer, :config, :mode} = howl
 {:Editor, :highlight} = howl.ui
 
 describe 'Application', ->
   local root_dir, application
+  config.autoclose_single_buffer = false
 
   before_each ->
     root_dir = File.tmpdir!

--- a/spec/application_spec.moon
+++ b/spec/application_spec.moon
@@ -4,11 +4,11 @@
 
 describe 'Application', ->
   local root_dir, application
-  config.autoclose_single_buffer = false
 
   before_each ->
     root_dir = File.tmpdir!
     application = Application root_dir, {}
+    config.autoclose_single_buffer = false
 
   after_each -> root_dir\delete_all!
 

--- a/spec/interactions/buffer_selection_spec.moon
+++ b/spec/interactions/buffer_selection_spec.moon
@@ -12,7 +12,6 @@ require 'howl.interactions.buffer_selection'
 
 describe 'buffer_selection', ->
   local command_line, editor
-  config.autoclose_single_buffer = false
   buffers = {}
 
   before_each ->
@@ -22,6 +21,8 @@ describe 'buffer_selection', ->
       preview: (@buffer) => nil
     }
     command_line = app.window.command_line
+
+    config.autoclose_single_buffer = false
 
     for b in *app.buffers
       app\close_buffer b

--- a/spec/interactions/buffer_selection_spec.moon
+++ b/spec/interactions/buffer_selection_spec.moon
@@ -1,7 +1,7 @@
 -- Copyright 2012-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
-import app, bindings, interact, Project from howl
+import app, bindings, config, interact, Project from howl
 import File from howl.io
 import Window from howl.ui
 
@@ -12,6 +12,7 @@ require 'howl.interactions.buffer_selection'
 
 describe 'buffer_selection', ->
   local command_line, editor
+  config.autoclose_single_buffer = false
   buffers = {}
 
   before_each ->

--- a/spec/janitor_spec.moon
+++ b/spec/janitor_spec.moon
@@ -12,8 +12,9 @@ close_buffers = ->
     app\close_buffer b, true
 
 describe 'janitor', ->
-  config.autoclose_single_buffer = false
-  before_each -> close_buffers!
+  before_each ->
+    config.autoclose_single_buffer = false
+    close_buffers!
 
   after_each ->
     config.cleanup_min_buffers_open = cleanup_min_buffers_open

--- a/spec/janitor_spec.moon
+++ b/spec/janitor_spec.moon
@@ -12,6 +12,7 @@ close_buffers = ->
     app\close_buffer b, true
 
 describe 'janitor', ->
+  config.autoclose_single_buffer = false
   before_each -> close_buffers!
 
   after_each ->


### PR DESCRIPTION
In short, when you have no buffers open, an Untitled empty buffer will be added. Then, when you proceed to open another file...the untitled buffer still stays open. This will now automatically close it.