### PR TITLE
Ensure that buffers always contain valid UTF-8

### DIFF
--- a/lib/howl/util/utf8.moon
+++ b/lib/howl/util/utf8.moon
@@ -1,0 +1,126 @@
+-- Copyright 2018 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+ffi = require 'ffi'
+const_char_p = ffi.typeof('const unsigned char *')
+{:max} = math
+ffi_copy, ffi_string = ffi.copy, ffi.string
+
+SEQ_LENS = ffi.new 'const int[256]', {
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+  0,0,0,0,0,0,0,0,0,0,0,0,-1,-1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
+  2,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,4,4,4,4,4,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,
+}
+
+REPLACEMENT_CHARACTER = "\xEF\xBF\xBD"
+REPLACEMENT_SIZE = #REPLACEMENT_CHARACTER
+
+char_arr = ffi.typeof 'char [?]'
+uint_arr = ffi.typeof 'unsigned int [?]'
+
+get_warts = (s, len = #s) ->
+  src = const_char_p s
+  w_size = 0
+  warts = nil
+  w_idx = 0
+  conts = 0
+  seq_start = nil
+  i = 0
+
+  mark = ->
+    if w_idx >= w_size - 2
+      old = warts
+      w_size = max 8192, w_size * 2
+      warts = uint_arr w_size
+      if old
+        ffi_copy warts, old, w_idx * ffi.sizeof('unsigned int')
+
+    pos = seq_start or i
+    warts[w_idx] = pos
+    w_idx += 1
+    i = pos
+    seq_start = nil
+    conts = 0
+
+  while i < len
+    b = src[i]
+    if b >= 128 -- non-ascii
+      if b < 192 -- continuation byte
+        if conts > 0
+          conts -= 1 -- ok continuation
+          if conts == 0
+            seq_start = nil -- end of seq
+        else
+          mark! -- unexpected continuation byte
+      else
+        -- should be a sequence start
+        s_len = SEQ_LENS[b]
+        if s_len < 0
+          mark! -- no, an illegal value
+        else
+          if conts > 0
+            mark! -- in the middle of seq already
+          else
+            -- new seq starting
+            seq_start = i
+            conts = s_len - 1
+    else -- ascii
+      if conts > 0
+        mark! -- expected continuation byte instead of ascii
+      elseif b == 0
+        mark! -- zero byte
+
+    i += 1
+
+  if seq_start -- broken at end
+    mark!
+
+  size_delta = w_idx * (#REPLACEMENT_CHARACTER - 1)
+  nlen = len + size_delta + 1 -- additional size for \0
+  warts, w_idx, nlen
+
+clean = (s, len = #s) ->
+  src = const_char_p s
+  warts, wart_count, nlen = get_warts s, len
+
+  if wart_count == 0
+    return src, len, 0
+
+  -- create new valid string
+  dest = char_arr nlen
+  src_idx = 0
+  dest_idx = 0
+
+  for i = 0, wart_count - 1
+    at = warts[i]
+    diff = at - src_idx
+    if diff > 0 -- copy any content up until the wart
+      ffi_copy dest + dest_idx, src + src_idx, diff
+      dest_idx += diff
+
+    -- the replacement character
+    ffi_copy dest + dest_idx, REPLACEMENT_CHARACTER, REPLACEMENT_SIZE
+    dest_idx += REPLACEMENT_SIZE
+    src_idx = at + 1
+
+  diff = len - src_idx
+  if diff > 0 -- copy any content up until the end
+    ffi_copy dest + dest_idx, src + src_idx, diff
+
+  dest, nlen - 1, wart_count
+
+clean_string = (s, len = #s) ->
+  ptr, len, wart_count = clean s, len
+  return s, 0 unless wart_count != 0
+  ffi_string(ptr, len), wart_count
+
+is_valid = (s, len = #s) ->
+  _, wart_count, _ = get_warts const_char_p(s), len
+  wart_count != 0
+
+:clean, :clean_string, :is_valid

--- a/lib/ljglibs/cdefs/glib.moon
+++ b/lib/ljglibs/cdefs/glib.moon
@@ -60,6 +60,7 @@ ffi.cdef [[
   gint    g_utf8_collate(const gchar *str1, const gchar *str2);
   gchar * g_utf8_substring(const gchar *str, glong start_pos, glong end_pos);
   gboolean g_utf8_validate (const gchar *str, gssize max_len, const gchar **end);
+  gchar * g_utf8_make_valid (const gchar *str, gssize len);
   gint    g_unichar_to_utf8(gunichar c, gchar *outbuf);
   gchar * g_strndup(const gchar *str, gssize n);
 

--- a/spec/util/utf8_spec.moon
+++ b/spec/util/utf8_spec.moon
@@ -1,0 +1,138 @@
+-- Copyright 2018 The Howl Developers
+-- License: MIT (see LICENSE.md at the top-level directory of the distribution)
+
+{:clean, :is_valid} = require 'howl.util.utf8'
+{:get_monotonic_time} = require 'ljglibs.glib'
+ffi = require 'ffi'
+C = ffi.C
+
+to_hex_string = (s) ->
+  parts = {}
+  for i = 1, #s
+    parts[#parts + 1] = '\\x' .. string.format('%02x', s\byte(i))
+  table.concat parts, ' '
+
+describe 'utf8', ->
+
+  describe 'clean(s)', ->
+    glib_make_valid = (s) ->
+      ptr = C.g_utf8_make_valid(s, #s)
+      s = ffi.string ptr
+      C.g_free(ptr)
+      s
+
+    utf8_clean = (s) ->
+      r, size = clean s
+      ffi.string r, size
+
+    assert_clean = (s, expected) ->
+      rs = utf8_clean s
+      unless rs == expected
+        assert.equal to_hex_string(expected), to_hex_string(rs)
+
+    it 'returns a clean string as is', ->
+      assert_clean '123456789', '123456789'
+      assert_clean "åäöƏ⏱🌨", "åäöƏ⏱🌨"
+
+    it 'cleans up incorrect dual sequences', ->
+      assert_clean '|\xc3\x24|', '|�$|'
+      assert_clean '|\xc3\x24\xc3\x61|', '|�$�a|'
+      assert_clean '|\xc3\x24X\xc3\x61|', '|�$X�a|'
+
+    it 'cleans up incorrect three-byte sequences', ->
+      -- -- incorrect at second seq byte
+      assert_clean '|\xe1\x24|', '|�$|'
+
+      -- incorrect at third seq byte
+      assert_clean '|\xe1\x80\x24|', '|��$|'
+
+    it 'cleans up incorrect four-byte sequences', ->
+      -- incorrect at second seq byte
+      assert_clean '|\xf0\x24|', '|�$|'
+
+      -- incorrect at third seq byte
+      assert_clean '|\xf0\x80\x24|', '|��$|'
+
+      -- incorrect at fourth seq byte
+      assert_clean '|\xf0\x80\x80\x24|', '|���$|'
+
+    it 'cleans up stray continuation bytes', ->
+      assert_clean '|\x80|', '|�|'
+      assert_clean '|\x80\x80|', '|��|'
+      assert_clean '\x80|', '�|'
+      assert_clean '|\x80', '|�'
+      assert_clean '\xc2\xa9\xa9', '©�'
+
+    it 'cleans up illegal bytes', ->
+      for b = 192, 193
+         assert_clean "|#{string.char(b)}|", '|�|'
+
+      for b = 245, 255
+         assert_clean "|#{string.char(b)}|", '|�|'
+
+    it 'cleans up broken utf8 at the end', ->
+      assert_clean '\x8d\xc7\xe0', '���'
+
+    it 'handles sequence starts within sequences', ->
+      assert_clean '\xc7\xe0\x60\x28\x8c', '��`(�'
+
+    it 'handles illegal values in sequences', ->
+      assert_clean '\xc4\xf7\x61\xb9', '��a�'
+
+    -- below are some comparison runs with the builtin glib variants useful
+    -- for performance testing
+    if false
+      time = (title, f) ->
+        start = get_monotonic_time!
+        f!
+        done = get_monotonic_time!
+        elapsed = (done - start) / 1000000
+        print "'#{title}': #{elapsed} elapsed"
+
+      it 'performance', ->
+        valid = string.rep 'abcdefghijklmnopqrstuvxyzABCDEFGHIJKLMNOPQRSTUVXYZ', 1000
+
+        for i = 1, 100
+          C.g_utf8_validate valid, #valid, nil
+
+        time 'g_utf8_validate', ->
+          for i = 1, 1000
+            C.g_utf8_validate valid, #valid, nil
+
+        for i = 1, 100
+          is_valid valid
+
+        time 'own is_valid', ->
+          for i = 1, 1000
+            is_valid valid
+
+        for i = 1, 100
+          glib_make_valid(valid)
+
+        time 'g_utf8_make_valid CLEAN', ->
+          for i = 1, 1000
+            ptr = C.g_utf8_make_valid(valid, #valid)
+            C.g_free(ptr)
+
+        for i = 1, 100
+          clean valid
+
+        time 'own clean CLEAN', ->
+          for i = 1, 1000
+            clean valid
+
+        broken = string.rep 'ab⏱🌨\xc3\x24hiåäömn\xe1\x80\x24opq\xf0\x24', 1000
+        for i = 1, 100
+          glib_make_valid(broken)
+
+        time 'g_utf8_make_valid BROKEN', ->
+          for i = 1, 1000
+            ptr = C.g_utf8_make_valid(broken, #broken)
+            C.g_free(ptr)
+
+        for i = 1, 100
+          clean broken
+
+        time 'own clean BROKEN', ->
+          for i = 1, 1000
+            clean broken


### PR DESCRIPTION
There are a couple of reasons why this is always a good idea:

- Various routines in glib, etc., expects valid UTF-8. This is not a case of
  it just being better in general either - I've seen the regex engine segfault
  when attempting text-matching over invalid UTF-8 :(

- Our own offset caching does not behave exactly the same was a glib when
  calculating the length of broken UTF-8. This cause mismatch errors when
  doing boundary checks.

We use our own custom-written module for cleaning up UTF-8. There is also
a more performant variant available in glib, `g_utf8_make_valid`, but that
isn't available before glib 2.52 which was released only in 2017.