### PR TITLE
Basic support for ES6 template literals.

### DIFF
--- a/bundles/javascript/javascript_lexer.moon
+++ b/bundles/javascript/javascript_lexer.moon
@@ -34,6 +34,7 @@ howl.util.lpeg_lexer ->
   str = any {
     span('"', '"', '\\')
     span("'", "'", '\\')
+    span('`', '`', '\\') 
   }
   string = c 'string', str
 

--- a/bundles/javascript/misc/example.js
+++ b/bundles/javascript/misc/example.js
@@ -28,6 +28,8 @@ false;
 // strings
 "hello!" && 'hi there!';
 "esc\"aped" && 'esc\'aped';
+`this is a multi-line template string,
+with a string ${variable} inlined.`;
 
 // Capitalized identifiers are treated as types
 new String('foo');


### PR DESCRIPTION
Prevents syntax highlighting from breaking when using ES6 template literals.