### PR TITLE
Add additional Scheme source extensions

### DIFF
--- a/bundles/basic_modes/mode_definitions.moon
+++ b/bundles/basic_modes/mode_definitions.moon
@@ -312,7 +312,7 @@ common_auto_pairs = {
     parent: 'curly_mode'
 
   scheme:
-    extensions: { 'sch', 'scm' }
+    extensions: { 'sch', 'scm', 'sld', 'sls', 'ss' }
     comment_syntax: ';'
     auto_pairs: {
       '(': ')'


### PR DESCRIPTION
The following extensions are included:
	.sld -- R7RS Library Source
	.sls -- R6RS Library Source
	.ss  -- 'Scheme Source' as used in some implementations (e.g. Chez)