### PR TITLE
Increase the default scroll speed, and avoid over-scrolling

### DIFF
--- a/lib/aullar/config.moon
+++ b/lib/aullar/config.moon
@@ -96,12 +96,12 @@ define_options = ->
 
     scroll_speed_x: {
       type: 'number',
-      default: 100
+      default: 250
     },
 
     scroll_speed_y: {
       type: 'number',
-      default: 100
+      default: 250
     }
 
     gutter_styling: {

--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -1,4 +1,4 @@
- --Copyright 2014-2015 The Howl Developers
+-- Copyright 2014-2015 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 ffi = require 'ffi'
@@ -276,6 +276,7 @@ View = {
   scroll_to: (line) =>
     return if line < 1 or not @showing
     line = max(1, line)
+    line = min(line, @buffer.nr_lines)
     return if @first_visible_line == line
 
     @_first_visible_line = line

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -1067,13 +1067,13 @@ with config
   .define
     name: 'scroll_speed_y'
     description: 'A percentage value determining the vertical mouse scrolling speed'
-    default: 100
+    default: 250
     type_of: 'number'
 
   .define
     name: 'scroll_speed_x'
     description: 'A percentage value determining the horizontal mouse scrolling speed'
-    default: 100
+    default: 250
     type_of: 'number'
 
   .define


### PR DESCRIPTION
Closes #415. Ping @italomaia, @tastyminerals. From my testing, this is virtually identical to Visual Studio Code's speed.