### PR TITLE
Make sure editor-move-{lines-down},{text-right} work properly at EOF

### DIFF
--- a/lib/howl/commands/edit_commands.moon
+++ b/lib/howl/commands/edit_commands.moon
@@ -195,7 +195,8 @@ command.register
     buffer\as_one_undo ->
       editor\with_selection_preserved ->
         buffer.lines\delete nr, nr
-        buffer.lines\insert last, text
+        editor\with_position_restored ->
+          buffer.lines\insert last, text
 
 command.register
   name: 'editor-move-lines-down'
@@ -227,7 +228,7 @@ command.register
       start_pos = editor.cursor.pos
       end_pos = start_pos + 1
 
-    return unless end_pos < #buffer
+    return unless end_pos <= #buffer
 
     buffer\as_one_undo ->
       editor\with_selection_preserved ->

--- a/spec/commands/edit_commands_spec.moon
+++ b/spec/commands/edit_commands_spec.moon
@@ -1,0 +1,55 @@
+import app, Buffer, command from howl
+import Window from howl.ui
+
+howl.commands.edit_commands
+
+describe 'edit_commands', ->
+  local buffer
+  app.window = Window!
+  app.editor = app\new_editor!
+  cursor = app.editor.cursor
+
+  before_each ->
+    buffer = Buffer howl.mode.by_name 'default'
+    buffer.config.indent = 2
+    buffer.text = 'abc\ndef\nghi'
+    app.editor.buffer = buffer
+
+  after_each ->
+    app\close_buffer buffer, true
+
+  describe 'editor-move-lines-up', ->
+    it 'moves the current line up', ->
+      cursor\move_to line: 2, column: 2
+      command.editor_move_lines_up!
+
+      assert.equal 'def\nabc\nghi', buffer.text
+      assert.equal 1, cursor.line
+      assert.equal 2, cursor.column
+
+    it 'works properly at EOF', ->
+      cursor\eof!
+      command.editor_move_lines_up!
+
+      assert.equal 'abc\nghi\ndef\n', buffer.text
+      assert.equal 2, cursor.line
+      assert.equal 4, cursor.column
+
+  describe 'editor-move-text-right', ->
+    it 'moves the current text to the right', ->
+      cursor\move_to line: 1, column: 1
+      command.editor_move_text_right!
+
+      assert.equal 'bac\ndef\nghi', buffer.text
+      assert.equal 1, cursor.line
+      assert.equal 2, cursor.column
+
+    it 'works properly right next to EOF', ->
+      cursor\eof!
+      cursor\left!
+      cursor\left!
+      command.editor_move_text_right!
+
+      assert.equal 'abc\ndef\ngih', buffer.text
+      assert.equal 3, cursor.line
+      assert.equal 3, cursor.column


### PR DESCRIPTION
Fixes #424, as well as another issue I found with `editor-move-text-right` at the second-to-last character.