### PR TITLE
feat: add '%' key for vi (goto_matching_brace)

### DIFF
--- a/bundles/vi/base_map.moon
+++ b/bundles/vi/base_map.moon
@@ -146,6 +146,9 @@ map = {
 
     '}': (editor) -> apply editor, (editor) ->
       editor.cursor\para_down!
+
+    '%': (editor) -> apply editor, (editor) ->
+      editor.cursor\goto_matching_brace!
    }
 
   on_unhandled: (event, source, translations) ->

--- a/lib/howl/commands/edit_commands.moon
+++ b/lib/howl/commands/edit_commands.moon
@@ -199,9 +199,7 @@ command.register
   name: 'cursor-goto-brace'
   description: 'Go to the brace matching the current brace, if any'
   handler: ->
-    cursor = app.editor.cursor
-    pos = app.editor\get_matching_brace cursor.pos
-    cursor\move_to(:pos) if pos
+    app.editor.cursor\goto_matching_brace!
 
 command.register
   name: 'editor-replace-exec'

--- a/lib/howl/ui/cursor.moon
+++ b/lib/howl/ui/cursor.moon
@@ -211,6 +211,10 @@ class Cursor extends PropertyObject
     else
       @cursor\end_of_file :extend
 
+  goto_matching_brace: () =>
+    pos = @container\get_matching_brace @pos
+    @move_to(:pos) if pos
+
   -- private
 
   @property _line: get: =>

--- a/site/source/doc/api/ui/cursor.md
+++ b/site/source/doc/api/ui/cursor.md
@@ -240,5 +240,9 @@ selection, or extends the selection if already present.
 Moves the cursor one paragraph up. If `extend` is true, creates a new selection,
 or extends the selection if already present.
 
+### goto_matching_brace ()
+
+Moves the cursor to brace matching the current brace if any.
+
 [Editor]: editor.html
 [Selection]: selection.html

--- a/spec/ui/cursor_spec.moon
+++ b/spec/ui/cursor_spec.moon
@@ -673,3 +673,11 @@ And hƏre's line twʘ
       assert.equal 'L', sel.text
       cursor.line = 2
       assert.equals 'Liñe 1 ʘf tƏxt\nA', sel.text
+
+  describe 'goto_matching_brace', ->
+    it 'moves to the matching brace', ->
+      editor.buffer.mode.auto_pairs = {'[': ']'}
+      editor.buffer.text = '[foo]'
+      cursor.pos = 1
+      cursor\goto_matching_brace!
+      assert.equal 5, cursor.pos


### PR DESCRIPTION
Hi

This PR adds a basic support for the `%` in vi. (note: the behavior is slightly different, but I think it's already quite handy and good enough for a first iteration).

As the 3 lines logic was declared inline in the `cursor-goto-brace` command registration, I had to move this bit of code to a proper function `goto_matching_brace` on the cursor class.

I've completed the spec / api doc accordingly.