### PR TITLE
ctrl + [ support for exiting insert mode

### DIFF
--- a/bundles/vi/insert_map.moon
+++ b/bundles/vi/insert_map.moon
@@ -33,6 +33,12 @@ insert_map = {
     state.change_mode editor, 'command'
     editor.cursor.column = math.max 1, editor.cursor.column - 1
 
+  'ctrl_[': (editor) ->
+    state.insert_edit = get_edit editor
+    insert_pos = nil
+    state.change_mode editor, 'command'
+    editor.cursor.column = math.max 1, editor.cursor.column - 1
+
   ctrl_i: (editor) -> editor\shift_right!
   ctrl_d: (editor) -> editor\shift_left!
 }

--- a/bundles/vi/insert_map.moon
+++ b/bundles/vi/insert_map.moon
@@ -33,8 +33,8 @@ insert_map = {
       blink_interval: -> config.cursor_blink_interval
   }
 
-  escape: (editor) -> exit_insert_mode editor
-  'ctrl_[': (editor) -> exit_insert_mode editor
+  escape: exit_insert_mode
+  'ctrl_[': exit_insert_mode
   ctrl_i: (editor) -> editor\shift_right!
   ctrl_d: (editor) -> editor\shift_left!
 }

--- a/bundles/vi/insert_map.moon
+++ b/bundles/vi/insert_map.moon
@@ -14,6 +14,12 @@ get_edit = (editor) ->
     if text and #text > 0
       (editor) -> editor\insert text
 
+exit_insert_mode = (editor) ->
+    state.insert_edit = get_edit editor
+    insert_pos = nil
+    state.change_mode editor, 'command'
+    editor.cursor.column = math.max 1, editor.cursor.column - 1
+
 insert_map = {
   __meta: {
 
@@ -27,22 +33,11 @@ insert_map = {
       blink_interval: -> config.cursor_blink_interval
   }
 
-  escape: (editor) ->
-    state.insert_edit = get_edit editor
-    insert_pos = nil
-    state.change_mode editor, 'command'
-    editor.cursor.column = math.max 1, editor.cursor.column - 1
-
-  'ctrl_[': (editor) ->
-    state.insert_edit = get_edit editor
-    insert_pos = nil
-    state.change_mode editor, 'command'
-    editor.cursor.column = math.max 1, editor.cursor.column - 1
-
+  escape: (editor) -> exit_insert_mode editor
+  'ctrl_[': (editor) -> exit_insert_mode editor
   ctrl_i: (editor) -> editor\shift_right!
   ctrl_d: (editor) -> editor\shift_left!
 }
-
 setmetatable insert_map, {
   __call: (_, editor) ->
     state.enter_edit_mode editor


### PR DESCRIPTION
Added support for 'ctrl + [' to exit insert mode in the vi bundle.

Just duplicated the 'escape' portion of the insert_map.moon and swapped in the 'ctrl + ['
