### PR TITLE
Reinstate the scrollbar sync workaround

### DIFF
--- a/lib/aullar/view.moon
+++ b/lib/aullar/view.moon
@@ -4,6 +4,7 @@
 ffi = require 'ffi'
 bit = require 'bit'
 ffi_cast = ffi.cast
+callbacks = require 'ljglibs.callbacks'
 
 Gdk = require 'ljglibs.gdk'
 Gtk = require 'ljglibs.gtk'
@@ -21,6 +22,8 @@ config = require 'aullar.config'
 {:define_class} = require 'aullar.util'
 {:parse_key_event} = require 'ljglibs.util'
 {:max, :min, :floor} = math
+cast_arg = callbacks.cast_arg
+C = ffi.C
 append = table.insert
 
 jit.off true, true
@@ -150,6 +153,9 @@ View = {
 
     @buffer = buffer
     @config\add_listener self\_on_config_changed
+
+    @_refresh_cb_handle = callbacks.register self\_sync_scrollbars, "view-#{@}-refresh"
+    @_cb_handler = callbacks.unref_handle @_refresh_cb_handle
 
   destroy: =>
     @bin\destroy!
@@ -885,8 +891,14 @@ View = {
       @last_visible_line = @last_visible_line
 
     @buffer\ensure_styled_to line: @last_visible_line + 1
-    @_sync_scrollbars!
     notify @, 'on_resized'
+
+    -- we just can't sync the scrollbars here due to a Gtk issue, so we
+    -- work around this by syncing these immediately after the size_allocate
+    -- handling is done
+    -- Ref: https://bugzilla.gnome.org/show_bug.cgi?id=765410
+    C.g_timeout_add_full C.G_PRIORITY_LOW, 0, callbacks.source_func,
+      cast_arg(@_refresh_cb_handle.id), nil
 
   _on_config_changed: (option, val, old_val) =>
     if option == 'view_font_name' or option == 'view_font_size'


### PR DESCRIPTION
@nilnor This PR brings back your scrollbar sync workaround.

It fixes #567 and generally seems to make the scrollbars behave more predictably.

It was originally introduced in e83e98ee5e9e90286636bb753c85ddd887ba268c
as a fix for issue #371.

Then it was removed in f7c84b6d3220bb13f136154a68d67e70415a2348