### PR TITLE
fix: update copyright year for --version flag

### DIFF
--- a/lib/howl/init.lua
+++ b/lib/howl/init.lua
@@ -1,4 +1,4 @@
--- Copyright 2012-2015 The Howl Developers
+-- Copyright 2012-2019 The Howl Developers
 -- License: MIT (see LICENSE.md at the top-level directory of the distribution)
 
 local ffi = require('ffi')
@@ -184,7 +184,7 @@ local function main()
   elseif args.version then
     -- Change version here
     print("howl version 0.6-dev\n")
-    print("Copyright 2012-2017 The Howl Developers\nLicense: MIT License")
+    print("Copyright 2012-2019 The Howl Developers\nLicense: MIT License")
     os.exit(0)
   else
     require 'howl.cdefs.fontconfig'


### PR DESCRIPTION
Hi

 `howl --version` currently displays this output: 

```
howl version 0.6-dev

Copyright 2012-2017 The Howl Developers
License: MIT License
```

This is a bit misleading because I first I thought that I had installed an old version but the `0.6` was published this year.