### PR TITLE
doc: homogenize signal descriptions

### DIFF
--- a/lib/howl/bindings.moon
+++ b/lib/howl/bindings.moon
@@ -8,7 +8,7 @@ import signal, command, sys from howl
 append = table.insert
 
 signal.register 'key-press',
-  description: [[Signaled whenever a key is pressed.
+  description: [[Signaled right after a key is pressed.
 
 If any handler returns true, the key press is considered to be handled, and any subsequent
 processing is skipped.

--- a/lib/howl/log.moon
+++ b/lib/howl/log.moon
@@ -14,14 +14,14 @@ config.define
   type_of: 'number'
 
 signal.register 'log-entry-appended',
-  description: 'Called when a new entry is appended to the log'
+  description: 'Signaled right after a new entry is appended to the log'
   parameters:
     essentials: 'The log message essentials'
     level: 'The log level (one of info, warning, error)'
     message: 'The log message'
 
 signal.register 'log-trimmed',
-  description: 'Called when the log is trimmed to the given size'
+  description: 'Signaled right after the log is trimmed to the given size'
   parameters:
     size: 'The new number of entries in the log'
 

--- a/lib/howl/ui/editor.moon
+++ b/lib/howl/ui/editor.moon
@@ -1213,18 +1213,18 @@ signal.register 'editor-defocused',
     editor: 'The editor that lost focus'
 
 signal.register 'editor-destroyed',
-  description: 'Signaled as an editor is destroyed'
+  description: 'Signaled right after an editor was destroyed'
   parameters:
     editor: 'The editor that is being destroyed'
 
 signal.register 'insert-at-cursor',
-  description: 'Signaled when text has been inserted into an editor at the cursor position'
+  description: 'Signaled right after text has been inserted into an editor at the cursor position'
   parameters:
     editor: 'The editor for which the text was inserted'
     text: 'The inserted text'
 
 signal.register 'cursor-changed',
-  description: 'Signaled when the cursor position has changed'
+  description: 'Signaled right after the cursor position has changed'
   parameters:
     editor: 'The editor for which the text was inserted'
     cursor: 'The cursor object'

--- a/lib/howl/ui/selection.moon
+++ b/lib/howl/ui/selection.moon
@@ -132,19 +132,19 @@ class Selection extends PropertyObject
 with signal
   .register 'selection-changed',
     description: [[
-Emitted whenever a selection has been changed.
+Signaled right after a selection has been changed.
 
 This could be the result of a copy, cut or an explicit request to remove
 or create a selection.
 ]]
 
   .register 'selection-removed',
-    description: 'Emitted whenever a selection has been removed.'
+    description: 'Signaled right after a selection has been removed.'
 
   .register 'selection-copied',
-    description: 'Emitted whenever a selection has been copied.'
+    description: 'Signaled right after a selection has been copied.'
 
   .register 'selection-cut',
-    description: 'Emitted whenever a selection has been cut.'
+    description: 'Signaled right after a selection has been cut.'
 
 return Selection

--- a/lib/howl/ui/theme.moon
+++ b/lib/howl/ui/theme.moon
@@ -223,7 +223,7 @@ config.watch 'font_size', (name, value) ->
   apply_theme! if current_theme
 
 signal.register 'theme-changed',
-  description: 'Signaled after a theme has been applied'
+  description: 'Signaled right after a theme has been applied'
   parameters:
     theme: 'The theme that has been set'
 


### PR DESCRIPTION
Hello

With this PR, the `describe-signal` command output is now easier to visually scan.

Before:

![image](https://user-images.githubusercontent.com/39315/68965330-dae69c00-07db-11ea-817d-faa84723f55f.png)

After:

![image](https://user-images.githubusercontent.com/39315/68965351-e5089a80-07db-11ea-9c45-b31c5835f0d0.png)
