### PR TITLE
Add some background image enhancements

### DIFF
--- a/lib/ljglibs/aux/background.moon
+++ b/lib/ljglibs/aux/background.moon
@@ -166,7 +166,7 @@ class Background
 
     if color
       @_fill_with_color cr, color, @opts.alpha
-    elseif image
+    if image
       @_fill_with_image cr, image
 
     if gradient
@@ -184,11 +184,17 @@ class Background
     if image.repeat == 'stretch'
       pb = Pixbuf.new_from_file_at_scale tostring(image.path), @width, @height, false
       Gdk.cairo.set_source_pixbuf cr, pb, 0, 0
-      cr\fill_preserve!
     else
       pb = Pixbuf.new_from_file tostring(image.path)
       Gdk.cairo.set_source_pixbuf cr, pb, 0, 0
       cr.source.extend = cairo.EXTEND_REPEAT
+
+    if image.alpha
+      cr\save!
+      cr\clip_preserve!
+      cr\paint_with_alpha image.alpha
+      cr\restore!
+    else
       cr\fill_preserve!
 
   _fill_with_gradient: (cr, gradient) =>

--- a/lib/ljglibs/cairo/context.moon
+++ b/lib/ljglibs/cairo/context.moon
@@ -99,6 +99,7 @@ core.define 'cairo_t', {
   stroke_preserve: => C.cairo_stroke_preserve @
   fill: => C.cairo_fill @
   fill_preserve: => C.cairo_fill_preserve @
+  paint_with_alpha: (alpha) => C.cairo_paint_with_alpha @, alpha
   line_to: (x, y) => C.cairo_line_to @, x, y
   rel_line_to: (dx, dy) => C.cairo_rel_line_to @, dx, dy
   move_to: (x, y) => C.cairo_move_to @, x, y


### PR DESCRIPTION
You can now set an alpha value for a background image. In addition, if you specify a color *and* an image, the color will be used as a background for the image, meaning that you can set an alpha value for the image and have it blended with the color.