### PR TITLE
Rework logging to be signal-based and add a log buffer

### DIFF
--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -102,6 +102,21 @@ class Application extends PropertyObject
       on_error: _G.log.error
     }
 
+    signal.connect 'log-entry-appended', (entry) ->
+      level = entry.level
+      message = entry.message
+      return if level == 'traceback'
+
+      if @window and @window.visible
+        essentials = entry.essentials
+
+        status = @window.status
+        command_line = @window.command_line
+        status[level] status, essentials
+        command_line\notify essentials, level if command_line.showing
+      elseif not @args.spec
+        print message
+
     super!
 
   @property idle: get: =>

--- a/lib/howl/commands/app_commands.moon
+++ b/lib/howl/commands/app_commands.moon
@@ -2,7 +2,7 @@
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 import app, activities, breadcrumbs, Buffer, command, config, bindings, bundle, interact, signal, mode, Project from howl
-import ActionBuffer, ProcessBuffer, BufferPopup, StyledText from howl.ui
+import ActionBuffer, JournalBuffer, ProcessBuffer, BufferPopup, StyledText from howl.ui
 import Process from howl.io
 serpent = require 'serpent'
 
@@ -371,6 +371,13 @@ command.register
   handler: (loc) ->
     return unless loc
     breadcrumbs.location = loc[1]
+
+command.register
+  name: 'open-journal'
+  description: 'Opens the Howl log journal'
+  handler: ->
+    app\add_buffer JournalBuffer!
+    app.editor.cursor\eof!
 
 -----------------------------------------------------------------------
 -- Howl eval commands

--- a/lib/howl/keymap.moon
+++ b/lib/howl/keymap.moon
@@ -114,6 +114,7 @@
 
   f11:              'window-toggle-fullscreen'
   alt_x:            'run'
+  alt_j:            'open-journal'
 
   shift_alt_left:  'view-left-or-create'
   shift_alt_right: 'view-right-or-create'

--- a/lib/howl/moonscript_support.lua
+++ b/lib/howl/moonscript_support.lua
@@ -23,7 +23,7 @@ end
 local function error_rewriter(err)
   if type(err) ~= 'string' then return err end
   if not err:match('%.moon') then return err end
-  local moon_file = err:match('^%[string "([^"]+%.moon)"%]')
+  local moon_file = err:match('^%[string "([^"]+%.moon)"%]') or err:match('^([^%s]+%.moon)')
   if not moon_file then return err end
 
   -- if the file hasn't been compiled yet we do it first for error rewriting to work
@@ -34,6 +34,10 @@ local function error_rewriter(err)
   local trace = debug.traceback("", 2)
   trace = trace:match('%s*(.+)%s*$')
   local rewritten = moonscript.errors.rewrite_traceback(trace, err)
+  if howl.sys.env.HOWL_PRINT_TRACEBACKS then
+    print(rewritten)
+  end
+  howl.log.traceback(rewritten)
   return rewritten or err
 end
 

--- a/lib/howl/ui/journal_buffer.moon
+++ b/lib/howl/ui/journal_buffer.moon
@@ -1,0 +1,63 @@
+import log, signal from howl
+import ActionBuffer from howl.ui
+
+append = table.insert
+
+class JournalBuffer extends ActionBuffer
+  new: =>
+    super!
+
+    @read_only = true
+    @title = 'Howl Journal'
+    @entry_sizes = {}
+
+    @_appended = self\append_entry
+    @_trimmed = self\trim
+
+    signal.connect 'log-entry-appended', @_appended
+    signal.connect 'log-trimmed', @_trimmed
+
+    for entry in *log.entries
+      @append_entry entry
+
+  modify: (f) =>
+    @read_only = false
+    f!
+    @read_only = true
+    @modified = false
+
+  append_entry: (entry) =>
+    level = entry.level
+    message = entry.message .. '\n'
+    append @entry_sizes, message\count '\n'
+
+    @modify ->
+      editor = howl.app.editor
+      at_end_of_file = editor and editor.cursor.at_end_of_file
+      level = 'error' if level == 'traceback'
+      @append message, level
+      editor.cursor\eof! if at_end_of_file
+
+    if howl.app.editor and howl.app.editor.buffer == @
+      howl.app.editor.cursor\eof!
+
+  trim: (options) =>
+    size = options.size
+    assert size <= #@entry_sizes
+
+    nlines = 0
+    to_remove = #@entry_sizes - size
+    for _=1,to_remove
+      nlines += table.remove @entry_sizes, 1
+
+    @modify ->
+      @lines\delete 1, nlines
+
+signal.connect 'buffer-closed', (params) ->
+  {:buffer} = params
+  return if typeof(buffer) != 'JournalBuffer'
+
+  signal.disconnect 'log-entry-appended', buffer._appended
+  signal.disconnect 'log-trimmed', buffer._trimmed
+
+return JournalBuffer

--- a/lib/howl/ui/status.moon
+++ b/lib/howl/ui/status.moon
@@ -17,6 +17,7 @@ class Status
   info: (text) => @_set 'info', text
   warning: (text) => @_set 'warning', text
   error: (text) => @_set 'error', text
+  traceback: (text) => @_set 'error', text
 
   to_gobject: => @label
 

--- a/spec/application_spec.moon
+++ b/spec/application_spec.moon
@@ -7,7 +7,7 @@ describe 'Application', ->
 
   before_each ->
     root_dir = File.tmpdir!
-    application = Application root_dir, {}
+    application = Application root_dir, spec: true
     config.autoclose_single_buffer = false
 
   after_each -> root_dir\delete_all!

--- a/spec/interact_spec.moon
+++ b/spec/interact_spec.moon
@@ -105,7 +105,7 @@ describe 'interact', ->
         finish1 = captured_finish
         finish1!
 
-        assert.has_error finish1, 'Cannot finish - no running activities'
+        assert.error_matches finish1, 'Cannot finish - no running activities', nil, true
 
       it 'allows cancelling outer interactions, when nested interactions present', ->
         local captured_finish


### PR DESCRIPTION
This does two key things:

- It reworks logging to be based on signals and subscriptions. Anyone can now subscribe to log output. This can be handy for things like bundles to be able to listen to log events and send them to custom receivers (e.g. journald). Or, of course, it can be useful so we don't have to keep on making `log.dispatch` a huge function that sends events to a bunch of different places with a bunch of preconditions (a problem I ran into while adding the log buffer).
- Adds a log buffer that can be opened via `open-journal`. I named it the journal because *log* tends be used as a verb, which wouldn't fit with this noun-based usage.

I actually found two minor but interesting bugs in Howl while looking at the journal buffer, which I'll be fixing soon. :man_shrugging: 