### PR TITLE
Add missing javascript keywords introduced in ES2015+

### DIFF
--- a/bundles/javascript/javascript_lexer.moon
+++ b/bundles/javascript/javascript_lexer.moon
@@ -9,10 +9,11 @@ howl.util.lpeg_lexer ->
   identifer = c 'identifer', ident
 
   keyword = c 'keyword', word {
-    'break', 'case', 'catch', 'continue', 'const', 'debugger', 'default', 'delete',
-    'do', 'else', 'finally', 'for', 'function', 'if', 'in', 'instanceof',
-    'new', 'return', 'switch', 'this', 'throw', 'try', 'typeof', 'var',
-    'void', 'while', 'with', 'yield'
+    'async', 'await', 'break', 'case', 'catch', 'class', 'const', 'continue',
+    'debugger', 'default', 'delete', 'do', 'else', 'export', 'extends',
+    'finally', 'from', 'for', 'function', 'if', 'import', 'in', 'instanceof',
+    'let', 'new', 'of', 'return', 'super', 'switch', 'this', 'throw', 'try',
+    'typeof', 'var', 'void', 'while', 'with', 'yield'
   }
 
   operator = c 'operator', S'+-*/%=<>&^|!(){}[];'

--- a/bundles/javascript/misc/example.js
+++ b/bundles/javascript/misc/example.js
@@ -74,3 +74,19 @@ function* g(c) { yield c; }
 var
   foo = 1,
   my_func = function() {};
+
+// aync await
+async function () {
+  await Promise.resolve(true);
+}
+
+// modules
+import foo from './foo';
+export default 'a';
+
+// class
+class Foo extends Bar {
+  constructor () {
+    super();
+  }
+}


### PR DESCRIPTION
Hi.

Here's a refreshed list of js keywords with recent additions: `async`, `await`, `class`…