### PR TITLE
Don't close menu_popup when just a modifier key such as ctrl is pressed.

### DIFF
--- a/lib/howl/ui/menu_popup.moon
+++ b/lib/howl/ui/menu_popup.moon
@@ -46,6 +46,12 @@ class MenuPopup extends Popup
     page_up: => @list\prev_page!
 
     on_unhandled: (event, source, translations, self) ->
+      -- if a bare modifier, don't close popup
+      modifiers = {ctrl: true, alt: true, shift: true}
+      for translation in *translations
+        return if modifiers[translation]
+
+      -- any other not character such as home or escape closes the popup
       unless event.character
         self\close!
 


### PR DESCRIPTION
This also allows keystrokes such as ctrl_n and ctrl_p to navigate the menu popup.

Fixes #520 