### PR TITLE
Don't close menu_popup when just a modifier key is pressed.

### DIFF
--- a/lib/howl/bindings.moon
+++ b/lib/howl/bindings.moon
@@ -52,6 +52,8 @@ alternate_names = {
   metaR: 'meta'
   superL: 'super'
   superR: 'super'
+  hyperL: 'hyper'
+  hyperR: 'hyper'
  }
 
 substituted_names = {
@@ -67,6 +69,20 @@ substituted_names = {
   super_r: 'superR'
   kp_prior: 'kp_page_up'
   kp_next: 'kp_page_down'
+  hyper_l: 'hyperL'
+  hyper_r: 'hyperR'
+}
+
+modifier_keys = {
+  'alt',
+  'shift',
+  'ctrl',
+  'meta',
+  'super',
+  'hyper',
+  'iso_level3_shift',
+  'iso_level5_shift',
+
 }
 
 substitute_keyname = (event) ->
@@ -190,6 +206,14 @@ export translate_key = (event) ->
   append translations, modifiers .. event.key_code
 
   translations
+
+export is_modifier = (translations) ->
+  for translation in *translations
+    for modifier in *modifier_keys
+      if translation == modifier
+        return true
+  return false
+
 
 export dispatch = (event, source, maps_to_search, ...) ->
   event = substitute_keyname event

--- a/lib/howl/ui/menu_popup.moon
+++ b/lib/howl/ui/menu_popup.moon
@@ -2,7 +2,7 @@
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 {:List, :ListWidget, :Popup} = howl.ui
-{:config} = howl
+{:bindings, :config} = howl
 
 class MenuPopup extends Popup
   new: (@items, @callback) =>
@@ -46,6 +46,9 @@ class MenuPopup extends Popup
     page_up: => @list\prev_page!
 
     on_unhandled: (event, source, translations, self) ->
+      -- if a bare modifier such as just 'ctrl', don't close popup
+      return if bindings.is_modifier translations
+      -- any other not character such as home or escape closes the popup
       unless event.character
         self\close!
 


### PR DESCRIPTION
Also add a list of modifiers to bindings.moon.