### PR TITLE
[WIp] Automated nightly Howl Flatpak builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,19 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- master
+
+pool:
+  vmImage: 'Ubuntu-16.04'
+
+steps:
+- script: echo Hello, world!
+  displayName: 'Run a one-line script'
+
+- script: |
+    echo Add other tasks to build, test, and deploy your project.
+    echo See https://aka.ms/yaml
+  displayName: 'Run a multi-line script'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,21 +1,17 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
 trigger:
 - master
 
 pool:
   vmImage: 'Ubuntu-16.04'
 
-container: 'fedora:29'
+container: 'registry.gitlab.gnome.org/gnome/gnome-runtime-images/gnome:3.30'
 
 steps:
-- script: echo Hello, world!
-  displayName: 'Run a one-line script'
-
-- script: |
-    echo Add other tasks to build, test, and deploy your project.
-    echo See https://aka.ms/yaml
-  displayName: 'Run a multi-line script'
+- displayName: 'Build the Flatpak'
+  script: |
+    flatpak-builder --repo repo build src/io.howl.Editor.yaml
+    flatpak build-bundle repo howl.flatpak io.howl.Editor
+- tasks: PublishPipelineArtifact@0
+  inputs:
+    artifactName: 'howl.flatpak'
+    targetPath: 'howl.flatpak'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
     steps:
       - task: DownloadPipelineArtifact@0
         inputs:
+          artifactName: 'Flatpak bundle'
           targetPath: $(System.DefaultWorkingDirectory)
       - task: DownloadSecureFile@1
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,11 +4,13 @@ trigger:
 pool:
   vmImage: 'Ubuntu-16.04'
 
-container: 'registry.gitlab.gnome.org/gnome/gnome-runtime-images/gnome:3.30'
+container:
+  image: 'registry.gitlab.gnome.org/gnome/gnome-runtime-images/gnome:3.30'
+  options: --privileged
 
 steps:
   - script: |
-      flatpak-builder --repo repo build src/io.howl.Editor.yaml
+      flatpak-builder --disable-rofiles-fuse --repo repo build src/io.howl.Editor.yaml
       flatpak build-bundle repo howl.flatpak io.howl.Editor
     displayName: 'Build the Flatpak'
   - task: PublishPipelineArtifact@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ steps:
   script: |
     flatpak-builder --repo repo build src/io.howl.Editor.yaml
     flatpak build-bundle repo howl.flatpak io.howl.Editor
-- tasks: PublishPipelineArtifact@0
+- task: PublishPipelineArtifact@0
   inputs:
     artifactName: 'howl.flatpak'
     targetPath: 'howl.flatpak'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
 
   - job: FlatpakRepoDeploy
     dependsOn: FlatpakBuild
-    condition: eq(variables('Build.Reason'), 'Schedule')
+    condition: eq(variables['Build.Reason'], 'Schedule')
     container:
       image: 'google/cloud-sdk'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
         inputs:
           secureFile: gc-account.json
       - script: |
-          env | grep -i temp
+          apt install flatpak ostree
           gcloud auth activate-service-account --key-file $DOWNLOADSECUREFILE_SECUREFILEPATH
           gsutil -m cp -r gs://howl-dl/repo .
           ostree init --repo=repo --mode=archive

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,14 +1,14 @@
 trigger:
 - master
 
-pool:
-  vmImage: 'Ubuntu-16.04'
-
 jobs:
   - job: FlatpakBuild
     container:
       image: 'registry.gitlab.gnome.org/gnome/gnome-runtime-images/gnome:3.30'
       options: --privileged
+
+    pool:
+      vmImage: 'Ubuntu-16.04'
 
     steps:
       - script: |
@@ -25,6 +25,9 @@ jobs:
     condition: eq(variables('Build.Reason'), 'Schedule')
     container:
       image: 'google/cloud-sdk'
+
+    pool:
+      vmImage: 'Ubuntu-16.04'
 
     steps:
       - task: DownloadPipelineArtifact@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,8 @@ trigger:
 pool:
   vmImage: 'Ubuntu-16.04'
 
+container: 'fedora:29'
+
 steps:
 - script: echo Hello, world!
   displayName: 'Run a one-line script'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
     dependsOn: FlatpakBuild
     # condition: eq(variables['Build.Reason'], 'Schedule')
     container:
-      image: 'google/cloud-sdk'
+      image: 'quay.io/refi64/gcloud-flatpak'
 
     pool:
       vmImage: 'Ubuntu-16.04'
@@ -38,7 +38,6 @@ jobs:
         inputs:
           secureFile: gc-account.json
       - script: |
-          sudo apt install flatpak ostree
           gcloud auth activate-service-account --key-file $DOWNLOADSECUREFILE_SECUREFILEPATH
           gsutil -m cp -r gs://howl-dl/repo .
           ostree init --repo=repo --mode=archive

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,16 +4,42 @@ trigger:
 pool:
   vmImage: 'Ubuntu-16.04'
 
-container:
-  image: 'registry.gitlab.gnome.org/gnome/gnome-runtime-images/gnome:3.30'
-  options: --privileged
+jobs:
+  - job: FlatpakBuild
+    container:
+      image: 'registry.gitlab.gnome.org/gnome/gnome-runtime-images/gnome:3.30'
+      options: --privileged
 
-steps:
-  - script: |
-      flatpak-builder --disable-rofiles-fuse --repo repo build src/io.howl.Editor.yaml
-      flatpak build-bundle repo howl.flatpak io.howl.Editor
-    displayName: 'Build the Flatpak'
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: 'howl.flatpak'
-      targetPath: 'howl.flatpak'
+    steps:
+      - script: |
+          flatpak-builder --disable-rofiles-fuse --repo repo build src/io.howl.Editor.yaml
+          flatpak build-bundle repo howl.flatpak io.howl.Editor
+        displayName: Flatpak Build
+      - task: PublishPipelineArtifact@0
+        inputs:
+          artifactName: 'Flatpak bundle'
+          targetPath: 'howl.flatpak'
+
+  - job: FlatpakRepoDeploy
+    dependsOn: FlatpakBuild
+    condition: eq(variables('Build.Reason'), 'Schedule')
+    container:
+      image: 'google/cloud-sdk'
+
+    steps:
+      - task: DownloadPipelineArtifact@0
+        inputs:
+          targetPath: $(System.DefaultWorkingDirectory)
+      - task: DownloadSecureFile@1
+        inputs:
+          secureFile: gc-account.json
+      - script: |
+          env | grep -i temp
+          gcloud auth activate-service-account --key-file $DOWNLOADSECUREFILE_SECUREFILEPATH
+          gsutil -m cp -r gs://howl-dl/repo .
+          ostree init --repo=repo --mode=archive
+          flatpak build-import-bundle repo howl.flatpak
+          flatpak build-sign repo
+          flatpak build-update-repo --generate-static-deltas repo
+          gsutil -m cp -r repo gs://howl-dl/
+        displayName: 'Push to Google Cloud Storage'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
         inputs:
           secureFile: gc-account.json
       - script: |
-          apt install flatpak ostree
+          sudo apt install flatpak ostree
           gcloud auth activate-service-account --key-file $DOWNLOADSECUREFILE_SECUREFILEPATH
           gsutil -m cp -r gs://howl-dl/repo .
           ostree init --repo=repo --mode=archive

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,11 +7,11 @@ pool:
 container: 'registry.gitlab.gnome.org/gnome/gnome-runtime-images/gnome:3.30'
 
 steps:
-- displayName: 'Build the Flatpak'
-  script: |
-    flatpak-builder --repo repo build src/io.howl.Editor.yaml
-    flatpak build-bundle repo howl.flatpak io.howl.Editor
-- task: PublishPipelineArtifact@0
-  inputs:
-    artifactName: 'howl.flatpak'
-    targetPath: 'howl.flatpak'
+  - script: |
+      flatpak-builder --repo repo build src/io.howl.Editor.yaml
+      flatpak build-bundle repo howl.flatpak io.howl.Editor
+    displayName: 'Build the Flatpak'
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'howl.flatpak'
+      targetPath: 'howl.flatpak'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
 
   - job: FlatpakRepoDeploy
     dependsOn: FlatpakBuild
-    # condition: eq(variables['Build.Reason'], 'Schedule')
+    condition: eq(variables['Build.Reason'], 'Schedule')
     container:
       image: 'quay.io/refi64/gcloud-flatpak'
 
@@ -43,6 +43,6 @@ jobs:
           ostree init --repo=repo --mode=archive
           flatpak build-import-bundle repo howl.flatpak
           flatpak build-sign repo
-          flatpak build-update-repo --generate-static-deltas repo
+          flatpak build-update-repo --generate-static-deltas --prune --prune-depth=2 repo
           gsutil -m cp -r repo gs://howl-dl/
         displayName: 'Push to Google Cloud Storage'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
 
   - job: FlatpakRepoDeploy
     dependsOn: FlatpakBuild
-    condition: eq(variables['Build.Reason'], 'Schedule')
+    # condition: eq(variables['Build.Reason'], 'Schedule')
     container:
       image: 'google/cloud-sdk'
 

--- a/src/io.howl.Editor.yaml
+++ b/src/io.howl.Editor.yaml
@@ -1,6 +1,6 @@
 app-id: io.howl.Editor
 runtime: org.gnome.Platform
-runtime-version: '3.30'
+runtime-version: '3.32'
 sdk: org.gnome.Sdk
 command: howl
 rename-appdata-file: howl.appdata.xml


### PR DESCRIPTION
Basically, it is what it says. You can try out the repo:

```bash
# Add the remote
flatpak remote-add --user --no-gpg-verify howl-nightly https://storage.googleapis.com/howl-dl/repo
# List the refs inside
flatpak remote-ls howl-nightly
# Install Howl nightly
flatpak install howl-nightly io.howl.Editor
```

### Why is this [WIP]?

There are four more things that probably need to be done:

- Right now the cloud bucket bucket name is just `howl-dl`. If we want to use a shorter URL, e.g. off the howl.io domain (something like `dl.howl.io`), it needs to be changed here to match.
- Dropping `--no-gpg-verify` is generally a good thing, but first the commits need to be GPG-signed. In general using a new, separate key from anyone's normal one is preferred, but I wasn't sure if @nilnor would prefer it point to e.g. his email or mine or something else, so I didn't create one yet.
- Related to the above, we can create a `.flatpakrepo` file that a user can double-click to automatically add the remote, but it depends on GPG signatures being enabled, so see the above point.
- Make artifacts public (see below).

In addition to the scheduled "nightly" builds (I haven't actually enabled the trigger yet), Azure Pipelines will build a Flatpak bundle for every PR or commit. So, if someone wants to try something out, they can just download the Flatpak bundle and install it to give that PR / commit / whatever a spin. You can see the current bundles [here](https://dev.azure.com/howl-editor/howl/_build), just select a build, then go to Artifacts -> Flatpak bundle -> download howl.flatpak. These artifacts need to be published in a slightly different way to make them public but I haven't done that yet.

So yeah, initial feedback welcome. :grin:

**EDIT:** Also the commit history is a mess, please squash when merging.