### PR TITLE
Support using curl to download

### DIFF
--- a/site/source/getit.md
+++ b/site/source/getit.md
@@ -32,8 +32,8 @@ __Release notes:__
 
 Howl requires the following build dependencies:
 
-- `wget`: For auto-downloading build dependencies (only needed when building
-from a code checkout, as the release tarball contains pre-downloaded
+- `curl` or `wget`: For auto-downloading build dependencies (only needed when
+building from a code checkout, as the release tarball contains pre-downloaded
 dependencies).
 
 - `GTK+`: Version >= 3, with development files.

--- a/src/tools/download
+++ b/src/tools/download
@@ -20,7 +20,11 @@ if [ -z "$tmp" ]; then
 fi
 
 echo "Downloading $file.."
-wget -O $tmp $file || exit 1
+if which curl >/dev/null 2>&1; then
+  curl -Lo $tmp $file || exit 1
+else
+  wget -O $tmp $file || exit 1
+fi
 
 file_checksum=$($sha256 $tmp | awk '{print $1}')
 


### PR DESCRIPTION
Many distros now ship with curl but not wget out-of-the-box.