### PR TITLE
Added `rename` and `delete` commands

### DIFF
--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -248,6 +248,15 @@ class Buffer extends PropertyObject
     @_associate_with_file file
     @save!
 
+  rename: (file) =>
+    old_file = @file
+    @_associate_with_file file
+    @save!
+    if @file != old_file
+      status, err = pcall old_file\delete
+      if not status
+          log.warn "Failed to delete old alias #{old_file} for #{@file}: #{err}"
+
   as_one_undo: (f) => @_buffer\as_one_undo f
 
   undo: =>

--- a/lib/howl/buffer.moon
+++ b/lib/howl/buffer.moon
@@ -248,7 +248,7 @@ class Buffer extends PropertyObject
     @_associate_with_file file
     @save!
 
-  rename: (file) =>
+  rename_file: (file) =>
     old_file = @file
     @_associate_with_file file
     @save!
@@ -256,6 +256,13 @@ class Buffer extends PropertyObject
       status, err = pcall old_file\delete
       if not status
           log.warn "Failed to delete old alias #{old_file} for #{@file}: #{err}"
+
+  delete_file: (file) =>
+    if @file
+      status, err = pcall @file\delete
+      if not status
+          log.warn "Failed to delete #{@file}: #{err}"
+    @_associate_with_file nil
 
   as_one_undo: (f) => @_buffer\as_one_undo f
 

--- a/lib/howl/commands/file_commands.moon
+++ b/lib/howl/commands/file_commands.moon
@@ -173,10 +173,31 @@ command.register
       command.run 'save-as'
       return
 
-    buffer\rename file
+    buffer\rename_file file
     buffer.mode = mode.for_file file
     log.info ("%s: %d lines, %d bytes written")\format buffer.file.basename,
       #buffer.lines, #buffer
+
+command.register
+  name: 'delete',
+  description: 'Delete the file associated with the current buffer'
+  handler: ->
+    buffer = app.editor.buffer
+    if not buffer.file
+      log.info "Not deleting; buffer not associated with a file"
+      return
+
+    if buffer.modified_on_disk
+      overwrite = interact.yes_or_no
+        prompt: "Buffer '#{buffer}' has changed on disk, delete anyway? "
+        default: false
+      unless overwrite
+        log.info "Not deleting; buffer not saved"
+        return
+
+    old_name = buffer.file.basename
+    buffer\delete_file!
+    log.info ("%s has been deleted")\format old_name
 
 command.register
   name: 'buffer-close',

--- a/lib/howl/commands/file_commands.moon
+++ b/lib/howl/commands/file_commands.moon
@@ -149,6 +149,36 @@ command.register
       #buffer.lines, #buffer
 
 command.register
+  name: 'rename',
+  description: 'Rename the current buffer\'s file'
+  input: (opts) ->
+    parent = app.editor.buffer.file and app.editor.buffer.file.parent
+    file = interact.select_file prompt: ':rename ', text: opts.text, allow_new: true, path: parent and parent.path
+    return unless file
+
+    if file.exists
+      unless interact.yes_or_no prompt: "File '#{file}' already exists, overwrite? "
+        log.info "Not overwriting; buffer not renamed"
+        return
+
+    unless auto_mkdir file.parent
+      log.info "Parent directory doesn't exist; buffer not renamed"
+      return
+
+    return file
+
+  handler: (file) ->
+    buffer = app.editor.buffer
+    if not buffer.file
+      command.run 'save-as'
+      return
+
+    buffer\rename file
+    buffer.mode = mode.for_file file
+    log.info ("%s: %d lines, %d bytes written")\format buffer.file.basename,
+      #buffer.lines, #buffer
+
+command.register
   name: 'buffer-close',
   description: 'Close the current buffer'
   handler: ->


### PR DESCRIPTION
It's very common for me to accidentally create a file with the wrong name, be it due to a typo or just changing my mind about what the file should be called or where it should be. Previously, this meant:

1) Closing the file in Howl so that I don't accidentally end up re-saving it as its old name
2) Switching to my terminal / file explorer
3) Moving + renaming the file
4) Switching back to Howl, opening it via its new path

With the addition of this `rename` command, it's as simple as just typing out the new name/path I wish to give it, and Howl handles the rest.

For completeness, I've also added a `delete` command that deletes the underlying file and then disassociates the buffer with that file.