### PR TITLE
Flatpak!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.flatpak-builder/
 src/deps/*/*
 src/*.o
 src/howl

--- a/io.howl.Editor.yaml
+++ b/io.howl.Editor.yaml
@@ -1,0 +1,69 @@
+app-id: io.howl.Editor
+runtime: org.gnome.Platform
+runtime-version: 3.28
+sdk: org.gnome.Sdk
+command: howl
+rename-appdata-file: howl
+rename-desktop-file: howl.desktop
+rename-icon: howl
+copy-icon: true
+finish-args:
+  - '--share=ipc'
+  - '--share=network'
+  - '--socket=x11'
+  - '--socket=wayland'
+  - '--filesystem=host'
+  - '--own-name=io.howl.*'
+  - '--talk-name=org.freedesktop.Flatpak'
+add-extensions:
+  io.howl.Editor.Bundle:
+    version: '1'
+    directory: bundles
+    merge-dirs: share/howl/bundles
+    subdirectories: true
+    no-autodownload: true
+    autodelete: true
+modules:
+  - name: howl
+    buildsystem: simple
+    build-commands:
+      - 'make -C src install PREFIX=$FLATPAK_DEST'
+    post-install:
+      - 'install -d /app/bundles'
+    sources:
+      - type: archive
+        url: 'http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz'
+        sha256: '1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3'
+        strip-components: 0
+        dest: 'src/deps'
+      - type: archive
+        url: 'http://nordman.org/mirror/lpeg/lpeg-0.10.2.tar.gz'
+        sha256: 'd1a7698e4bcd0ac305633774062d22b27300a41673c3d733ea9993244a64ea6f'
+        strip-components: 0
+        dest: 'src/deps'
+      - type: file
+        path: 'lint_config.moon'
+        dest-filename: 'lint_config.moon'
+      - type: dir
+        path: 'bin'
+        dest: 'bin'
+      - type: dir
+        path: 'bundles'
+        dest: 'bundles'
+      - type: dir
+        path: 'fonts'
+        dest: 'fonts'
+      - type: dir
+        path: 'lib'
+        dest: 'lib'
+      - type: dir
+        path: 'share'
+        dest: 'share'
+      - type: dir
+        path: 'spec'
+        dest: 'spec'
+      - type: dir
+        path: 'src'
+        dest: 'src'
+    cleanup:
+      - '/share/howl/lib/scripts'

--- a/lib/howl/application.moon
+++ b/lib/howl/application.moon
@@ -360,6 +360,8 @@ class Application extends PropertyObject
         fonts_dir = @settings.dir\join('fonts')
         if fonts_dir.exists
           C.FcConfigAppFontAddDir(nil, fonts_dir.path)
+      if howl.sys.info.flatpak
+        append bundle.dirs, File '/app/bundles'
 
       bundle.load_all!
 

--- a/lib/howl/io/process.moon
+++ b/lib/howl/io/process.moon
@@ -52,6 +52,10 @@ launch = (argv, p_opts) ->
   append flags, 'STDERR_TO_DEV_NULL' unless p_opts.read_stderr
   working_directory = p_opts.working_directory and tostring p_opts.working_directory
 
+  if howl.sys.info.flatpak
+    table.insert argv, 1, 'flatpak-spawn'
+    table.insert argv, 2, '--host'
+
   opts = {
     write_stdin: p_opts.write_stdin
     read_stdout: p_opts.read_stdout

--- a/lib/howl/settings.moon
+++ b/lib/howl/settings.moon
@@ -2,13 +2,14 @@ serpent = require 'serpent'
 
 import File from howl.io
 import SandboxedLoader from howl.util
-{:env} = howl.sys
+import sys from howl
 
 default_dir = ->
-  howl_dir = env.HOWL_DIR
+  return File(sys.env.XDG_DATA_HOME) if sys.info.flatpak
+  howl_dir = sys.env.HOWL_DIR
   return File(howl_dir) if howl_dir
-  home = env.HOME
-  xdg_config_home = env.XDG_CONFIG_HOME
+  home = sys.env.HOME
+  xdg_config_home = sys.env.XDG_CONFIG_HOME
 
   -- if none of these are set, we won't be able to find config
   unless home or xdg_config_home

--- a/lib/howl/sys.moon
+++ b/lib/howl/sys.moon
@@ -36,5 +36,6 @@ time = -> glib.get_real_time! / 1000000
   :time,
   info: {
     os: jit.os\lower!
+    flatpak: File('/.flatpak-info').exists
   }
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,8 +5,10 @@ GTK = gtk+-3.0
 GTK_CFLAGS = $(shell pkg-config --cflags $(GTK))
 GTK_LIBS = $(shell pkg-config --libs $(GTK) gmodule-2.0 gio-unix-2.0)
 
+# If you change the versions and checksums, make sure to also update io.howl.Editor.yaml.
+
 LUAJIT_VER = LuaJIT-2.1.0-beta3
-LUAJIT_CHECKSUM = eae40bc29d06ee5e3078f9444fcea39b
+LUAJIT_CHECKSUM = 1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3
 LUAJIT = deps/${LUAJIT_VER}
 LUAJIT_SRC_DIR = $(realpath $(LUAJIT)/src)
 LUAJIT_CFLAGS = -I$(LUAJIT_SRC_DIR)
@@ -14,7 +16,7 @@ LUAJIT_ARCHIVE = $(LUAJIT)/src/libluajit.a
 LUAJIT_URL = http://luajit.org/download/$(LUAJIT_VER).tar.gz
 
 LPEG_VER = lpeg-0.10.2
-LPEG_CHECKSUM = 1402433f02e37ddadff04a3d4118b026
+LPEG_CHECKSUM = d1a7698e4bcd0ac305633774062d22b27300a41673c3d733ea9993244a64ea6f
 LPEG = deps/$(LPEG_VER)
 LPEG_OBJECT = $(LPEG)/lpeg.o
 LPEG_URL = http://nordman.org/mirror/lpeg/$(LPEG_VER).tar.gz
@@ -23,10 +25,10 @@ CFLAGS = -Wall -O2 -g $(LUAJIT_CFLAGS) $(GTK_CFLAGS) -DHOWL_PREFIX=$(PREFIX)
 ARCHIVES = $(LUAJIT_ARCHIVE)
 LIBS = -lm -ldl ${GTK_LIBS}
 ifeq ($(UNAME_S),FreeBSD)
-    LIBS = -lm ${GTK_LIBS}
+	LIBS = -lm ${GTK_LIBS}
 endif
 ifeq ($(UNAME_S),OpenBSD)
-    LIBS = -lm ${GTK_LIBS}
+	LIBS = -lm ${GTK_LIBS}
 endif
 ifeq ($(UNAME_S),Darwin)
 	LD_FLAGS = -Wl,-export_dynamic -pagezero_size 10000 -image_base 100000000
@@ -63,8 +65,8 @@ deps-purge:
 	rm -rf $(LUAJIT) $(LPEG)
 
 deps-clean:
-	@rm $(LPEG_OBJECT) || true
-	@cd $(LUAJIT) && $(MAKE) clean
+	@rm -f $(LPEG_OBJECT) || true
+	@[ -d $(LUAJIT) ] && cd $(LUAJIT) && $(MAKE) clean || true
 
 clean:
 	-rm -f ${OBJECTS}

--- a/src/tools/download
+++ b/src/tools/download
@@ -4,7 +4,7 @@
 # License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 os=`uname -s`
-([ "$os" = "Darwin" ] || [ "$os" = "FreeBSD" ] || [ "$os" = "OpenBSD" ]) && md5="md5 -r" || md5=md5sum
+([ "$os" = "Darwin" ] || [ "$os" = "FreeBSD" ] || [ "$os" = "OpenBSD" ]) && sha256="shasum -b -a 256" || sha256=sha256sum
 
 file=$1; shift
 checksum=$1; shift
@@ -22,7 +22,7 @@ fi
 echo "Downloading $file.."
 wget -O $tmp $file || exit 1
 
-file_checksum=$($md5 $tmp | awk '{print $1}')
+file_checksum=$($sha256 $tmp | awk '{print $1}')
 
 if [ "$checksum" != "$file_checksum" ]; then
   echo "ERROR: Checksum mismatch for $file (expected $checksum, got $file_checksum)"


### PR DESCRIPTION
There are some niceties that come along with this:

- New user wants to try out new changes? They can just use `flatpak-builder` to build and run a Flatpak without having to install dependencies and such.
- This would let us put Howl on Flathub, which would make installation rather nice and *incredibly* easy.