### PR TITLE
Positive number snake case

### DIFF
--- a/lib/howl/breadcrumbs.moon
+++ b/lib/howl/breadcrumbs.moon
@@ -329,14 +329,14 @@ config.define
   name: 'breadcrumb_limit'
   description: 'The maximum number of breadcrumbs to keep'
   scope: 'global'
-  type_of: 'positive-number'
+  type_of: 'positive_number'
   default: 200
 
 config.define
   name: 'breadcrumb_tolerance'
   description: 'Distance in positions for which breadcrumbs are merged or skipped over'
   scope: 'global'
-  type_of: 'positive-number'
+  type_of: 'positive_number'
   default: 10
 
 -- track last edit with a breadcrumb

--- a/lib/howl/config.moon
+++ b/lib/howl/config.moon
@@ -25,7 +25,7 @@ predefined_types =
     validate: (value) -> type(value) == 'number'
   },
 
-  'positive-number': {
+  positive_number: {
     convert: (value) -> tonumber(value) or tonumber(tostring(value)) or value
     validate: (value) -> type(value) == 'number' and value >= 0
   },

--- a/site/source/doc/api/config.md
+++ b/site/source/doc/api/config.md
@@ -163,6 +163,7 @@ into a native representation.
 
   - boolean
   - number
+  - positive_number
   - string
   - string_list
 

--- a/spec/config_spec.moon
+++ b/spec/config_spec.moon
@@ -260,6 +260,31 @@ describe 'config', ->
         config.number = '1'
         assert.equal config.number, 1
 
+    context 'and is "positive_number"', ->
+      def = nil
+      before_each ->
+        config.define name: 'positive_number', description: 'foo', type_of: 'positive_number'
+        def = config.definitions.positive_number
+
+      it 'convert handles numbers and string numbers', ->
+        assert.equal def.convert(1), 1
+        assert.equal def.convert('1'), 1
+        assert.equal def.convert(0.5), 0.5
+        assert.equal def.convert('0.5'), 0.5
+        assert.equal def.convert('blargh'), 'blargh'
+
+      it 'validate returns true for positive numbers only', ->
+        assert.is_true def.validate 1
+        assert.is_true def.validate 1.2
+        assert.is_false def.validate -1
+        assert.is_false def.validate -1.2
+        assert.is_false def.validate '1'
+        assert.is_false def.validate 'blargh'
+
+      it 'converts to number upon assignment', ->
+        config.number = '1'
+        assert.equal config.number, 1
+
     context 'and is "string_list"', ->
       def = nil
       before_each ->


### PR DESCRIPTION
Renames the predefined config type `positive-number` to `positive_number`, following the snake case naming convention. Also documents and adds a spec for said type. Fixes #529.