### PR TITLE
Add an examples.rs file and fix a few bugs in the Rust lexer

### DIFF
--- a/bundles/rust/misc/example.rs
+++ b/bundles/rust/misc/example.rs
@@ -1,0 +1,111 @@
+#![allow(unused)]
+
+extern crate
+
+// an old fashion single line comment
+
+/*
+a multi-line
+comment
+*/
+
+/*
+a
+/*
+nested
+*/
+multiline
+comment
+*/
+
+as
+const
+crate
+extern
+for
+impl
+in
+move
+mut
+ref
+return
+Self
+static
+super
+trait
+unsafe
+where
+while
+
+abstract
+alignof
+become
+box
+do
+final
+macro
+offsetof
+override
+priv
+proc
+pure
+sizeof
+typeof
+unsized
+virtual
+yield
+
+union
+'static
+
+type Label = String;
+
+mod a {
+    pub fn foo() { self::bar() }
+
+    fn bar() {}
+}
+
+mod b {
+    pub fn foo() { super::a::foo() }
+}
+
+enum MyEnum {
+    Variant1(i8,i16,i32,i64),
+    Variant2(u8,u16,u32,u64),
+    Variant3
+}
+
+struct MyStruct {
+    field1: bool,
+    field2: char,
+    field3: str
+}
+
+struct NamedTuple(f32,f64,isize,usize);
+
+fn main() {
+    use std::Vec;
+    let literal_chars = ['a', '\n', '\0', '§', '\u{00e9}'];
+    let literal_strings = ["normal  \"string\"", r#"raw "string""#, r##"another "raw" #"string"#"##];
+    let literal_ascii_char = b'H';
+    let literal_ascii_str = br#"raw ascii "string""#
+    let literal_decimal = 1234_5678i32;
+    let literal_hex = 0xabcdef_0123456789u64;
+    let literal_octal = 0o4567_0123__u32;
+    let literal_binary = 0b1001____0110u16;
+    let literal_float = 1_23.45E+67f64;
+    let v = vec!{123, 456};
+    macro_rules! macro_name { () => () };
+    macro_name!();
+
+    let b: bool = match Some(3i32) {
+        Some(_) => true,
+        None => false,
+    };
+
+    loop { break; continue; }
+
+    let i: i32 = if true { 3 } else { 4 };
+
+}

--- a/bundles/rust/rust_lexer.moon
+++ b/bundles/rust/rust_lexer.moon
@@ -88,10 +88,10 @@ howl.util.lpeg_lexer ->
     all: any {
       keyword,
       extension,
-      type_library,
-      type,
       comment,
       string,
+      type_library,
+      type,
       attribute,
       number,
       operator,

--- a/bundles/rust/rust_lexer.moon
+++ b/bundles/rust/rust_lexer.moon
@@ -14,6 +14,9 @@ howl.util.lpeg_lexer ->
   comment = c 'comment', any {line_comment, block_comment}
 
 
+  hex_digit = R'09' + R'af' + R'AF' + '_'
+
+
   -- Strings.
   dq_str = span  '"', '"', '\\'
   raw_str_start = P'r'^0 * Cg(P'#'^0, 'lvl') * '"'
@@ -26,13 +29,17 @@ howl.util.lpeg_lexer ->
 
 
   -- Numbers.
-  binary = P'0b'^-1 * S'01_'^1
+  binary = P'0b' * S'01_'^1
+  oct = P'0o' * S'01234567_'^1
+  hex = P'0x' * hex_digit^1
+  decimal = (digit + '_')^1
+  floats = float * (S'eE' * S'+-'^-1 * decimal)^-1
   number = c 'number', any {
     binary,
-    hexadecimal,
-    octal,
-    (digit + '_')^1 -- decimal integer
-    float
+    hex,
+    oct,
+    decimal,
+    floats
   }
 
 

--- a/bundles/rust/rust_lexer.moon
+++ b/bundles/rust/rust_lexer.moon
@@ -23,8 +23,11 @@ howl.util.lpeg_lexer ->
   raw_str_end = '"' * match_back 'lvl'
   raw_str = raw_str_start * scan_to raw_str_end
   -- Character.
-  anychar = alpha + digit + '_' + space
-  char = P"'" * (('\\' * anychar) + anychar) * P"'"
+  cont = R'\128\191'
+  utf8 = R'\0\127' + R'\194\223' * cont + R'\224\239' * cont * cont + R'\240\244' * cont * cont * cont
+  ascii_esc = '\\' * S'trn\'"\\0'
+  unicode_esc = ('\\u{' * hex_digit^1 * '}')
+  char = P"'" * (unicode_esc + ascii_esc + utf8) * P"'"
   string  = c 'string', any {dq_str, raw_str, char}
 
 

--- a/bundles/rust/rust_lexer.moon
+++ b/bundles/rust/rust_lexer.moon
@@ -46,7 +46,7 @@ howl.util.lpeg_lexer ->
     'move',       'mut',        "offsetof", 'override', 'priv',
     'proc',       'pub',        'pure',     'ref',      'return',
     'Self',       'self',       'sizeof',   'static',   'struct',
-    'super',      'trait',      'true',     'type',     'typeof',
+    'super',      'trait',      'true',     'typeof',   'type',
     'unsafe',     'unsized',    'use',      'virtual',  'where',
     'while',      'yield'
   }


### PR DESCRIPTION
This series of commits adds an `example.rs` file and fixes the following in the Rust lexer:

- lifetime specifiers are given lower precedence than character literals
- `type` keyword is given lower precedence than `type` keyword
- rules for capturing numeric literals are re-implemented to better conform to Rust syntax rules
- support for Unicode character literals is added

Closes #442 

![2018-05-22-155454_226x104_scrot](https://user-images.githubusercontent.com/6710130/40386705-7b254d24-5dd8-11e8-8030-8edc62640944.png)
