### PR TITLE
Fix running external commands from Flatpak Howl

### DIFF
--- a/lib/howl/sys.moon
+++ b/lib/howl/sys.moon
@@ -23,8 +23,8 @@ find_executable = (name) ->
   return File(name).exists if File.is_absolute(name)
 
   if is_flatpak
-    stdout, stderr = Process.execute {'which', name}
-    if #stderr == 0
+    stdout, _, p = Process.execute {'which', name}
+    if p.successful
       return stdout.stripped
   else
     path = env.PATH

--- a/src/io.howl.Editor.yaml
+++ b/src/io.howl.Editor.yaml
@@ -1,9 +1,9 @@
 app-id: io.howl.Editor
 runtime: org.gnome.Platform
-runtime-version: 3.28
+runtime-version: 3.30
 sdk: org.gnome.Sdk
 command: howl
-rename-appdata-file: howl
+rename-appdata-file: howl.appdata.xml
 rename-desktop-file: howl.desktop
 rename-icon: howl
 copy-icon: true


### PR DESCRIPTION
Basically, an app inside a Flatpak doesn't have full access to the host environment, meaning just trying to read `PATH` won't work.

This leaves out `lib/howl/interactions/external_command.moon`'s autocomplete capabilities, which I'm still trying to figure out how to cleanly fix...