### PR TITLE
Some quick fixes for Flatpak and JS bundle

### DIFF
--- a/bundles/javascript/javascript_lexer.moon
+++ b/bundles/javascript/javascript_lexer.moon
@@ -16,7 +16,7 @@ howl.util.lpeg_lexer ->
     'typeof', 'var', 'void', 'while', 'with', 'yield'
   }
 
-  operator = c 'operator', S'+-*/%=<>&^|!(){}[].,;'
+  operator = c 'operator', S'+-*/%=<>&^|!(){}[].,?:;'
 
   comment = c 'comment', any {
     P'//' * scan_until eol,

--- a/src/io.howl.Editor.yaml
+++ b/src/io.howl.Editor.yaml
@@ -1,6 +1,6 @@
 app-id: io.howl.Editor
 runtime: org.gnome.Platform
-runtime-version: 3.30
+runtime-version: '3.30'
 sdk: org.gnome.Sdk
 command: howl
 rename-appdata-file: howl.appdata.xml
@@ -15,6 +15,11 @@ finish-args:
   - '--filesystem=host'
   - '--own-name=io.howl.*'
   - '--talk-name=org.freedesktop.Flatpak'
+  # Add dconf so GTK can read its theme properly
+  - '--filesystem=xdg-run/dconf'
+  - '--filesystem=~/.config/dconf:ro'
+  - '--talk-name=ca.desrt.dconf'
+  - '--env=DCONF_USER_CONFIG_DIR=.config/dconf'
 add-extensions:
   io.howl.Editor.Bundle:
     version: '1'


### PR DESCRIPTION
- Adds dconf support to the Flatpak so it'll read GTK themes properly + quotes the runtime-version. (Considering I'm the one who added the warning to flatpak-builder, you'd think I'd have remembered to fix it here...)
- Adds `?` and `:` to the JS operators because they were weirdly missing (?), and I didn't catch it on my previous JS bundle fixup.