### PR TITLE
Make File.with_tmpfile() return the callback result.

### DIFF
--- a/lib/howl/io/file.moon
+++ b/lib/howl/io/file.moon
@@ -39,9 +39,12 @@ class File extends PropertyObject
 
   with_tmpfile: (f) ->
     file = File.tmpfile!
-    status, err = pcall f, file
+    result = { pcall f, file }
     file\delete_all! if file.exists
-    error err if not status
+    if result[1]
+      error result[2]
+    else
+      table.unpack result, 2
 
   is_absolute: (path) ->
     (path\match('^/') or path\match('^%a:\\\\')) != nil

--- a/lib/howl/io/file.moon
+++ b/lib/howl/io/file.moon
@@ -42,9 +42,9 @@ class File extends PropertyObject
     result = { pcall f, file }
     file\delete_all! if file.exists
     if result[1]
-      error result[2]
-    else
       table.unpack result, 2
+    else
+      error result[2]
 
   is_absolute: (path) ->
     (path\match('^/') or path\match('^%a:\\\\')) != nil

--- a/site/source/doc/api/io/file.md
+++ b/site/source/doc/api/io/file.md
@@ -192,7 +192,7 @@ not be automatically deleted.
 
 Invokes `callback` with a File instance pointing to an existing temporary file.
 The temporary file will be automatically deleted upon the return of `callback`,
-if it exists.
+if it exists. Returns the values returned by `callback`.
 
 ## Methods
 

--- a/spec/io/file_spec.moon
+++ b/spec/io/file_spec.moon
@@ -25,6 +25,13 @@ describe 'File', ->
       assert.raises 'noo', -> File.with_tmpfile f
       assert.is_false tmpfile.exists
 
+    it 'returns the return values of <f>', ->
+      f = (file) -> "abc", b: 1
+
+      str, tab = File.with_tmpfile f
+      assert.equals "abc", str
+      assert.same {b: 1}, tab
+
   describe 'tmpdir()', ->
     it 'returns a file instance pointing to an existing directory', ->
       file = File.tmpdir!


### PR DESCRIPTION
`File.with_tmpfile()` now returns the return values of the passed callback, if successful, instead of an unhelpful `nil`.