### PR TITLE
Faster completions

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -2,3 +2,4 @@ site/source/versions
 site/**/*.html
 site/**/*.erb
 src/deps/
+*.min.js

--- a/bundles/css/css_mode.moon
+++ b/bundles/css/css_mode.moon
@@ -8,8 +8,7 @@ class CSSMode
     @lexer = bundle_load 'css_lexer'
     @completers = { completer, 'in_buffer' }
 
-  default_config:
-    word_pattern: r'\\b[-_\\w]+\\b'
+  word_pattern: r'\\b[-_\\w]+\\b'
 
   comment_syntax: { '/*', '*/' }
 

--- a/bundles/hg/spec/hg_spec.moon
+++ b/bundles/hg/spec/hg_spec.moon
@@ -48,7 +48,7 @@ describe 'Hg bundle', ->
         assert.same list1, list2
 
       it 'returns a list of hg paths, including untracked', (done) ->
-        settimeout 2
+        settimeout 4
         howl_async ->
           assert_same_paths hg\paths!, {}
           file = root / 'new.lua'

--- a/bundles/lisp/lisp_mode.moon
+++ b/bundles/lisp/lisp_mode.moon
@@ -32,8 +32,7 @@ class LispMode
 
   comment_syntax: ';'
 
-  default_config:
-    word_pattern: '[^][%s/.(){}"\']+'
+  word_pattern: r'[^][\\s/.(){}"\']+'
 
   auto_pairs: {
     '(': ')'

--- a/bundles/markdown/markdown_mode.moon
+++ b/bundles/markdown/markdown_mode.moon
@@ -8,9 +8,9 @@ is_header = (line) ->
 
 {
   lexer: bundle_load('markdown_lexer')
+  word_pattern: r'\\b\\w[\\w\\d_-]+\\b'
 
   default_config:
-    word_pattern: r'\\b\\w[\\w\\d_-]+\\b'
     cursor_line_highlighted: false
 
   auto_pairs: {

--- a/bundles/python/python_mode.moon
+++ b/bundles/python/python_mode.moon
@@ -5,9 +5,7 @@
   lexer: bundle_load('python_lexer')
 
   comment_syntax: '#'
-
-  default_config:
-    word_pattern: r'\\b[\\pL_][\\pL\\pN_]+\\b'
+  word_pattern: r'\\b[\\pL_][\\pL\\pN_]+\\b'
 
   indentation: {
     more_after: {

--- a/bundles/ruby/ruby_mode.moon
+++ b/bundles/ruby/ruby_mode.moon
@@ -36,9 +36,9 @@ continuation_indent = (line, indent_level) ->
   lexer: bundle_load('ruby_lexer')
 
   comment_syntax: '#'
+  word_pattern: r'\\b\\w[\\w\\d_]+[?!=]?\\b'
 
   default_config:
-    word_pattern: r'\\b\\w[\\w\\d_]+[?!=]?\\b'
     inspectors_on_idle: { 'ruby' }
 
   indentation: {

--- a/bundles/vi/spec/vi_spec.moon
+++ b/bundles/vi/spec/vi_spec.moon
@@ -17,7 +17,7 @@ And third linƏ
 
 describe 'VI', ->
   local buffer, lines
-  editor = Editor Buffer {}
+  editor = Editor Buffer!
   cursor = editor.cursor
   selection = editor.selection
   window = Gtk.OffscreenWindow default_width: 800, default_height: 640
@@ -26,7 +26,7 @@ describe 'VI', ->
 
   before_each ->
     howl.app.window = window: Window!
-    buffer = Buffer {}
+    buffer = Buffer howl.mode.by_name 'default'
     buffer.text = text
     lines = buffer.lines
     editor.buffer = buffer

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -13,6 +13,7 @@ Revisions = require 'aullar.revisions'
 require 'ljglibs.cdefs.glib'
 
 char_arr = ffi.typeof 'char [?]'
+const_char_p = ffi.typeof 'const char *'
 
 scan_line = (base, offset, end_offset) ->
   start_offset = offset
@@ -135,7 +136,7 @@ Buffer = {
           @text_buffer\set text, size
           @styling\reset size + 1
         else
-          @text_buffer = GapBuffer 'char', size, initial: text
+          @text_buffer = GapBuffer 'unsigned char', size, initial: text
           @styling = Styling size + 1, @_style_listener
 
         @markers\remove!
@@ -301,7 +302,7 @@ Buffer = {
     nil
 
   get_ptr: (offset, size) =>
-    @text_buffer\get_ptr offset - 1, size
+    const_char_p @text_buffer\get_ptr(offset - 1, size)
 
   sub: (start_index, end_index) =>
     return '' if start_index > @size

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -302,7 +302,12 @@ Buffer = {
     nil
 
   get_ptr: (offset, size) =>
-    const_char_p @text_buffer\get_ptr(offset - 1, size)
+    ptr, compacted = @text_buffer\get_ptr(offset - 1, size)
+    if compacted
+      @offsets\invalidate_from 0
+      @_invalidate_lines_from_offset 0
+
+    const_char_p(ptr)
 
   sub: (start_index, end_index) =>
     return '' if start_index > @size

--- a/lib/aullar/buffer.moon
+++ b/lib/aullar/buffer.moon
@@ -302,6 +302,7 @@ Buffer = {
     nil
 
   get_ptr: (offset, size) =>
+    return const_char_p(char_arr(1)) if size == 0
     ptr, compacted = @text_buffer\get_ptr(offset - 1, size)
     if compacted
       @offsets\invalidate_from 0

--- a/lib/aullar/gap_buffer.moon
+++ b/lib/aullar/gap_buffer.moon
@@ -33,13 +33,13 @@ define_class {
       error "GapBuffer.get_ptr(): Illegal range: offset=#{offset}, size=#{size} for buffer of size #{@size}", 2
 
     if offset >= @gap_start -- post gap ptr
-      @array + @gap_size + offset
+      @array + @gap_size + offset, false
     elseif offset + size <= @gap_start -- pre gap ptr
-      @array + offset
+      @array + offset, false
     else -- ephemeral copy pointer
       if size == @size
         @compact!
-        @get_ptr offset, size
+        @get_ptr(offset, size), true
       else
         arr = self.new_arr(size + 1)
         pregap_size = @gap_start - offset
@@ -47,7 +47,7 @@ define_class {
         ffi_copy arr, @array + offset, pregap_size * @type_size
         ffi_copy arr + pregap_size, @array + @gap_end, postgap_size * @type_size
         arr[size] = 0
-        arr
+        arr, false
 
   move_gap_to: (offset) =>
     if offset < 0 or offset > @size

--- a/lib/aullar/gap_buffer.moon
+++ b/lib/aullar/gap_buffer.moon
@@ -37,13 +37,17 @@ define_class {
     elseif offset + size <= @gap_start -- pre gap ptr
       @array + offset
     else -- ephemeral copy pointer
-      arr = self.new_arr(size + 1)
-      pregap_size = @gap_start - offset
-      postgap_size = size - pregap_size
-      ffi_copy arr, @array + offset, pregap_size * @type_size
-      ffi_copy arr + pregap_size, @array + @gap_end, postgap_size * @type_size
-      arr[size] = 0
-      arr
+      if size == @size
+        @compact!
+        @get_ptr offset, size
+      else
+        arr = self.new_arr(size + 1)
+        pregap_size = @gap_start - offset
+        postgap_size = size - pregap_size
+        ffi_copy arr, @array + offset, pregap_size * @type_size
+        ffi_copy arr + pregap_size, @array + @gap_end, postgap_size * @type_size
+        arr[size] = 0
+        arr
 
   move_gap_to: (offset) =>
     if offset < 0 or offset > @size

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -343,6 +343,11 @@ describe 'Buffer', ->
       ptr = b\get_ptr 1, 1
       assert.raises 'constant', -> ptr[0] = 88
 
+    it 'returns a "empty" pointer when size is zero', ->
+      b = Buffer ''
+      ptr = b\get_ptr 1, 0
+      assert.equals 0, ptr[0]
+
   describe 'sub(start_index [, end_index])', ->
     it 'returns a string for the given inclusive range', ->
       b = Buffer '123456789'

--- a/lib/aullar/spec/buffer_spec.moon
+++ b/lib/aullar/spec/buffer_spec.moon
@@ -338,6 +338,11 @@ describe 'Buffer', ->
       assert.raises 'Illegal', -> b\get_ptr 1, 4
       assert.raises 'Illegal', -> b\get_ptr 3, 2
 
+    it 'returns a read-only pointer', ->
+      b = Buffer '123'
+      ptr = b\get_ptr 1, 1
+      assert.raises 'constant', -> ptr[0] = 88
+
   describe 'sub(start_index [, end_index])', ->
     it 'returns a string for the given inclusive range', ->
       b = Buffer '123456789'

--- a/lib/aullar/spec/gap_buffer_spec.moon
+++ b/lib/aullar/spec/gap_buffer_spec.moon
@@ -233,17 +233,16 @@ describe 'GapBuffer', ->
       assert.equals 3, ptr[2]
 
     it 'always returns pointers that are zero terminated at the boundaries', ->
-      for _ = 1,20
-        b = buffer '0123456789', 10
-        b\move_gap_to 5
-        pre_gap_ptr = b\get_ptr(0, 4)
-        assert.equals 0, pre_gap_ptr[5]
+      b = buffer '0123456789', 10
+      b\move_gap_to 5
+      pre_gap_ptr = b\get_ptr(0, 4)
+      assert.equals 0, pre_gap_ptr[5]
 
-        cross_gap_ptr = b\get_ptr(4, 2)
-        assert.equals 0, cross_gap_ptr[2]
+      cross_gap_ptr = b\get_ptr(4, 2)
+      assert.equals 0, cross_gap_ptr[2]
 
-        post_gap_ptr = b\get_ptr(5, 1)
-        assert.equals 0, post_gap_ptr[5]
+      post_gap_ptr = b\get_ptr(5, 1)
+      assert.equals 0, post_gap_ptr[5]
 
   describe 'insert(offset, data, size)', ->
     context 'when <data> is provided', ->

--- a/lib/aullar/spec/offsets_spec.moon
+++ b/lib/aullar/spec/offsets_spec.moon
@@ -6,7 +6,7 @@ C = ffi.C
 
 describe 'offsets', ->
 
-  gap_b = (data) -> GapBuffer 'char', #data, initial: data
+  gap_b = (data) -> GapBuffer 'unsigned char', #data, initial: data
 
   glib_byte_offset = (ptr, char_offset) ->
     next_ptr = C.g_utf8_offset_to_pointer ptr, char_offset

--- a/lib/ext/moonscript/moon/init.lua
+++ b/lib/ext/moonscript/moon/init.lua
@@ -99,7 +99,7 @@ extend = function(...)
     ...
   }
   if #tbls < 2 then
-    return 
+    return
   end
   for i = 1, #tbls - 1 do
     local a = tbls[i]

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -267,6 +267,17 @@ class Buffer extends PropertyObject
     return '' if byte_size <= 0
     ffi.string @_buffer\get_ptr(byte_start_pos, byte_size), byte_size
 
+  get_ptr: (start_pos, end_pos) =>
+    len = @length
+    if not start_pos or start_pos < 1 or start_pos > len or
+      not end_pos or end_pos < 1 or end_pos > len
+      error "Buffer.get_ptr(): Illegal span: (#{start_pos}, #{end_pos} for buffer with length #{len}", 2
+
+    byte_start_pos = @byte_offset(start_pos)
+    byte_end_pos = min @byte_offset(end_pos + 1), @_buffer.size + 1
+    count = byte_end_pos - byte_start_pos
+    @_buffer\get_ptr(byte_start_pos, count), count
+
   find: (search, init = 1) =>
     if init < 0
       init = @length + init + 1

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -7,6 +7,7 @@ import File from howl.io
 aullar = require 'aullar'
 
 ffi = require 'ffi'
+ffi_string, ffi_new = ffi.string, ffi.new
 
 append = table.insert
 min = math.min
@@ -265,9 +266,12 @@ class Buffer extends PropertyObject
     byte_end_pos = min @byte_offset(end_pos + 1), @_buffer.size + 1
     byte_size = byte_end_pos - byte_start_pos
     return '' if byte_size <= 0
-    ffi.string @_buffer\get_ptr(byte_start_pos, byte_size), byte_size
+    ffi_string @_buffer\get_ptr(byte_start_pos, byte_size), byte_size
 
   get_ptr: (start_pos, end_pos) =>
+    if end_pos < start_pos
+      return ffi_new('const char[1]', 0), 0
+
     len = @length
     if not start_pos or start_pos < 1 or start_pos > len or
       not end_pos or end_pos < 1 or end_pos > len

--- a/lib/howl/buffer_context.moon
+++ b/lib/howl/buffer_context.moon
@@ -59,7 +59,7 @@ class Context extends PropertyObject
   }
 
   _get_word_boundaries: =>
-    word_pattern = @buffer\config_at(@pos).word_pattern
+    word_pattern = @buffer\mode_at(@pos).word_pattern
 
     line_text = @line.text
     line_start_pos = @line.start_pos

--- a/lib/howl/completer.moon
+++ b/lib/howl/completer.moon
@@ -12,7 +12,11 @@ load_completers = (buffer, context, mode = {}) ->
       for f in *factories
         if type(f) == 'string'
           completer = completion[f]
-          f = completer and completer.factory
+          unless completer
+            log.warn "unknown completer '#{f}' set for #{buffer} not found"
+            continue
+
+          f = completer.factory
 
         error "`nil` completer set for #{buffer}" if not f
         completer = f(buffer, context)

--- a/lib/howl/completion/in_buffer_completer.moon
+++ b/lib/howl/completion/in_buffer_completer.moon
@@ -1,13 +1,15 @@
--- Copyright 2012-2014-2015 The Howl Developers
+-- Copyright 2012-2018 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 Matcher = require 'howl.util.matcher'
-import config, signal, app from howl
+GRegex = require 'ljglibs.glib.regex'
+{:config, :signal, :app} = howl
+{:abs, :min, :max} = math
 os = os
 append = table.insert
 
 RESCAN_STALE_AFTER = 60
-MAX_TOKEN_LENGTH = 60
+MAX_TOKEN_SIZE = 100
 
 signal.connect 'buffer-modified', (args) ->
     data = args.buffer.data.inbuffer_completer
@@ -36,7 +38,16 @@ load = (buffer, conf) ->
     data = b.data.inbuffer_completer or {}
     b_tokens = data.tokens
     if not b_tokens or should_update data
-      b_tokens = { token, true for token in b.text\ugmatch conf.word_pattern when token.ulen <= MAX_TOKEN_LENGTH }
+      b_tokens = {}
+      p = GRegex r(conf.word_pattern).pattern
+      ptr = b\get_ptr 1, b.length
+      match_info = p\match_with_info ptr
+      if match_info
+        while match_info\matches!
+          token = match_info\fetch(0)
+          b_tokens[token] = true if #token <= MAX_TOKEN_SIZE
+          match_info\next!
+
       data.tokens = b_tokens
       data.updated_at = os.time!
       b.data.inbuffer_completer = data
@@ -46,34 +57,45 @@ load = (buffer, conf) ->
   [token for token, _ in pairs tokens]
 
 close_chunk = (context) ->
-  lines = context.buffer.lines
-  line = context.line
-  start_line = lines[math.max 1, line.nr - 10]
-  end_line = lines[math.min #lines, line.nr + 10]
-  context.buffer\chunk start_line.start_pos, end_line.end_pos
+  SIZE = 3000
+  buffer = context.buffer
+  pos = context.pos
+  start_pos = max 1, pos - (SIZE / 2)
+  end_pos = min buffer.length, pos + (SIZE / 2)
 
-near_tokens = (context) ->
+  if end_pos - start_pos < SIZE
+    start_pos = max 1, start_pos - (SIZE / 2)
+    end_pos = min buffer.length, pos + (SIZE / 2)
+
+  buffer\chunk start_pos, end_pos
+
+near_tokens = (context, conf) ->
   part = context.word_prefix
   cur_word = context.word.text
   chunk = close_chunk context
-  line_pos = context.pos - chunk.start_pos
 
   tokens = {}
   start_pos = 1
   chunk_text = chunk.text
   buffer = context.buffer
 
-  while start_pos < #chunk_text
-    pattern = buffer\config_at(start_pos).word_pattern
-    start_pos, end_pos = chunk_text\ufind pattern, start_pos
-    break unless start_pos
-    token = chunk_text\usub start_pos, end_pos
-    if token != part and token != cur_word and token.ulen < MAX_TOKEN_LENGTH
-      rank = math.abs line_pos - start_pos
-      info = tokens[token]
-      rank = math.min info.rank, rank if info
-      tokens[token] = pos: start_pos, :rank, text: token
-    start_pos = end_pos + 1
+  -- determine the current context's byte position within the close chunk
+  cur_byte_pos = buffer\byte_offset context.pos
+  close_byte_pos = buffer\byte_offset chunk.start_pos
+  cur_pos = cur_byte_pos - close_byte_pos
+  pattern = r conf.word_pattern
+  match_info = pattern.re\match_with_info chunk_text
+  if match_info
+    while match_info\matches!
+      token = match_info\fetch(0)
+      if token != part and token != cur_word and #token <= MAX_TOKEN_SIZE
+        start_pos = match_info\fetch_pos(0)
+        rank = abs cur_pos - start_pos
+        info = tokens[token]
+        rank = min info.rank, rank if info
+        tokens[token] = :rank, text: token
+
+      match_info\next!
 
   data = buffer.data.inbuffer_completer
   if data and data.tokens
@@ -84,7 +106,7 @@ near_tokens = (context) ->
 class InBufferCompleter
   new: (buffer, context) =>
     config = buffer\config_at context.pos
-    @near_tokens = near_tokens context
+    @near_tokens = near_tokens context, config
     @matcher = Matcher load buffer, config
     @limit = config.completion_max_shown
 

--- a/lib/howl/completion/in_buffer_completer.moon
+++ b/lib/howl/completion/in_buffer_completer.moon
@@ -39,7 +39,7 @@ load = (buffer, conf) ->
     b_tokens = data.tokens
     if not b_tokens or should_update data
       b_tokens = {}
-      p = GRegex r(conf.word_pattern).pattern
+      p = GRegex b.mode.word_pattern.pattern
       ptr = b\get_ptr 1, b.length
       match_info = p\match_with_info ptr
       if match_info
@@ -83,7 +83,7 @@ near_tokens = (context, conf) ->
   cur_byte_pos = buffer\byte_offset context.pos
   close_byte_pos = buffer\byte_offset chunk.start_pos
   cur_pos = cur_byte_pos - close_byte_pos
-  pattern = r conf.word_pattern
+  pattern = buffer.mode.word_pattern
   match_info = pattern.re\match_with_info chunk_text
   if match_info
     while match_info\matches!

--- a/lib/howl/interactions/location_selection.moon
+++ b/lib/howl/interactions/location_selection.moon
@@ -1,4 +1,4 @@
--- Copyright 2012-2017 The Howl Developers
+-- Copyright 2012-2018 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 {:app, :interact} = howl

--- a/lib/howl/modes/default_mode.moon
+++ b/lib/howl/modes/default_mode.moon
@@ -12,6 +12,7 @@ is_comment = (line, comment_prefix) ->
 
 class DefaultMode
   completers: { 'in_buffer' }
+  word_pattern: r'\\b[\\pL_][\\pL\\d_]*\\b'
 
   code_blocks: {}
 

--- a/lib/howl/regex.moon
+++ b/lib/howl/regex.moon
@@ -131,6 +131,7 @@ mt = {
 is_instance = (v) -> getmetatable(v) == mt
 
 r = (pattern, compile_options, match_options) ->
+  return pattern if is_instance pattern
   comp_flags = 0
 
   if compile_options
@@ -143,7 +144,6 @@ r = (pattern, compile_options, match_options) ->
     for flag in *match_options
       match_flags = bit.bor(match_flags, flag)
 
-  return pattern if is_instance pattern
   re = GRegex pattern, comp_flags, match_flags
   setmetatable {:re}, mt
 

--- a/lib/howl/ui/command_line.moon
+++ b/lib/howl/ui/command_line.moon
@@ -532,7 +532,6 @@ class CommandLine extends PropertyObject
     escape: =>
       return false unless @close_popup!
 
-
   default_keymap:
     binding_for:
       ["cursor-home"]: => @command_widget.cursor.pos = @_prompt_end

--- a/lib/howl/ui/cursor.moon
+++ b/lib/howl/ui/cursor.moon
@@ -129,7 +129,7 @@ class Cursor extends PropertyObject
          -- eat up space from next char until next token
         _, _, i = text\ufind '^%s*()', 2
         -- do we have a new word at this pos?
-        word_pattern = @container.buffer\config_at(@pos).word_pattern
+        word_pattern = @container.buffer\mode_at(@pos).word_pattern
         start_pos, end_pos = text\ufind(word_pattern, i)
         if not end_pos or start_pos != i -- no
           _, end_pos = text\ufind('^%p+', i)
@@ -155,7 +155,7 @@ class Cursor extends PropertyObject
         text = ctx.prefix\match '(.-)%s*$'
         last_group = text\ufind '%S+$'
         if last_group -- scan for a previous word first
-          word_pattern = @container.buffer\config_at(@pos).word_pattern
+          word_pattern = @container.buffer\mode_at(@pos).word_pattern
           word_start, word_end = text\ufind word_pattern, last_group
           while word_end and word_end < text.ulen
             word_start, word_end = text\ufind word_pattern, word_end + 1

--- a/lib/howl/variables/core_variables.moon
+++ b/lib/howl/variables/core_variables.moon
@@ -21,12 +21,6 @@ config.define {
   }
 }
 
-config.define {
-  name: 'word_pattern'
-  description: 'A pattern determining what constitutes a "word" in a buffer'
-  default: r'\\b[\\pL_][\\pL\\d_]*\\b'
-}
-
 config.define
   name: 'auto_format'
   description: 'Whether to automatically format code when possible'

--- a/site/source/doc/api/buffer.md
+++ b/site/source/doc/api/buffer.md
@@ -207,6 +207,19 @@ from the end, where -1 means the last character of the buffer.
 
 See also: [rfind()](#rfind)
 
+### get_ptr(start_pos, end_pos)
+
+This returns a FFI `const char *` pointer for the given (inclusive) span of the
+buffer, as well as a byte count for the span. This can be used to get read-only
+access to a buffer's content in the most efficient way. As should be clear this
+is a very low level interface, which should only be used with great care. The
+returned pointer is only valid until the next internal buffer modification.
+Since invisible context switches can happen a a normal part of using Howl's APIs
+you need to be real sure that the code processing the pointer does not
+inadvertently cause these. You need to process this pointer directly and be done
+with it. As with the FFI in general there is no hand holding - misuse this and
+you can cause segmentation faults or otherwise hard to diagnose bugs.
+
 ### insert(text, pos)
 
 Inserts `text` at the position given by `pos`, and returns the position right

--- a/spec/buffer_context_spec.moon
+++ b/spec/buffer_context_spec.moon
@@ -7,7 +7,7 @@ describe 'BufferContext', ->
   local b
 
   before_each ->
-    b = Buffer!
+    b = Buffer howl.mode.by_name 'default'
     b.text = '"HƏllo", said Mr.Bačon'
 
   context_at = (pos) -> BufferContext b, pos
@@ -27,18 +27,14 @@ describe 'BufferContext', ->
       b.text = 'first'
       assert.equal 'first', context_at(1).word.text
 
-    it "the word boundaries are determined using the variable word_pattern", ->
-      b.config.word_pattern = '[Əl]+'
+    it "the word boundaries are determined using the mode variable word_pattern", ->
+      b.mode = word_pattern: r'[Əl]+'
       assert.equal 'Əll', context_at(3).word.text
 
-      b.config.word_pattern = '["Ə%w]+'
+      b.mode = word_pattern: r'["Ə\\w]+'
       assert.equal '"HƏllo"', context_at(3).word.text
       assert.equal '"HƏllo"', context_at(8).word.text -- after "
       assert.equal '', context_at(9).word.text -- after ','
-
-    it "the word_pattern can be a regex", ->
-      b.config.word_pattern = r'\\pL+'
-      assert.equal 'HƏllo', context_at(3).word.text
 
   it ".word_prefix holds the words's text up until pos", ->
     assert.equal '', context_at(2).word_prefix

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -1,6 +1,8 @@
-import Buffer, config from howl
-import File from howl.io
-import with_tmpfile from File
+{:Buffer, :config} = howl
+{:File} = howl.io
+{:with_tmpfile} = File
+
+ffi = require 'ffi'
 
 describe 'Buffer', ->
   buffer = (text) ->
@@ -773,6 +775,37 @@ describe 'Buffer', ->
 
       it "accepts .byte_end_column as the end specifier", ->
         assert.same {1, 5}, {buf\resolve_span {byte_end_column: 6}, 1}
+
+  describe 'get_ptr(start_pos, end_pos)', ->
+    assert_returns = (s, count, ...) ->
+      r_ptr, r_count = ...
+      assert.equals count, r_count
+      assert.equals s, ffi.string(r_ptr, r_count)
+
+    it 'returns a pointer to a char buffer for the span, and a byte count', ->
+      b = buffer '123456789'
+      assert_returns '3456', 4, b\get_ptr(3, 6)
+
+      b = buffer '1åäö8'
+      assert_returns 'äö', 4, b\get_ptr(3, 4)
+
+    it 'handles boundary conditions', ->
+      b = buffer '123'
+      assert_returns '123', 3, b\get_ptr(1, 3)
+      assert_returns '1', 1, b\get_ptr(1, 1)
+
+    it 'raises errors for illegal span values', ->
+      b = buffer '123'
+      assert.raises 'Illegal', -> b\get_ptr -1, 2
+      assert.raises 'Illegal', -> b\get_ptr 1, 4
+      assert.raises 'Illegal', -> b\get_ptr 3, 4
+      assert.raises 'Illegal', -> b\get_ptr 4, 3
+      assert.raises 'Illegal', -> b\get_ptr 1, 0
+
+    it 'returns a read-only pointer', ->
+      b = buffer '123'
+      ptr = b\get_ptr 1, 1
+      assert.raises 'constant', -> ptr[0] = 88
 
   describe 'titles', ->
     it 'uses file basename as the default title', ->

--- a/spec/buffer_spec.moon
+++ b/spec/buffer_spec.moon
@@ -794,13 +794,15 @@ describe 'Buffer', ->
       assert_returns '123', 3, b\get_ptr(1, 3)
       assert_returns '1', 1, b\get_ptr(1, 1)
 
+    it 'returns a zero pointer for an empty range', ->
+      b = buffer ''
+      assert_returns '', 0, b\get_ptr(1, 0)
+
     it 'raises errors for illegal span values', ->
       b = buffer '123'
       assert.raises 'Illegal', -> b\get_ptr -1, 2
       assert.raises 'Illegal', -> b\get_ptr 1, 4
       assert.raises 'Illegal', -> b\get_ptr 3, 4
-      assert.raises 'Illegal', -> b\get_ptr 4, 3
-      assert.raises 'Illegal', -> b\get_ptr 1, 0
 
     it 'returns a read-only pointer', ->
       b = buffer '123'

--- a/spec/completion/in_buffer_completer_spec.moon
+++ b/spec/completion/in_buffer_completer_spec.moon
@@ -85,7 +85,7 @@ eat.food.
 *
 oo
 ]]
-      buffer.config.word_pattern = '[^/%s.]+'
+      buffer.config.word_pattern = r'[^/\\s.]+'
       assert.same { '*foo*' }, complete_at lines[3].end_pos
 
     context '(multiple buffers)', ->

--- a/spec/completion/in_buffer_completer_spec.moon
+++ b/spec/completion/in_buffer_completer_spec.moon
@@ -1,11 +1,16 @@
-import Buffer, app, completion  from howl
+{:Buffer, :app, :completion, :mode} = howl
+require 'howl.modes.default_mode'
 
 require 'howl.completion.in_buffer_completer'
 require 'howl.variables.core_variables'
 
 describe 'InBufferCompleter', ->
   setup ->
+    mode.register name: 'test_mode', create: -> {}
     close_all_buffers!
+
+  teardown ->
+    mode.unregister 'test_mode'
 
   describe 'complete()', ->
     local buffer, lines
@@ -17,7 +22,7 @@ describe 'InBufferCompleter', ->
       completer\complete context
 
     before_each ->
-      buffer = Buffer {}
+      buffer = Buffer mode.by_name 'default'
       lines = buffer.lines
 
     it 'returns completions for local matches in the buffer', ->
@@ -78,14 +83,14 @@ h
 ]]
       assert.same { 'häst', 'hellö' }, complete_at lines[3].end_pos
 
-    it 'detects existing words using the word_pattern variable', ->
+    it 'detects existing words using the word_pattern mode variable', ->
       buffer.text = [[
 *foo*/-bar
 eat.food.
 *
 oo
 ]]
-      buffer.config.word_pattern = r'[^/\\s.]+'
+      buffer.mode = word_pattern: r'\\*\\w+\\*'
       assert.same { '*foo*' }, complete_at lines[3].end_pos
 
     context '(multiple buffers)', ->
@@ -125,7 +130,7 @@ oo
 
       it 'skips buffers with a different mode if <config.inbuffer_completion_same_mode_only> is true', ->
         buffer.config.inbuffer_completion_same_mode_only = true
-        buffer2.mode = {}
+        buffer2.mode = mode.by_name 'test_mode'
         buffer.text = 'fry\nf'
         comps = complete_at buffer.lines[2].end_pos
         assert.same { 'fry', 'fabulous' }, comps

--- a/spec/ui/cursor_spec.moon
+++ b/spec/ui/cursor_spec.moon
@@ -3,7 +3,7 @@ import Editor from howl.ui
 Gtk = require 'ljglibs.gtk'
 
 describe 'Cursor', ->
-  buffer = Buffer {}
+  buffer = Buffer howl.mode.by_name 'default'
   editor = Editor buffer
   cursor = editor.cursor
   selection = editor.selection

--- a/spec/ui/editor_spec.moon
+++ b/spec/ui/editor_spec.moon
@@ -15,7 +15,7 @@ describe 'Editor', ->
   howl.app\pump_mainloop!
 
   before_each ->
-    buffer = Buffer {}
+    buffer = Buffer howl.mode.by_name 'default'
     buffer.config.indent = 2
     lines = buffer.lines
     editor.buffer = buffer

--- a/spec/ui/searcher_spec.moon
+++ b/spec/ui/searcher_spec.moon
@@ -8,7 +8,7 @@ describe 'Searcher', ->
   cursor = editor.cursor
 
   before_each ->
-    buffer = Buffer {}
+    buffer = Buffer howl.mode.by_name 'default'
     editor.buffer = buffer
 
   after_each -> searcher\cancel!


### PR DESCRIPTION
The in-buffer completer is now a _lot_ faster. I didn't bother with collecting the actual speedup numbers, but the improvement is massive. The slowness wasn't typically noticeable for ordinary files, but was readily apparent with unicode heavy files.

Also in this PR: 

- Added Buffer:get_ptr - a low level accessor for the fastest possible access to a buffer's content
- Changed the `word_pattern` configuration variable to be a mode variable instead